### PR TITLE
fix: surface backend error messages in upload toasts

### DIFF
--- a/frontend/src/app/upload/page.tsx
+++ b/frontend/src/app/upload/page.tsx
@@ -15,15 +15,14 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { useDropzone } from "react-dropzone";
 import { toast } from "sonner";
 import {
+  extractErrorMessage,
   getJobStatus,
   type JobStatus,
   type UploadResponse,
   type UploadResult,
   uploadImages,
   uploadImagesBulk,
-  extractErrorMessage,
 } from "@/lib/api";
-
 
 type UploadMode = "single" | "bulk";
 type ProcessingState = "queued" | "processing" | "indexed" | "failed";

--- a/frontend/src/app/upload/page.tsx
+++ b/frontend/src/app/upload/page.tsx
@@ -21,7 +21,9 @@ import {
   type UploadResult,
   uploadImages,
   uploadImagesBulk,
+  extractErrorMessage,
 } from "@/lib/api";
+
 
 type UploadMode = "single" | "bulk";
 type ProcessingState = "queued" | "processing" | "indexed" | "failed";
@@ -107,8 +109,8 @@ export default function UploadPage() {
         `Queued ${data.total} file${data.total === 1 ? "" : "s"} for analysis`,
       );
     },
-    onError: () => {
-      toast.error("Upload failed");
+    onError: (error) => {
+      toast.error(extractErrorMessage(error, "Upload failed"));
     },
   });
 
@@ -125,8 +127,8 @@ export default function UploadPage() {
         })`,
       );
     },
-    onError: () => {
-      toast.error("Bulk upload failed");
+    onError: (error) => {
+      toast.error(extractErrorMessage(error, "Bulk upload failed"));
     },
   });
 

--- a/frontend/src/app/upload/page.tsx
+++ b/frontend/src/app/upload/page.tsx
@@ -131,11 +131,21 @@ export default function UploadPage() {
       const uploadedCount = data.results.filter(
         (item) => item.status === "uploaded",
       ).length;
+      const failedResults = data.results.filter(
+        (item) => item.status === "failed" && item.error,
+      );
       toast.success(
         `Archive accepted (${uploadedCount} new upload${
           uploadedCount === 1 ? "" : "s"
         })`,
       );
+      if (failedResults.length > 0) {
+        toast.error(
+          failedResults.length === 1
+            ? failedResults[0]?.error
+            : `${failedResults.length} files failed. ${failedResults[0]?.error}`,
+        );
+      }
     },
     onError: (error) => {
       toast.error(extractErrorMessage(error, "Bulk upload failed"));

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -266,10 +266,7 @@ export const triggerClustering = async (): Promise<ClusteringJobResponse> => {
   return response.data;
 };
 
-export function extractErrorMessage(
-  error: unknown,
-  fallback: string,
-): string {
+export function extractErrorMessage(error: unknown, fallback: string): string {
   if (axios.isAxiosError(error)) {
     const data = error.response?.data;
     if (typeof data?.message === "string" && data.message.trim()) {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -265,3 +265,22 @@ export const triggerClustering = async (): Promise<ClusteringJobResponse> => {
   const response = await api.post<ClusteringJobResponse>("/api/cluster/run");
   return response.data;
 };
+
+export function extractErrorMessage(
+  error: unknown,
+  fallback: string,
+): string {
+  if (axios.isAxiosError(error)) {
+    const data = error.response?.data;
+    if (typeof data?.message === "string" && data.message.trim()) {
+      return data.message.trim();
+    }
+    if (typeof data?.error === "string" && data.error.trim()) {
+      return data.error.trim();
+    }
+    if (typeof data === "string" && data.trim()) {
+      return data.trim();
+    }
+  }
+  return fallback;
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -269,6 +269,9 @@ export const triggerClustering = async (): Promise<ClusteringJobResponse> => {
 export function extractErrorMessage(error: unknown, fallback: string): string {
   if (axios.isAxiosError(error)) {
     const data = error.response?.data;
+    if (typeof data?.detail === "string" && data.detail.trim()) {
+      return data.detail.trim();
+    }
     if (typeof data?.message === "string" && data.message.trim()) {
       return data.message.trim();
     }


### PR DESCRIPTION
Closes #71

## What changed
- Added `extractErrorMessage()` helper in `api.ts` that safely unwraps Axios error responses (`message`, `error`, or plain string body)
- Applied it to both `uploadMutation` and `bulkUploadMutation` `onError` callbacks in `upload/page.tsx`

## How it works
- If backend returns `{ message: "..." }` or `{ error: "..." }` → shows that string
- If backend returns a plain string body → shows that
- If none of the above → falls back to original generic message
- Stack traces and raw objects never reach the UI

## Testing
- Successful upload behavior unchanged
- No backend validation rules modified

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Single-image uploads now show clearer, server-provided error messages instead of a generic "Upload failed".
  * Bulk ZIP uploads surface more informative server-derived error text and now report how many files failed, including the first failure message for quicker troubleshooting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Abhash-Chakraborty/Find/pull/77?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->