### PR TITLE
feat: make single-image upload size limit configurable via env var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,6 +28,9 @@ NEXT_PUBLIC_MINIO_BUCKET=images
 # Only used as a fallback when objects are publicly readable
 NEXT_PUBLIC_MINIO_URL=http://localhost:9000
 NEXT_PUBLIC_MAX_BULK_FILES=200
+# Client-side upload size limit (MB). Keep in sync with MAX_UPLOAD_SIZE_MB (server-side).
+# If this exceeds MAX_UPLOAD_SIZE_MB, files will pass client validation but be rejected by the server.
+NEXT_PUBLIC_MAX_UPLOAD_SIZE_MB=50
 
 # ML Model Settings
 ML_MODE=full

--- a/frontend/src/app/upload/page.tsx
+++ b/frontend/src/app/upload/page.tsx
@@ -91,6 +91,14 @@ export default function UploadPage() {
   const [uploadedFiles, setUploadedFiles] = useState<UploadListItem[]>([]);
   const [mode, setMode] = useState<UploadMode>("single");
 
+  const parsedUploadLimit = Number(
+    process.env.NEXT_PUBLIC_MAX_UPLOAD_SIZE_MB ?? "50",
+  );
+  const maxUploadSizeMb =
+    Number.isFinite(parsedUploadLimit) && parsedUploadLimit > 0
+      ? Math.floor(parsedUploadLimit)
+      : 50;
+
   const parsedBulkLimit = Number(
     process.env.NEXT_PUBLIC_MAX_BULK_FILES ?? "200",
   );
@@ -255,7 +263,7 @@ export default function UploadPage() {
       "image/webp": [".webp"],
       "image/gif": [".gif"],
     },
-    maxSize: 50 * 1024 * 1024,
+    maxSize: maxUploadSizeMb * 1024 * 1024,
     multiple: true,
     disabled: mode !== "single" || isUploading,
   });
@@ -286,11 +294,11 @@ export default function UploadPage() {
 
   const helperText = useMemo(() => {
     if (mode === "single") {
-      return "JPEG, PNG, WebP, GIF. Max 50MB each";
+      return `JPEG, PNG, WebP, GIF. Max ${maxUploadSizeMb}MB each`;
     }
 
     return `ZIP archive up to ${maxBulkFiles} images`;
-  }, [mode, maxBulkFiles]);
+  }, [mode, maxUploadSizeMb, maxBulkFiles]);
 
   const stats = useMemo(
     () => ({


### PR DESCRIPTION
## Summary

- Adds `NEXT_PUBLIC_MAX_UPLOAD_SIZE_MB` frontend env var (default `50`) so the single-image upload limit can be configured without touching code
- Wires the value into the dropzone `maxSize` calculation (was hard-coded `50 * 1024 * 1024`)
- Uses the value in the helper text shown to users (`Max ${maxUploadSizeMb}MB each`)
- Documents the new var in `.env.example` alongside the existing `NEXT_PUBLIC_MAX_BULK_FILES` entry
- Follows the exact same pattern already used for `NEXT_PUBLIC_MAX_BULK_FILES` (safe parse → positive-integer guard → fallback)

Closes #74 

## Test plan

- [x] Default behaviour unchanged: start without setting `NEXT_PUBLIC_MAX_UPLOAD_SIZE_MB` — dropzone still rejects files over 50 MB and helper text reads "Max 50MB each"
- [x] Custom limit: set `NEXT_PUBLIC_MAX_UPLOAD_SIZE_MB=10` in `.env.local`, restart dev server — helper text reads "Max 10MB each" and files over 10 MB are rejected client-side
- [x] Invalid value guard: set `NEXT_PUBLIC_MAX_UPLOAD_SIZE_MB=abc` — falls back to 50 MB silently


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Frontend upload size limit is now configurable via an environment setting.

* **UI**
  * Upload interface displays the configured max file size in helper text and enforces client-side file-size validation for single-file uploads.

* **Documentation**
  * Example environment template updated to include the new frontend upload-size setting and a note that client checks may differ from server-side rejection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Abhash-Chakraborty/Find/pull/76)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->