### PR TITLE
ci: add issue-triage workflow to label community created issues for approval

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -1,0 +1,33 @@
+name: Issue Triage
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  issues: write
+
+jobs:
+  label-community-issues:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add 'needs approval' label for community-created issues
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // author_association is set by GitHub, based on the opener's relationship
+            // with the repository. Only OWNER, MEMBER, and COLLABORATOR have write
+            // access and only they are trusted to open pre-approved issues. Anyone else
+            // (CONTRIBUTOR, FIRST_TIME_CONTRIBUTOR, NONE, etc.) gets flagged for
+            // maintainer review before they can start work on the issue.
+            const trusted = ['OWNER', 'MEMBER', 'COLLABORATOR'];
+            const association = context.payload.issue.author_association;
+
+            if (!trusted.includes(association)) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.issue.number,
+                labels: ['needs approval'],
+              });
+            }


### PR DESCRIPTION
## Summary

Adds a GitHub actions workflow that marks issues opened by community members as needs approval, so the maintainers can have a triage queue during gssoc

Fixes #62 

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Documentation update
- [ ] Refactor
- [x] CI / tooling

## What changed

- Added github/workflows/issue-triage.yml
- This workflow triggers on issues: opened
- Any issues opened by non-maintainers automatically get the needs approval label

## Screenshots / recordings (for UI changes)

not applicable

## How to test

1. Merge this PR into main
2. Open an issue from someone who is not a maintainer
3. See the Actions tab to confirm that the workflow ran succesfully

## Checklist

- [x] I linked the related issue
- [x] I ran required checks from CONTRIBUTING.md
- [ ] I updated docs/env notes if needed
- [x] My PR is scoped to a single issue
- [x] I followed commit message conventions
- [x] I am not committing secrets or local artifacts

## GSSoC'26 checklist

- [x] I requested issue assignment before starting
- [x] I have meaningful commits (no spam commits)
- [x] I am ready to explain my implementation in review comments


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented an automated system to classify issues in the repository, improving issue management and triaging efficiency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Abhash-Chakraborty/Find/pull/84)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->