### PR TITLE
fix: validate gallery status filter

### DIFF
--- a/backend/src/find_api/routers/gallery.py
+++ b/backend/src/find_api/routers/gallery.py
@@ -3,10 +3,11 @@ Gallery endpoint for browsing images
 """
 
 import json
+from typing import Literal, Optional
+
 from fastapi import APIRouter, Depends, Query, HTTPException
 from sqlalchemy.orm import Session
 from sqlalchemy import desc
-from typing import Optional
 
 from find_api.core.database import get_db
 from find_api.core.storage import get_file_url, delete_file
@@ -14,6 +15,8 @@ from find_api.models.media import Media
 from find_api.models.cluster import Cluster
 
 router = APIRouter()
+
+GalleryStatus = Literal["pending", "processing", "indexed", "failed"]
 
 
 def normalize_metadata(value):
@@ -32,7 +35,10 @@ def normalize_metadata(value):
 def get_gallery(
     skip: int = Query(0, ge=0),
     limit: int = Query(50, ge=1, le=100),
-    status: Optional[str] = None,
+    status: Optional[GalleryStatus] = Query(
+        None,
+        description="Filter by processing status",
+    ),
     liked: Optional[bool] = None,
     db: Session = Depends(get_db),
 ):

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -12,11 +12,13 @@ export const api: AxiosInstance = axios.create({
 });
 
 // Types
+export type MediaStatus = "pending" | "processing" | "indexed" | "failed";
+
 export interface MediaItem {
   id: number;
   filename: string;
   minio_key: string;
-  status: "pending" | "processing" | "indexed" | "failed";
+  status: MediaStatus;
   created_at: string;
   processed_at?: string | null;
   width?: number | null;
@@ -195,7 +197,7 @@ export const getGallery = async (
   params: {
     page?: number;
     limit?: number;
-    status?: string;
+    status?: MediaStatus;
     liked?: boolean;
   } = {},
 ): Promise<GalleryResponse> => {


### PR DESCRIPTION
Fixes #70.

## Summary
- Restrict the gallery `status` query param to `pending`, `processing`, `indexed`, or `failed` at the FastAPI boundary.
- Tighten the frontend API client status parameter type to the same media status union.
- Preserve existing pagination and liked filtering behavior.

## Type of change

* [x] Bug fix
* [ ] Feature
* [ ] Documentation update
* [ ] Refactor
* [ ] CI / tooling

## How to test

1. Call `GET /api/gallery?status=indexed` and verify it still returns gallery data.
2. Call `GET /api/gallery?status=random` and verify FastAPI returns a validation error response.
3. Use the gallery page and verify existing filters/pagination continue to work.

## Checks run

```bash
cd backend
uv run ruff check src/find_api/routers/gallery.py
uv run ruff format --check src/find_api/routers/gallery.py

cd frontend
pnpm exec biome check src/lib/api.ts
pnpm build

git diff --check
```

Note: full `pnpm check` currently reports existing CRLF formatting diagnostics across many frontend files; the touched `src/lib/api.ts` passes Biome after formatting.

## Checklist

* [x] I linked the related issue
* [x] I ran relevant checks from CONTRIBUTING.md
* [ ] I updated docs/env notes if needed
* [x] My PR is scoped to a single issue
* [x] I followed commit message conventions
* [x] I am not committing secrets or local artifacts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Gallery status filtering now enforces standardized status values (pending, processing, indexed, failed) across backend and frontend APIs with improved parameter documentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Abhash-Chakraborty/Find/pull/82)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->