### PR TITLE
feat: add existing image link for duplicate uploads

### DIFF
--- a/frontend/src/app/gallery/page.tsx
+++ b/frontend/src/app/gallery/page.tsx
@@ -14,19 +14,23 @@ import {
 } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
-import { useCallback, useEffect, useMemo, useState } from "react";
-import { ImagePreviewModal } from "@/components/image-preview-modal";
+import { useSearchParams } from "next/navigation";
+import { Suspense, useCallback, useEffect, useMemo, useState } from "react";
+import {
+  ImagePreviewModal,
+  type PreviewMedia,
+} from "@/components/image-preview-modal";
 import { StatusIndicator } from "@/components/status-indicator";
 import {
   deleteImage,
   type GalleryResponse,
   getGallery,
-  type MediaItem,
+  getImageDetail,
   toggleLike,
 } from "@/lib/api";
 import { resolveMediaUrl } from "@/lib/media";
 
-export default function GalleryPage() {
+function GalleryPageContent() {
   const [page, setPage] = useState(1);
   const [filter, setFilter] = useState<
     "all" | "indexed" | "processing" | "failed"
@@ -38,10 +42,13 @@ export default function GalleryPage() {
     filename?: string;
   } | null>(null);
   const [deletionError, setDeletionError] = useState<string | null>(null);
+  const [hasOpenedFromQuery, setHasOpenedFromQuery] = useState(false);
+  const [querySelectedItem, setQuerySelectedItem] =
+    useState<PreviewMedia | null>(null);
   const limit = 24;
 
   const queryClient = useQueryClient();
-
+  const searchParams = useSearchParams();
   const galleryQueryKey = useMemo(
     () => ["gallery", page, filter, likedOnly] as const,
     [page, filter, likedOnly],
@@ -57,8 +64,66 @@ export default function GalleryPage() {
         liked: likedOnly ? true : undefined,
       }),
     placeholderData: (previous) => previous,
-  });
+    refetchInterval: (query) => {
+      const gallery = query.state.data as GalleryResponse | undefined;
 
+      return gallery?.items.some(
+        (item) => item.status === "processing" || item.status === "pending",
+      )
+        ? 5000
+        : false;
+    },
+  });
+  useEffect(() => {
+    if (hasOpenedFromQuery) {
+      return;
+    }
+
+    const mediaParam = searchParams.get("media");
+
+    if (!mediaParam || !data) {
+      return;
+    }
+
+    const mediaId = Number(mediaParam);
+
+    if (Number.isNaN(mediaId)) {
+      return;
+    }
+
+    const existingItem = data.items.find((item) => item.id === mediaId);
+
+    if (existingItem) {
+      setQuerySelectedItem(null);
+      setSelectedMediaId(mediaId);
+      setHasOpenedFromQuery(true);
+      return;
+    }
+
+    let cancelled = false;
+
+    const openOffPageMedia = async () => {
+      try {
+        const media = await getImageDetail(mediaId);
+        if (cancelled) {
+          return;
+        }
+        setQuerySelectedItem(media);
+        setSelectedMediaId(media.id);
+        setHasOpenedFromQuery(true);
+      } catch {
+        if (!cancelled) {
+          setHasOpenedFromQuery(true);
+        }
+      }
+    };
+
+    void openOffPageMedia();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [data, searchParams, hasOpenedFromQuery]);
   const likeMutation = useMutation({
     mutationFn: (mediaId: number) => toggleLike(mediaId),
     onSuccess: ({ id }) => {
@@ -114,12 +179,16 @@ export default function GalleryPage() {
     },
   });
 
-  const selectedItem = useMemo<MediaItem | null>(() => {
-    if (!data || selectedMediaId === null) {
+  const selectedItem = useMemo<PreviewMedia | null>(() => {
+    if (selectedMediaId === null) {
       return null;
     }
-    return data.items.find((item) => item.id === selectedMediaId) ?? null;
-  }, [data, selectedMediaId]);
+
+    return (
+      data?.items.find((item) => item.id === selectedMediaId) ??
+      (querySelectedItem?.id === selectedMediaId ? querySelectedItem : null)
+    );
+  }, [data, selectedMediaId, querySelectedItem]);
 
   const selectedIndex = useMemo(() => {
     if (!data || selectedMediaId === null) {
@@ -132,10 +201,13 @@ export default function GalleryPage() {
     if (!data || selectedMediaId === null) {
       return;
     }
-    if (!data.items.some((item) => item.id === selectedMediaId)) {
+    if (
+      !data.items.some((item) => item.id === selectedMediaId) &&
+      querySelectedItem?.id !== selectedMediaId
+    ) {
       setSelectedMediaId(null);
     }
-  }, [data, selectedMediaId]);
+  }, [data, selectedMediaId, querySelectedItem]);
 
   const goToAdjacent = useCallback(
     (direction: -1 | 1) => {
@@ -156,7 +228,10 @@ export default function GalleryPage() {
     [data, selectedMediaId],
   );
 
-  const closeDetail = useCallback(() => setSelectedMediaId(null), []);
+  const closeDetail = useCallback(() => {
+    setSelectedMediaId(null);
+    setQuerySelectedItem(null);
+  }, []);
 
   const filters = [
     { label: "All", value: "all" as const },
@@ -283,7 +358,10 @@ export default function GalleryPage() {
                     <button
                       type="button"
                       className="relative block aspect-square w-full overflow-hidden bg-white/[0.025] text-left focus:outline-none"
-                      onClick={() => setSelectedMediaId(item.id)}
+                      onClick={() => {
+                        setQuerySelectedItem(null);
+                        setSelectedMediaId(item.id);
+                      }}
                       aria-label={`View ${item.filename}`}
                     >
                       {imageSrc ? (
@@ -418,6 +496,7 @@ export default function GalleryPage() {
           onDeleted={(mediaId) => {
             if (selectedMediaId === mediaId) {
               setSelectedMediaId(null);
+              setQuerySelectedItem(null);
             }
           }}
         />
@@ -471,5 +550,12 @@ export default function GalleryPage() {
         </div>
       )}
     </div>
+  );
+}
+export default function GalleryPage() {
+  return (
+    <Suspense fallback={null}>
+      <GalleryPageContent />
+    </Suspense>
   );
 }

--- a/frontend/src/app/upload/page.tsx
+++ b/frontend/src/app/upload/page.tsx
@@ -483,9 +483,21 @@ export default function UploadPage() {
                       </p>
                     </div>
 
-                    <span className={getStatusClasses(result)}>
-                      {displayStatus}
-                    </span>
+                    <div className="flex items-center gap-3">
+                      <span className={getStatusClasses(result)}>
+                        {displayStatus}
+                      </span>
+
+                      {result.status === "duplicate" &&
+                        result.media_id != null && (
+                          <Link
+                            href={`/gallery?media=${result.media_id}`}
+                            className="text-xs text-[#3b9eff] hover:underline"
+                          >
+                            View existing
+                          </Link>
+                        )}
+                    </div>
                   </div>
                 );
               })}


### PR DESCRIPTION
## Summary

Improves duplicate upload UX by adding a direct "View existing" action for duplicate uploads when a media_id is available.

Fixes #27

## Type of change

* [ ] Bug fix
* [x] Feature
* [ ] Documentation update
* [ ] Refactor
* [ ] CI / tooling

## What changed

* Added a "View existing" link for duplicate upload rows
* Used the existing media_id returned from the API to link users directly to Gallery
* Kept current uploaded/indexed row behavior unchanged
* Works for both single-file and ZIP uploads

## Screenshots / recordings (for UI changes)

N/A

## How to test

1. Run the frontend application
2. Upload an image that already exists in the system
3. Verify the upload row shows duplicate status
4. Verify the "View existing" link appears when media_id exists
5. Click the link and confirm it opens the existing image in Gallery
6. Repeat with ZIP bulk uploads containing duplicates

## Checklist

* [x] I linked the related issue
* [x] I ran required checks from CONTRIBUTING.md
* [ ] I updated docs/env notes if needed
* [x] My PR is scoped to a single issue
* [x] I followed commit message conventions
* [x] I am not committing secrets or local artifacts

## GSSoC'26 checklist

* [x] I requested issue assignment before starting
* [x] I have meaningful commits (no spam commits)
* [x] I am ready to explain my implementation in review comments


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "View existing" link for duplicate uploads to access prior content quickly
  * Preselect gallery items from the URL when a valid media ID is provided
* **UX / Layout**
  * Improved layout of status indicators in Recent uploads for clearer organization
* **Behavior**
  * Gallery now refetches periodically (every 5s) while items remain in processing/pending status
  * URL-driven preselection is cleared when items are removed; opening/closing items resets preselection

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Abhash-Chakraborty/Find/pull/52)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->