### PR TITLE
fix(upload): remove unsafe FileList cast in upload handler

### DIFF
--- a/frontend/src/app/upload/page.tsx
+++ b/frontend/src/app/upload/page.tsx
@@ -219,11 +219,7 @@ export default function UploadPage() {
         return;
       }
 
-      const fileList = Object.assign(acceptedFiles, {
-        item: (index: number) => acceptedFiles[index] || null,
-      }) as unknown as FileList;
-
-      uploadMutation.mutate(fileList);
+      uploadMutation.mutate(acceptedFiles);
     },
     [uploadMutation],
   );


### PR DESCRIPTION
Hey! 👋

This PR removes the unsafe `as unknown as FileList` cast in the upload handler.

## The Problem

The upload handler was using `as unknown as FileList` to cast a `File[]` to `FileList`. This is:
- Unsafe
- Unnecessary (since `uploadImages` already accepts `File[]`)
- Not type-safe

## The Solution

Removed the unnecessary cast and passed the `File[]` directly to `uploadMutation.mutate()`.

## What Changed

- Removed `Object.assign` and `as unknown as FileList` cast
- Passed `acceptedFiles` directly to `uploadMutation.mutate()`

## Testing

- Upload still works for multiple image files
- TypeScript remains strict and passes project checks

Fixes #2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined file handling in the upload feature by simplifying how files are processed during the drop event, improving code efficiency without affecting user-facing functionality.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Abhash-Chakraborty/Find/pull/7)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->