### PR TITLE
feat: add reprocess action for failed or incomplete media

### DIFF
--- a/backend/src/find_api/routers/gallery.py
+++ b/backend/src/find_api/routers/gallery.py
@@ -198,10 +198,6 @@ def reprocess_image(media_id: int, db: Session = Depends(get_db)):
             "Reprocess is only available for failed images or indexed images with incomplete metadata.",
         )
 
-    prev_status = media.status
-    prev_error = media.error_message
-    prev_processed_at = media.processed_at
-
     media.status = "pending"
     media.error_message = None
     media.processed_at = None
@@ -212,12 +208,8 @@ def reprocess_image(media_id: int, db: Session = Depends(get_db)):
         )
         db.commit()
     except Exception as exc:  # noqa: BLE001
-        media.status = prev_status
-        media.error_message = prev_error
-        media.processed_at = prev_processed_at
         db.rollback()
-        logger.error("Failed to enqueue reprocess for media %s: %s", media.id, exc)
-        raise HTTPException(503, "Reprocess queue is unavailable. Please retry later.") from exc
+        raise HTTPException(503, "Reprocess queue is unavailable. Please retry.") from exc
 
     logger.info("Requeued analysis for media %s (job %s)", media.id, job.id)
 

--- a/backend/src/find_api/routers/gallery.py
+++ b/backend/src/find_api/routers/gallery.py
@@ -209,7 +209,9 @@ def reprocess_image(media_id: int, db: Session = Depends(get_db)):
         db.commit()
     except Exception as exc:  # noqa: BLE001
         db.rollback()
-        raise HTTPException(503, "Reprocess queue is unavailable. Please retry.") from exc
+        raise HTTPException(
+            503, "Reprocess queue is unavailable. Please retry."
+        ) from exc
 
     logger.info("Requeued analysis for media %s (job %s)", media.id, job.id)
 

--- a/backend/src/find_api/routers/gallery.py
+++ b/backend/src/find_api/routers/gallery.py
@@ -198,14 +198,26 @@ def reprocess_image(media_id: int, db: Session = Depends(get_db)):
             "Reprocess is only available for failed images or indexed images with incomplete metadata.",
         )
 
+    prev_status = media.status
+    prev_error = media.error_message
+    prev_processed_at = media.processed_at
+
     media.status = "pending"
     media.error_message = None
     media.processed_at = None
-    db.commit()
 
-    job = get_task_queue().enqueue(
-        analyze_image, media.id, job_timeout=settings.WORKER_TIMEOUT
-    )
+    try:
+        job = get_task_queue().enqueue(
+            analyze_image, media.id, job_timeout=settings.WORKER_TIMEOUT
+        )
+        db.commit()
+    except Exception as exc:  # noqa: BLE001
+        media.status = prev_status
+        media.error_message = prev_error
+        media.processed_at = prev_processed_at
+        db.rollback()
+        logger.error("Failed to enqueue reprocess for media %s: %s", media.id, exc)
+        raise HTTPException(503, "Reprocess queue is unavailable. Please retry later.") from exc
 
     logger.info("Requeued analysis for media %s (job %s)", media.id, job.id)
 

--- a/backend/src/find_api/routers/gallery.py
+++ b/backend/src/find_api/routers/gallery.py
@@ -3,15 +3,21 @@ Gallery endpoint for browsing images
 """
 
 import json
+import logging
 from fastapi import APIRouter, Depends, Query, HTTPException
 from sqlalchemy.orm import Session
 from sqlalchemy import desc
 from typing import Optional
 
+from find_api.core.config import settings
 from find_api.core.database import get_db
+from find_api.core.queue import get_task_queue
 from find_api.core.storage import get_file_url, delete_file
 from find_api.models.media import Media
 from find_api.models.cluster import Cluster
+from find_api.workers.jobs import analyze_image
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
@@ -168,6 +174,42 @@ def toggle_like(media_id: int, db: Session = Depends(get_db)):
     db.refresh(media)
 
     return {"id": media.id, "liked": media.liked}
+
+
+@router.post("/image/{media_id}/reprocess")
+def reprocess_image(media_id: int, db: Session = Depends(get_db)):
+    """
+    Reset a media record to pending and re-enqueue analysis.
+
+    Allowed for:
+    - Images with status ``failed``
+    - Images with status ``indexed`` that have incomplete metadata (no caption)
+    """
+    media = db.query(Media).filter(Media.id == media_id).first()
+    if not media:
+        raise HTTPException(404, "Image not found")
+
+    metadata = normalize_metadata(media.metadata_json)
+    is_indexed_incomplete = media.status == "indexed" and not metadata.get("caption")
+
+    if media.status != "failed" and not is_indexed_incomplete:
+        raise HTTPException(
+            400,
+            "Reprocess is only available for failed images or indexed images with incomplete metadata.",
+        )
+
+    media.status = "pending"
+    media.error_message = None
+    media.processed_at = None
+    db.commit()
+
+    job = get_task_queue().enqueue(
+        analyze_image, media.id, job_timeout=settings.WORKER_TIMEOUT
+    )
+
+    logger.info("Requeued analysis for media %s (job %s)", media.id, job.id)
+
+    return {"media_id": media_id, "job_id": job.id, "status": "queued"}
 
 
 @router.delete("/image/{media_id}")

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -13,7 +13,8 @@ import sqlalchemy
 # ---------------------------------------------------------------------------
 # 1. Point DATABASE_URL at SQLite so no psycopg2 is needed.
 # ---------------------------------------------------------------------------
-# Hard-pin to safe test values so external env vars cannot point tests at real services.
+# Hard-pin these so tests never accidentally hit real DB/Redis/MinIO even if
+# those env vars are set in the host environment.
 os.environ["DATABASE_URL"] = "sqlite:///:memory:"
 os.environ["REDIS_URL"] = "redis://localhost:6379/0"
 os.environ["MINIO_ENDPOINT"] = "localhost:9000"

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -7,7 +7,7 @@ out pgvector (which requires a live Postgres extension) and MinIO storage.
 
 import sys
 import os
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 import sqlalchemy
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -59,3 +59,10 @@ sys.modules.setdefault("minio.error", minio_error_mock)
 rq_mock = MagicMock()
 sys.modules.setdefault("rq", rq_mock)
 sys.modules.setdefault("rq.job", rq_mock)
+
+# ---------------------------------------------------------------------------
+# 6. Stub redis so queue.py can import Redis without the real package.
+# ---------------------------------------------------------------------------
+redis_mock = MagicMock()
+redis_mock.Redis = MagicMock()
+sys.modules.setdefault("redis", redis_mock)

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -13,12 +13,13 @@ import sqlalchemy
 # ---------------------------------------------------------------------------
 # 1. Point DATABASE_URL at SQLite so no psycopg2 is needed.
 # ---------------------------------------------------------------------------
-os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
-os.environ.setdefault("REDIS_URL", "redis://localhost:6379/0")
-os.environ.setdefault("MINIO_ENDPOINT", "localhost:9000")
-os.environ.setdefault("MINIO_ACCESS_KEY", "minioadmin")
-os.environ.setdefault("MINIO_SECRET_KEY", "minioadmin")
-os.environ.setdefault("MINIO_BUCKET", "find-images")
+# Hard-pin to safe test values so external env vars cannot point tests at real services.
+os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+os.environ["REDIS_URL"] = "redis://localhost:6379/0"
+os.environ["MINIO_ENDPOINT"] = "localhost:9000"
+os.environ["MINIO_ACCESS_KEY"] = "minioadmin"
+os.environ["MINIO_SECRET_KEY"] = "minioadmin"
+os.environ["MINIO_BUCKET"] = "find-images"
 
 # ---------------------------------------------------------------------------
 # 2. Patch create_engine to strip kwargs unsupported by SQLite (pool_size,

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,61 @@
+"""
+conftest.py – patch heavy dependencies before find_api is imported.
+
+Sets a SQLite DATABASE_URL so no PostgreSQL/psycopg2 is needed, and stubs
+out pgvector (which requires a live Postgres extension) and MinIO storage.
+"""
+
+import sys
+import os
+from unittest.mock import MagicMock, patch
+import sqlalchemy
+
+# ---------------------------------------------------------------------------
+# 1. Point DATABASE_URL at SQLite so no psycopg2 is needed.
+# ---------------------------------------------------------------------------
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+os.environ.setdefault("REDIS_URL", "redis://localhost:6379/0")
+os.environ.setdefault("MINIO_ENDPOINT", "localhost:9000")
+os.environ.setdefault("MINIO_ACCESS_KEY", "minioadmin")
+os.environ.setdefault("MINIO_SECRET_KEY", "minioadmin")
+os.environ.setdefault("MINIO_BUCKET", "find-images")
+
+# ---------------------------------------------------------------------------
+# 2. Patch create_engine to strip kwargs unsupported by SQLite (pool_size,
+#    max_overflow) so database.py module-level call succeeds.
+# ---------------------------------------------------------------------------
+_orig_create_engine = sqlalchemy.create_engine
+
+
+def _sqlite_safe_create_engine(url, **kwargs):
+    kwargs.pop("pool_size", None)
+    kwargs.pop("max_overflow", None)
+    kwargs.setdefault("connect_args", {"check_same_thread": False})
+    return _orig_create_engine(url, **kwargs)
+
+
+sqlalchemy.create_engine = _sqlite_safe_create_engine  # type: ignore[assignment]
+
+# ---------------------------------------------------------------------------
+# 3. Stub pgvector before SQLAlchemy tries to use the Vector column type.
+# ---------------------------------------------------------------------------
+pgvector_mock = MagicMock()
+pgvector_mock.sqlalchemy.Vector = MagicMock(return_value=MagicMock())
+sys.modules.setdefault("pgvector", pgvector_mock)
+sys.modules.setdefault("pgvector.sqlalchemy", pgvector_mock.sqlalchemy)
+
+# ---------------------------------------------------------------------------
+# 4. Stub minio so storage.py doesn't fail at import.
+# ---------------------------------------------------------------------------
+minio_mock = MagicMock()
+minio_error_mock = MagicMock()
+minio_error_mock.S3Error = Exception
+sys.modules.setdefault("minio", minio_mock)
+sys.modules.setdefault("minio.error", minio_error_mock)
+
+# ---------------------------------------------------------------------------
+# 5. Stub rq so queue.py doesn't fail without a Redis connection at import.
+# ---------------------------------------------------------------------------
+rq_mock = MagicMock()
+sys.modules.setdefault("rq", rq_mock)
+sys.modules.setdefault("rq.job", rq_mock)

--- a/backend/tests/test_reprocess.py
+++ b/backend/tests/test_reprocess.py
@@ -47,9 +47,15 @@ class FakeMedia(Base):
     liked: Mapped[bool] = mapped_column(Boolean, default=False)
     status: Mapped[str] = mapped_column(String(50), default="pending")
     error_message: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
-    created_at: Mapped[Optional[datetime.datetime]] = mapped_column(DateTime, nullable=True)
-    updated_at: Mapped[Optional[datetime.datetime]] = mapped_column(DateTime, nullable=True)
-    processed_at: Mapped[Optional[datetime.datetime]] = mapped_column(DateTime, nullable=True)
+    created_at: Mapped[Optional[datetime.datetime]] = mapped_column(
+        DateTime, nullable=True
+    )
+    updated_at: Mapped[Optional[datetime.datetime]] = mapped_column(
+        DateTime, nullable=True
+    )
+    processed_at: Mapped[Optional[datetime.datetime]] = mapped_column(
+        DateTime, nullable=True
+    )
     width: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
     height: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
     exif_json: Mapped[Optional[dict]] = mapped_column(JSON, nullable=True)
@@ -123,8 +129,8 @@ def make_media(*, status: str, metadata_json=None, error_message=None) -> FakeMe
 # Tests
 # ---------------------------------------------------------------------------
 
-class TestReprocessEndpoint:
 
+class TestReprocessEndpoint:
     @patch("find_api.routers.gallery.get_task_queue")
     def test_reprocess_failed_image_returns_queued(self, mock_queue, client):
         """Failed image is accepted; response contains job_id and status=queued."""
@@ -223,6 +229,7 @@ class TestReprocessEndpoint:
         mock_queue_instance.enqueue.assert_called_once()
         call_args = mock_queue_instance.enqueue.call_args
         from find_api.workers.jobs import analyze_image
+
         assert call_args[0][0] is analyze_image
         assert call_args[0][1] == media.id
 
@@ -248,5 +255,3 @@ class TestReprocessEndpoint:
 
         r2 = client.post(f"/api/image/{media.id}/reprocess")
         assert r2.status_code == 200
-
-

--- a/backend/tests/test_reprocess.py
+++ b/backend/tests/test_reprocess.py
@@ -80,9 +80,6 @@ def _fresh_db():
 
 import sys
 
-# Pre-populate the gallery module namespace with our FakeMedia
-# by patching the module's Media reference after import.
-
 # First import — pgvector is already mocked in conftest.py
 import find_api.routers.gallery as gallery_module
 

--- a/backend/tests/test_reprocess.py
+++ b/backend/tests/test_reprocess.py
@@ -6,17 +6,17 @@ Run with (from backend/ directory):
     pytest tests/test_reprocess.py -v
 """
 
+import datetime
+from typing import Optional
 import pytest
 from unittest.mock import MagicMock, patch
-
-# conftest.py sets env vars and stubs pgvector / minio / rq before any import.
-
 from fastapi.testclient import TestClient
+from fastapi import FastAPI
+import find_api.routers.gallery as gallery_module
+from find_api.core.database import get_db
 from sqlalchemy import create_engine, String, Integer, Boolean, DateTime, Text, JSON
 from sqlalchemy.orm import sessionmaker, DeclarativeBase, Mapped, mapped_column
 from sqlalchemy.pool import StaticPool
-from typing import Optional
-import datetime
 
 # ---------------------------------------------------------------------------
 # Minimal in-memory SQLite replica of the Media model (no pgvector needed)
@@ -74,19 +74,10 @@ def _fresh_db():
 
 # ---------------------------------------------------------------------------
 # Import the router under test and override dependencies
-# Patch find_api.routers.gallery.Media *before* importing so the router
-# uses our SQLite-compatible FakeMedia class.
+# Patch find_api.routers.gallery.Media so the router uses our FakeMedia.
 # ---------------------------------------------------------------------------
 
-import sys
-
-# First import — pgvector is already mocked in conftest.py
-import find_api.routers.gallery as gallery_module
-
 gallery_module.Media = FakeMedia  # type: ignore[assignment]
-
-from fastapi import FastAPI
-from find_api.core.database import get_db
 
 test_app = FastAPI()
 test_app.include_router(gallery_module.router, prefix="/api")

--- a/backend/tests/test_reprocess.py
+++ b/backend/tests/test_reprocess.py
@@ -79,11 +79,9 @@ def _fresh_db():
 # ---------------------------------------------------------------------------
 
 import sys
-import types
 
 # Pre-populate the gallery module namespace with our FakeMedia
 # by patching the module's Media reference after import.
-import importlib
 
 # First import — pgvector is already mocked in conftest.py
 import find_api.routers.gallery as gallery_module

--- a/backend/tests/test_reprocess.py
+++ b/backend/tests/test_reprocess.py
@@ -1,0 +1,266 @@
+"""
+Tests for the POST /image/{media_id}/reprocess endpoint.
+
+Run with (from backend/ directory):
+    $env:PYTHONPATH = "src"
+    pytest tests/test_reprocess.py -v
+"""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+# conftest.py sets env vars and stubs pgvector / minio / rq before any import.
+
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, String, Integer, Boolean, DateTime, Text, JSON
+from sqlalchemy.orm import sessionmaker, DeclarativeBase, Mapped, mapped_column
+from sqlalchemy.pool import StaticPool
+from typing import Optional
+import datetime
+
+# ---------------------------------------------------------------------------
+# Minimal in-memory SQLite replica of the Media model (no pgvector needed)
+# ---------------------------------------------------------------------------
+
+SQLALCHEMY_DATABASE_URL = "sqlite:///:memory:"
+engine = create_engine(
+    SQLALCHEMY_DATABASE_URL,
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+class Base(DeclarativeBase):
+    pass
+
+
+class FakeMedia(Base):
+    __tablename__ = "media"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    file_hash: Mapped[str] = mapped_column(String(64), unique=True)
+    minio_key: Mapped[str] = mapped_column(String(255))
+    filename: Mapped[str] = mapped_column(String(255))
+    content_type: Mapped[Optional[str]] = mapped_column(String(100), nullable=True)
+    file_size: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
+    liked: Mapped[bool] = mapped_column(Boolean, default=False)
+    status: Mapped[str] = mapped_column(String(50), default="pending")
+    error_message: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    created_at: Mapped[Optional[datetime.datetime]] = mapped_column(DateTime, nullable=True)
+    updated_at: Mapped[Optional[datetime.datetime]] = mapped_column(DateTime, nullable=True)
+    processed_at: Mapped[Optional[datetime.datetime]] = mapped_column(DateTime, nullable=True)
+    width: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
+    height: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
+    exif_json: Mapped[Optional[dict]] = mapped_column(JSON, nullable=True)
+    metadata_json: Mapped[Optional[dict]] = mapped_column(JSON, nullable=True)
+    cluster_id: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
+
+
+Base.metadata.create_all(bind=engine)
+
+
+def get_test_db():
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+def _fresh_db():
+    return TestingSessionLocal()
+
+
+# ---------------------------------------------------------------------------
+# Import the router under test and override dependencies
+# Patch find_api.routers.gallery.Media *before* importing so the router
+# uses our SQLite-compatible FakeMedia class.
+# ---------------------------------------------------------------------------
+
+import sys
+import types
+
+# Pre-populate the gallery module namespace with our FakeMedia
+# by patching the module's Media reference after import.
+import importlib
+
+# First import — pgvector is already mocked in conftest.py
+import find_api.routers.gallery as gallery_module
+
+gallery_module.Media = FakeMedia  # type: ignore[assignment]
+
+from fastapi import FastAPI
+from find_api.core.database import get_db
+
+test_app = FastAPI()
+test_app.include_router(gallery_module.router, prefix="/api")
+test_app.dependency_overrides[get_db] = get_test_db
+
+
+@pytest.fixture(autouse=True)
+def reset_db():
+    """Truncate the media table between tests."""
+    db = _fresh_db()
+    db.query(FakeMedia).delete()
+    db.commit()
+    db.close()
+    yield
+
+
+@pytest.fixture()
+def client():
+    with TestClient(test_app) as c:
+        yield c
+
+
+def make_media(*, status: str, metadata_json=None, error_message=None) -> FakeMedia:
+    db = _fresh_db()
+    m = FakeMedia(
+        file_hash="abc123",
+        minio_key="images/ab/abc123.jpg",
+        filename="test.jpg",
+        content_type="image/jpeg",
+        file_size=1024,
+        status=status,
+        metadata_json=metadata_json,
+        error_message=error_message,
+    )
+    db.add(m)
+    db.commit()
+    db.refresh(m)
+    db.close()
+    return m
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestReprocessEndpoint:
+
+    @patch("find_api.routers.gallery.get_task_queue")
+    def test_reprocess_failed_image_returns_queued(self, mock_queue, client):
+        """Failed image is accepted; response contains job_id and status=queued."""
+        mock_job = MagicMock()
+        mock_job.id = "fake-job-001"
+        mock_queue.return_value.enqueue.return_value = mock_job
+
+        media = make_media(status="failed", error_message="some error")
+
+        resp = client.post(f"/api/image/{media.id}/reprocess")
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["media_id"] == media.id
+        assert body["job_id"] == "fake-job-001"
+        assert body["status"] == "queued"
+
+    @patch("find_api.routers.gallery.get_task_queue")
+    def test_reprocess_clears_error_and_resets_status(self, mock_queue, client):
+        """After reprocess: status must be pending, error_message must be None."""
+        mock_job = MagicMock()
+        mock_job.id = "fake-job-002"
+        mock_queue.return_value.enqueue.return_value = mock_job
+
+        media = make_media(status="failed", error_message="old error")
+
+        client.post(f"/api/image/{media.id}/reprocess")
+
+        db = _fresh_db()
+        updated = db.query(FakeMedia).filter(FakeMedia.id == media.id).first()
+        assert updated.status == "pending"
+        assert updated.error_message is None
+        assert updated.processed_at is None
+        db.close()
+
+    @patch("find_api.routers.gallery.get_task_queue")
+    def test_reprocess_indexed_incomplete_no_caption(self, mock_queue, client):
+        """Indexed image with no caption is eligible for reprocessing."""
+        mock_job = MagicMock()
+        mock_job.id = "fake-job-003"
+        mock_queue.return_value.enqueue.return_value = mock_job
+
+        media = make_media(status="indexed", metadata_json={"objects": []})
+
+        resp = client.post(f"/api/image/{media.id}/reprocess")
+
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "queued"
+
+    def test_reprocess_indexed_complete_is_rejected(self, client):
+        """Indexed image with a caption must return 400 — no spurious retries."""
+        media = make_media(
+            status="indexed",
+            metadata_json={"caption": "a dog on a bench", "objects": []},
+        )
+
+        resp = client.post(f"/api/image/{media.id}/reprocess")
+
+        assert resp.status_code == 400
+
+    def test_reprocess_pending_image_is_rejected(self, client):
+        """Already-pending image must not be double-enqueued."""
+        media = make_media(status="pending")
+
+        resp = client.post(f"/api/image/{media.id}/reprocess")
+
+        assert resp.status_code == 400
+
+    def test_reprocess_processing_image_is_rejected(self, client):
+        """Currently-processing image must not be requeued."""
+        media = make_media(status="processing")
+
+        resp = client.post(f"/api/image/{media.id}/reprocess")
+
+        assert resp.status_code == 400
+
+    def test_reprocess_nonexistent_media_returns_404(self, client):
+        """Unknown media_id returns 404."""
+        resp = client.post("/api/image/99999/reprocess")
+
+        assert resp.status_code == 404
+
+    @patch("find_api.routers.gallery.get_task_queue")
+    def test_reprocess_enqueues_analyze_image_job(self, mock_queue, client):
+        """The RQ queue must receive exactly one enqueue call with correct args."""
+        mock_job = MagicMock()
+        mock_job.id = "fake-job-004"
+        mock_queue_instance = MagicMock()
+        mock_queue_instance.enqueue.return_value = mock_job
+        mock_queue.return_value = mock_queue_instance
+
+        media = make_media(status="failed")
+
+        client.post(f"/api/image/{media.id}/reprocess")
+
+        mock_queue_instance.enqueue.assert_called_once()
+        call_args = mock_queue_instance.enqueue.call_args
+        from find_api.workers.jobs import analyze_image
+        assert call_args[0][0] is analyze_image
+        assert call_args[0][1] == media.id
+
+    @patch("find_api.routers.gallery.get_task_queue")
+    def test_repeated_reprocess_allowed(self, mock_queue, client):
+        """A failed image may be retried multiple times."""
+        mock_job = MagicMock()
+        mock_job.id = "fake-job-005"
+        mock_queue.return_value.enqueue.return_value = mock_job
+
+        media = make_media(status="failed")
+
+        r1 = client.post(f"/api/image/{media.id}/reprocess")
+        assert r1.status_code == 200
+
+        # Simulate second failure
+        db = _fresh_db()
+        item = db.query(FakeMedia).filter(FakeMedia.id == media.id).first()
+        item.status = "failed"
+        item.error_message = "failed again"
+        db.commit()
+        db.close()
+
+        r2 = client.post(f"/api/image/{media.id}/reprocess")
+        assert r2.status_code == 200
+
+

--- a/docs/reprocess-retry.md
+++ b/docs/reprocess-retry.md
@@ -67,16 +67,9 @@ pnpm install    # or npm install
 pnpm vitest run src/__tests__/reprocess.test.ts
 ```
 
-## Suggested commit & PR workflow
-
-1. Create a feature branch from `main`: `git checkout -b feature/reprocess-retry`.
-2. Add tests and docs together with the code changes so reviewers can run them locally.
-3. Push the branch and open a pull request against `main` describing the change and linking related issues.
-
 ## Notes
 
 - The backend tests were designed to be fast and not require a running worker or object storage instance. If you run full integration tests (manual run), you will need MinIO and an RQ worker configured.
 - The frontend tests cover the small UI/logic changes; integration/e2e tests are not included in this change.
 
----
-If you want, I can commit these docs and the code changes to a feature branch and push a PR for you.
+

--- a/docs/reprocess-retry.md
+++ b/docs/reprocess-retry.md
@@ -1,0 +1,82 @@
+# Reprocess / Retry Analysis Feature
+
+This document describes the "reprocess" (retry analysis) feature added to the project, what was changed, how the tests were written, and how to run them locally.
+
+## Summary
+
+- Adds a backend endpoint to re-enqueue the existing `analyze_image` worker for an existing media row without requiring a duplicate upload.
+- Adds a frontend action (modal and gallery card) to trigger the reprocess for eligible media rows.
+- Adds unit tests for both backend and frontend and developer documentation for running the tests.
+
+## What changed (high level)
+
+- Backend
+  - `backend/src/find_api/routers/gallery.py`: adds `POST /api/image/{media_id}/reprocess` endpoint that:
+    - validates eligibility (failed or indexed with missing caption),
+    - resets `status` to `pending`, clears stale `error_message`/`processed_at`, and
+    - enqueues the existing `find_api.workers.jobs.analyze_image(media_id)` job via the configured RQ queue.
+
+- Frontend
+  - `frontend/src/lib/api.ts`: adds `reprocessImage(mediaId) -> ReprocessResponse` wrapper.
+  - `frontend/src/components/image-preview-modal.tsx`: adds a "Retry Analysis" action visible for `failed` images (and indexed images missing caption).
+  - `frontend/src/app/gallery/page.tsx`: shows a per-card retry icon for `failed` images.
+
+- Tests
+  - Backend tests: `backend/tests/test_reprocess.py` (plus test shims in `backend/tests/conftest.py`) — uses an in-memory SQLite DB (StaticPool) and test-time shims for RQ/MinIO to keep tests fast and isolated.
+  - Frontend tests: `frontend/src/__tests__/reprocess.test.ts` — Vitest unit tests for the API wrapper and UI eligibility logic. Tests mock `axios` and use a small helper to provide a fake `api` axios instance.
+
+## How the tests were written
+
+- Backend
+  - Tests exercise the FastAPI router directly using `TestClient`.
+  - Heavy external dependencies (MinIO, RQ, pgvector) are stubbed in `conftest.py` so the test suite does not require those services.
+  - The DB is created in-memory with SQLAlchemy `StaticPool` so the app and tests share the same memory DB.
+
+- Frontend
+  - Tests use Vitest and @testing-library patterns. The `axios` module is mocked and `axios.create()` is made to return a small object implementing `post/get/delete` so the exported `api` instance can be spied on.
+
+## How to run the tests locally
+
+Backend (Windows PowerShell):
+
+```powershell
+Set-Location d:\gssoc\find\Find\backend
+$env:PYTHONPATH = 'src'; py -m pytest tests/test_reprocess.py -q
+```
+
+Backend (Linux/macOS / POSIX):
+
+```bash
+cd backend
+PYTHONPATH=src pytest tests/test_reprocess.py -q
+```
+
+Frontend (PowerShell):
+
+```powershell
+Set-Location d:\gssoc\find\Find\frontend
+npm install    # or pnpm install
+npx vitest run src/__tests__/reprocess.test.ts
+```
+
+Frontend (POSIX):
+
+```bash
+cd frontend
+pnpm install    # or npm install
+pnpm vitest run src/__tests__/reprocess.test.ts
+```
+
+## Suggested commit & PR workflow
+
+1. Create a feature branch from `main`: `git checkout -b feature/reprocess-retry`.
+2. Add tests and docs together with the code changes so reviewers can run them locally.
+3. Push the branch and open a pull request against `main` describing the change and linking related issues.
+
+## Notes
+
+- The backend tests were designed to be fast and not require a running worker or object storage instance. If you run full integration tests (manual run), you will need MinIO and an RQ worker configured.
+- The frontend tests cover the small UI/logic changes; integration/e2e tests are not included in this change.
+
+---
+If you want, I can commit these docs and the code changes to a feature branch and push a PR for you.

--- a/frontend/biome.json
+++ b/frontend/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.13/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.15/schema.json",
   "linter": {
     "enabled": true,
     "rules": {

--- a/frontend/biome.json
+++ b/frontend/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.15/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.13/schema.json",
   "linter": {
     "enabled": true,
     "rules": {

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -37,7 +37,6 @@
     "tailwindcss-animate": "^1.0.7",
     "typescript": "^5.6.3",
     "vitest": "^4.1.6"
-    "typescript": "^5.6.3"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,7 +27,7 @@
     "tailwind-merge": "^3.5.0"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.4.13",
+    "@biomejs/biome": "2.4.15",
     "@types/node": "^22.8.6",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,9 @@
     "start": "next start",
     "lint": "biome check --write .",
     "format": "biome format --write .",
-    "check": "biome check ."
+    "check": "biome check .",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@tanstack/react-query": "^5.100.7",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -33,6 +33,7 @@
     "postcss": "^8.5.13",
     "tailwindcss": "^3.4.14",
     "tailwindcss-animate": "^1.0.7",
-    "typescript": "^5.6.3"
+    "typescript": "^5.6.3",
+    "vitest": "^4.1.6"
   }
 }

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -46,8 +46,8 @@ importers:
         version: 3.5.0
     devDependencies:
       '@biomejs/biome':
-        specifier: ^2.4.13
-        version: 2.4.13
+        specifier: 2.4.15
+        version: 2.4.15
       '@types/node':
         specifier: ^22.8.6
         version: 22.19.1
@@ -82,55 +82,55 @@ packages:
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
 
-  '@biomejs/biome@2.4.13':
-    resolution: {integrity: sha512-gLXOwkOBBg0tr7bDsqlkIh4uFeKuMjxvqsrb1Tukww1iDmHcfr4Uu8MoQxp0Rcte+69+osRNWXwHsu/zxT6XqA==}
+  '@biomejs/biome@2.4.15':
+    resolution: {integrity: sha512-j5VH3a/h/HXTKBM50MDMxRCzkeLv9S2XJcW2WgnZT1+xyisi+0bISrXR82gCX+8S9lvK0skEvHJRN+3Ktr2hlw==}
     engines: {node: '>=14.21.3'}
     hasBin: true
 
-  '@biomejs/cli-darwin-arm64@2.4.13':
-    resolution: {integrity: sha512-2KImO1jhNFBa2oWConyr0x6flxbQpGKv6902uGXpYM62Xyem8U80j441SyUJ8KyngsmKbQjeIv1q2CQfDkNnYg==}
+  '@biomejs/cli-darwin-arm64@2.4.15':
+    resolution: {integrity: sha512-rF3PPqLq1yoST79zaQbDjVJwsuIeci/O+9bgNmC5QpgOqz6aqYuzA4abyAGx+mgyiDXn4A049xAN8gijbuR1Qg==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [darwin]
 
-  '@biomejs/cli-darwin-x64@2.4.13':
-    resolution: {integrity: sha512-BKrJklbaFN4p1Ts4kPBczo+PkbsHQg57kmJ+vON9u2t6uN5okYHaSr7h/MutPCWQgg2lglaWoSmm+zhYW+oOkg==}
+  '@biomejs/cli-darwin-x64@2.4.15':
+    resolution: {integrity: sha512-/5KHXYMfSJs1fNXiX30xFtI8JcCFV6zaVVLxOa0M2sfqBKHkpQhRTv94yxQWxeTY2lzo2OuTlNvPC+hDQt2wcQ==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [darwin]
 
-  '@biomejs/cli-linux-arm64-musl@2.4.13':
-    resolution: {integrity: sha512-U5MsuBQW25dXaYtqWWSPM3P96H6Y+fHuja3TQpMNnylocHW0tEbtFTDlUj6oM+YJLntvEkQy4grBvQNUD4+RCg==}
+  '@biomejs/cli-linux-arm64-musl@2.4.15':
+    resolution: {integrity: sha512-ZPcxznxm0pogHBLZhYntyR3sR+MrZjqJIKEr7ZqVen0Rl+P/4upVmfYXjftizi9RoqZntg33fv/1fbdhbYXpEQ==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
 
-  '@biomejs/cli-linux-arm64@2.4.13':
-    resolution: {integrity: sha512-NzkUDSqfvMBrPplKgVr3aXLHZ2NEELvvF4vZxXulEylKWIGqlvNEcwUcj9OLrn75TD3lJ/GIqCVlBwd1MZCuYQ==}
+  '@biomejs/cli-linux-arm64@2.4.15':
+    resolution: {integrity: sha512-owaAMZD/T4LrD0ELNCk0Km3qrRHuM0X6EAyVE1FSqGY0rbLoiDLrO4Us2tllm6cAeB2Ioa9C2C08NZPdr8+0Ug==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
 
-  '@biomejs/cli-linux-x64-musl@2.4.13':
-    resolution: {integrity: sha512-Z601MienRgTBDza/+u2CH3RSrWoXo9rtr8NK6A4KJzqGgfxx+H3VlyLgTJ4sRo40T3pIsqpTmiOQEvYzQvBRvQ==}
+  '@biomejs/cli-linux-x64-musl@2.4.15':
+    resolution: {integrity: sha512-CNq/9W38SYSH023lfcQ4KKU8K0YX8T//FZUhcgtMMRABDojx5XsMV7jlweAvGSl389wJQB29Qo6Zb/a+jdvt+w==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
 
-  '@biomejs/cli-linux-x64@2.4.13':
-    resolution: {integrity: sha512-Az3ZZedYRBo9EQzNnD9SxFcR1G5QsGo6VEc2hIyVPZ1rdKwee/7E9oeBBZFpE8Z44ekxsDQBqbiWGW5ShOhUSQ==}
+  '@biomejs/cli-linux-x64@2.4.15':
+    resolution: {integrity: sha512-0jj7THz12GbUOLmMibktK6DZjqz2zV64KFxyBtcFTKPiiOIY0a7vns1elpO1dERvxpsZ5ik0oFfz0oGwFde1+g==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
 
-  '@biomejs/cli-win32-arm64@2.4.13':
-    resolution: {integrity: sha512-Px9PS2B5/Q183bUwy/5VHqp3J2lzdOCeVGzMpphYfl8oSa7VDCqenBdqWpy6DCy/en4Rbf/Y1RieZF6dJPcc9A==}
+  '@biomejs/cli-win32-arm64@2.4.15':
+    resolution: {integrity: sha512-ouhkYdlhp/1GghEJPdWwD/Vi3gQ1nFxuSpMolWsbq3Lsq3QUR4jl6UdhhscdCugKU5vOEuMiJhvKj66O0OCq+w==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [win32]
 
-  '@biomejs/cli-win32-x64@2.4.13':
-    resolution: {integrity: sha512-tTcMkXyBrmHi9BfrD2VNHs/5rYIUKETqsBlYOvSAABwBkJhSDVb5e7wPukftsQbO3WzQkXe6kaztC6WtUOXSoQ==}
+  '@biomejs/cli-win32-x64@2.4.15':
+    resolution: {integrity: sha512-zBrGq5mx5wwpnow4+2BxUvleDM+GNd4sLbPaMapsSLQLD0NGRCquqPBTgN+7XkUteHvj7M+BstuI8tmnV7+HgQ==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
@@ -1290,39 +1290,39 @@ snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
 
-  '@biomejs/biome@2.4.13':
+  '@biomejs/biome@2.4.15':
     optionalDependencies:
-      '@biomejs/cli-darwin-arm64': 2.4.13
-      '@biomejs/cli-darwin-x64': 2.4.13
-      '@biomejs/cli-linux-arm64': 2.4.13
-      '@biomejs/cli-linux-arm64-musl': 2.4.13
-      '@biomejs/cli-linux-x64': 2.4.13
-      '@biomejs/cli-linux-x64-musl': 2.4.13
-      '@biomejs/cli-win32-arm64': 2.4.13
-      '@biomejs/cli-win32-x64': 2.4.13
+      '@biomejs/cli-darwin-arm64': 2.4.15
+      '@biomejs/cli-darwin-x64': 2.4.15
+      '@biomejs/cli-linux-arm64': 2.4.15
+      '@biomejs/cli-linux-arm64-musl': 2.4.15
+      '@biomejs/cli-linux-x64': 2.4.15
+      '@biomejs/cli-linux-x64-musl': 2.4.15
+      '@biomejs/cli-win32-arm64': 2.4.15
+      '@biomejs/cli-win32-x64': 2.4.15
 
-  '@biomejs/cli-darwin-arm64@2.4.13':
+  '@biomejs/cli-darwin-arm64@2.4.15':
     optional: true
 
-  '@biomejs/cli-darwin-x64@2.4.13':
+  '@biomejs/cli-darwin-x64@2.4.15':
     optional: true
 
-  '@biomejs/cli-linux-arm64-musl@2.4.13':
+  '@biomejs/cli-linux-arm64-musl@2.4.15':
     optional: true
 
-  '@biomejs/cli-linux-arm64@2.4.13':
+  '@biomejs/cli-linux-arm64@2.4.15':
     optional: true
 
-  '@biomejs/cli-linux-x64-musl@2.4.13':
+  '@biomejs/cli-linux-x64-musl@2.4.15':
     optional: true
 
-  '@biomejs/cli-linux-x64@2.4.13':
+  '@biomejs/cli-linux-x64@2.4.15':
     optional: true
 
-  '@biomejs/cli-win32-arm64@2.4.13':
+  '@biomejs/cli-win32-arm64@2.4.15':
     optional: true
 
-  '@biomejs/cli-win32-x64@2.4.13':
+  '@biomejs/cli-win32-x64@2.4.15':
     optional: true
 
   '@emnapi/core@1.10.0':

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -72,6 +72,9 @@ importers:
       typescript:
         specifier: ^5.6.3
         version: 5.9.3
+      vitest:
+        specifier: ^4.1.6
+        version: 4.1.6(@types/node@22.19.1)(vite@8.0.12(@types/node@22.19.1)(jiti@1.21.7))
 
 packages:
 
@@ -132,8 +135,14 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@emnapi/core@1.10.0':
+    resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
+
   '@emnapi/runtime@1.10.0':
     resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
+
+  '@emnapi/wasi-threads@1.2.1':
+    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
   '@img/colour@1.1.0':
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
@@ -285,6 +294,12 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@napi-rs/wasm-runtime@1.1.4':
+    resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
   '@next/env@16.2.4':
     resolution: {integrity: sha512-dKkkOzOSwFYe5RX6y26fZgkSpVAlIOJKQHIiydQcrWH6y/97+RceSOAdjZ14Qa3zLduVUy0TXcn+EiM6t4rPgw==}
 
@@ -348,6 +363,104 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
+  '@oxc-project/types@0.129.0':
+    resolution: {integrity: sha512-3oz8m3FGdr2nDXVqmFUw7jolKliC4MoyXYIG2c7gpjBnzUWQpUGIYcXYKxTdTi+N2jusvt610ckTMkxdwHkYEg==}
+
+  '@rolldown/binding-android-arm64@1.0.0':
+    resolution: {integrity: sha512-TWMZnRLMe63C2Lhyicviu7ZHaU4kxa6PS3rofvc9GmcvptzNN11BcfQ4Sl7MwTOsisQoa2keB/EBdNCAnUo8vA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.0.0':
+    resolution: {integrity: sha512-6XcD+8k0gPVItNagEw78/qqcBDwKcwDYS8V2hRmVsfUSIrd8cWe/CBvRDI5toqFyPfj+FJr6t8U6Xj2P2prEew==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.0.0':
+    resolution: {integrity: sha512-iN/tWVXRQDWvmZlKdceP1Dwug9GDpEymhb9p4xnEe6zvCg5lFmzVljl+1qR1NVx3yfGpr2Na+CuLmv5IU8uzfQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.0.0':
+    resolution: {integrity: sha512-jjQMDvvwSOuhOwMszD/klSOjyWMM3zI64hWTj9KT5x4MxRbZAf+7vLQ6qouRhtsLVFHr3f0ILaJAfgENPiQdAQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0':
+    resolution: {integrity: sha512-d//Dtg2x6/m3mbV64yUGNnDGNZaDGRpDLLNGerHQUVObuNaIQaaDp25yUiqGXtHEXX+NP2d0wAlmKgpYgIAJ2A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0':
+    resolution: {integrity: sha512-n7Ofp0mx+aB2cC+Sdy5YtMnXtY9lchnHbY+3Yt0uq9JsWQExf4f5Whu0tK0R8Jdc9S6RchTHjIFY7uc92puOVQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0':
+    resolution: {integrity: sha512-EIVjy2cgd7uuMMo94FVkBp7F6DhcZAUwNURkSG3RwUmvAXR6s0ISxM81U+IydcZByPG0pZIHsf1b6kTxoFDgJA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0':
+    resolution: {integrity: sha512-JEwwOPcwTLAcpDQlqSmjEmfs63xJnSiUNIGvLcDLUHCWK4XowpS/7c7tUsUH6uT/ct6bMUTdXKfI8967FYj6mg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0':
+    resolution: {integrity: sha512-0wjCFhLrihtAubnT9iA0N++0pSV0z5Hg7tNGdNJ4RFaINceHadoF+kiFGyY1qSSNVIAZtLotG8Ju1bgDPkjnFA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0':
+    resolution: {integrity: sha512-Dfn7iak9BcMMePxcoJfpSbWqnEyrp/dRF63/8qW/eHBdOZov6x5aShLLEYGYdIeSJ6vMLK/XCVB+lGIxm41bQA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-musl@1.0.0':
+    resolution: {integrity: sha512-5/utzzDmD/pD/bmuaUcbTf/sZYy0aztwIVlfpoW1fTjCZ0BaPOMVWGZL1zvgxyi7ZIVYWlxKONHmSbHuiOh8Jw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-openharmony-arm64@1.0.0':
+    resolution: {integrity: sha512-ouJs8VcUomfLfpbUECqFMRqdV4x6aeAK3MA4m6vTrJJjKyWTV5KnxZx7Jd9G+GlDaQQxubcba00x16OyJ1meig==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-wasm32-wasi@1.0.0':
+    resolution: {integrity: sha512-E+oHKGiDA+lsKMmFtffDDw91EryDT7uJocrIuCHqhm6bCTM6xFK+3gaCkYOHfPwQr0cCNarSM2xaELoQDz9jJg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0':
+    resolution: {integrity: sha512-yYK02n8Rngo+gbm1y6G0+7jk1sJ/2Wt7K0me0Y7k/ErBpyf+LJ2gFpqWVTcRV1rUepBlQRmpgWkTQCiiwrK0Ow==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0':
+    resolution: {integrity: sha512-14bpChMahXRRXiTwahSl+zzHPW6qQTXtkMuJBFlbo+pqSAews2d4BdCSHfrJ/MBsCZtpmTafsY+1QhBzitcmdg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.0':
+    resolution: {integrity: sha512-aKs/3GSWyV0mrhNmt/96/Z3yczC3yvrzYATCiCXQebBsGyYzjNdUphRVLeJQ67ySKVXRfMxt2lm12pmXvbPFQQ==}
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
 
@@ -358,6 +471,18 @@ packages:
     resolution: {integrity: sha512-LoISYWz8dOOuQbeIctF8K6yi42TWtR1WPGpwGuRUpF3u79JVVIg/PVR0MQdIA0VSHqD/ydf/b7PhKTkg3I4fLQ==}
     peerDependencies:
       react: ^18 || ^19
+
+  '@tybys/wasm-util@0.10.2':
+    resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
   '@types/node@22.19.1':
     resolution: {integrity: sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ==}
@@ -370,6 +495,35 @@ packages:
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
 
+  '@vitest/expect@4.1.6':
+    resolution: {integrity: sha512-7EHDquPthALSV0jhhjgEW8FXaviMx7rSqu8W6oqCoAuOhKov814P99QDV1pxMA3QPv21YudvJngIhjrNI4opLg==}
+
+  '@vitest/mocker@4.1.6':
+    resolution: {integrity: sha512-MCFc63czMjEInOlcY2cpQCvCN+KgbAn+60xu9cMgP4sKaLC5JNAKw7JH8QdAnoAC88hW1IiSNZ+GgVXlN1UcMQ==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.6':
+    resolution: {integrity: sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw==}
+
+  '@vitest/runner@4.1.6':
+    resolution: {integrity: sha512-nOPCmn2+yD0ZNmKdsXGv/UxMMWbMuKeD6GyYncNwdkYDxpQvrPSKYj2rWuDjC2Y4b6w6hjip5dBKFzEUuZe3vA==}
+
+  '@vitest/snapshot@4.1.6':
+    resolution: {integrity: sha512-YhsdE6xAVfTDmzjxL2ZDUvjj+ZsgyOKe+TdQzqkD72wIOmHka8NuGQ6NpTNZv9D2Z63fbwWKJPeVpEw4EQgYxw==}
+
+  '@vitest/spy@4.1.6':
+    resolution: {integrity: sha512-JFKxMx6udhwKh/Ldo270e17QX710vgunMkuPAvXjHSvC6oqLWAHhVhjg/I71q0u0CBSErIODV1Kjv0FQNSWjdg==}
+
+  '@vitest/utils@4.1.6':
+    resolution: {integrity: sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==}
+
   any-promise@1.3.0:
     resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
 
@@ -379,6 +533,10 @@ packages:
 
   arg@5.0.2:
     resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
 
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
@@ -426,6 +584,10 @@ packages:
   caniuse-lite@1.0.30001791:
     resolution: {integrity: sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==}
 
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
+
   chokidar@3.6.0:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
     engines: {node: '>= 8.10.0'}
@@ -447,6 +609,9 @@ packages:
   commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
     engines: {node: '>= 6'}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
   cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
@@ -488,6 +653,9 @@ packages:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
 
+  es-module-lexer@2.1.0:
+    resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
+
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
@@ -499,6 +667,13 @@ packages:
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   fast-glob@3.3.3:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
@@ -611,6 +786,76 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
+  lightningcss-android-arm64@1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.32.0:
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
+    engines: {node: '>= 12.0.0'}
+
   lilconfig@3.1.3:
     resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
     engines: {node: '>=14'}
@@ -626,6 +871,9 @@ packages:
     resolution: {integrity: sha512-+1mdWcfSJVUsaTIjN9zoezmUhfXo5l0vP7ekBMPo3jcS/aIkxHnXqAPsByszMZx/Y8oQBRJxJx5xg+RH3urzxA==}
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -691,8 +939,14 @@ packages:
     resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
     engines: {node: '>= 6'}
 
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -703,6 +957,10 @@ packages:
 
   picomatch@4.0.3:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
+    engines: {node: '>=12'}
+
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
   pify@2.3.0:
@@ -764,6 +1022,10 @@ packages:
     resolution: {integrity: sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==}
     engines: {node: ^10 || ^12 || >=14}
 
+  postcss@8.5.14:
+    resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
+    engines: {node: ^10 || ^12 || >=14}
+
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
@@ -808,6 +1070,11 @@ packages:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
+  rolldown@1.0.0:
+    resolution: {integrity: sha512-yD986aXDESFGS95spT1LAv0jssywP4npMEjmMHyN2/5+eE8qQJUype2AaKkRiLgBgyD0LFlubwAht7VmY8rGoA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
@@ -823,6 +1090,9 @@ packages:
     resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   sonner@2.0.7:
     resolution: {integrity: sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==}
     peerDependencies:
@@ -832,6 +1102,12 @@ packages:
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
   styled-jsx@5.1.6:
     resolution: {integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==}
@@ -875,9 +1151,24 @@ packages:
   thenify@3.3.1:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.1.2:
+    resolution: {integrity: sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==}
+    engines: {node: '>=18'}
+
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
+
+  tinyglobby@0.2.16:
+    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
+    engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -905,6 +1196,95 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  vite@8.0.12:
+    resolution: {integrity: sha512-w2dDofOWv2QB09ZITZBsvKTVAlYvPR4IAmrY/v0ir9KvLs0xybR7i48wxhM1/oyBWO34wPns+bPGw5ZrZqDpZg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.1.18
+      esbuild: ^0.27.0 || ^0.28.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.1.6:
+    resolution: {integrity: sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.6
+      '@vitest/browser-preview': 4.1.6
+      '@vitest/browser-webdriverio': 4.1.6
+      '@vitest/coverage-istanbul': 4.1.6
+      '@vitest/coverage-v8': 4.1.6
+      '@vitest/ui': 4.1.6
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
 
 snapshots:
 
@@ -945,7 +1325,18 @@ snapshots:
   '@biomejs/cli-win32-x64@2.4.13':
     optional: true
 
+  '@emnapi/core@1.10.0':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.1
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/runtime@1.10.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.1':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -1061,6 +1452,13 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@tybys/wasm-util': 0.10.2
+    optional: true
+
   '@next/env@16.2.4': {}
 
   '@next/swc-darwin-arm64@16.2.4':
@@ -1099,6 +1497,61 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
 
+  '@oxc-project/types@0.129.0': {}
+
+  '@rolldown/binding-android-arm64@1.0.0':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.0.0':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.0.0':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.0.0':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.0.0':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.0.0':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.0.0':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.0': {}
+
+  '@standard-schema/spec@1.1.0': {}
+
   '@swc/helpers@0.5.15':
     dependencies:
       tslib: 2.8.1
@@ -1109,6 +1562,20 @@ snapshots:
     dependencies:
       '@tanstack/query-core': 5.100.7
       react: 19.2.5
+
+  '@tybys/wasm-util@0.10.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/estree@1.0.9': {}
 
   '@types/node@22.19.1':
     dependencies:
@@ -1122,6 +1589,47 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
+  '@vitest/expect@4.1.6':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.6
+      '@vitest/utils': 4.1.6
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.6(vite@8.0.12(@types/node@22.19.1)(jiti@1.21.7))':
+    dependencies:
+      '@vitest/spy': 4.1.6
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.12(@types/node@22.19.1)(jiti@1.21.7)
+
+  '@vitest/pretty-format@4.1.6':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.6':
+    dependencies:
+      '@vitest/utils': 4.1.6
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.6':
+    dependencies:
+      '@vitest/pretty-format': 4.1.6
+      '@vitest/utils': 4.1.6
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.6': {}
+
+  '@vitest/utils@4.1.6':
+    dependencies:
+      '@vitest/pretty-format': 4.1.6
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
   any-promise@1.3.0: {}
 
   anymatch@3.1.3:
@@ -1130,6 +1638,8 @@ snapshots:
       picomatch: 2.3.1
 
   arg@5.0.2: {}
+
+  assertion-error@2.0.1: {}
 
   asynckit@0.4.0: {}
 
@@ -1177,6 +1687,8 @@ snapshots:
 
   caniuse-lite@1.0.30001791: {}
 
+  chai@6.2.2: {}
+
   chokidar@3.6.0:
     dependencies:
       anymatch: 3.1.3
@@ -1203,6 +1715,8 @@ snapshots:
 
   commander@4.1.1: {}
 
+  convert-source-map@2.0.0: {}
+
   cssesc@3.0.0: {}
 
   csstype@3.2.3: {}
@@ -1211,8 +1725,7 @@ snapshots:
 
   delayed-stream@1.0.0: {}
 
-  detect-libc@2.1.2:
-    optional: true
+  detect-libc@2.1.2: {}
 
   didyoumean@1.2.2: {}
 
@@ -1230,6 +1743,8 @@ snapshots:
 
   es-errors@1.3.0: {}
 
+  es-module-lexer@2.1.0: {}
+
   es-object-atoms@1.1.1:
     dependencies:
       es-errors: 1.3.0
@@ -1242,6 +1757,12 @@ snapshots:
       hasown: 2.0.3
 
   escalade@3.2.0: {}
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
+  expect-type@1.3.0: {}
 
   fast-glob@3.3.3:
     dependencies:
@@ -1258,6 +1779,10 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
       picomatch: 4.0.3
+
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
 
   file-selector@2.1.2:
     dependencies:
@@ -1346,6 +1871,55 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    optional: true
+
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
+
   lilconfig@3.1.3: {}
 
   lines-and-columns@1.2.4: {}
@@ -1357,6 +1931,10 @@ snapshots:
   lucide-react@1.14.0(react@19.2.5):
     dependencies:
       react: 19.2.5
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   math-intrinsics@1.1.0: {}
 
@@ -1413,13 +1991,19 @@ snapshots:
 
   object-hash@3.0.0: {}
 
+  obug@2.1.1: {}
+
   path-parse@1.0.7: {}
+
+  pathe@2.0.3: {}
 
   picocolors@1.1.1: {}
 
   picomatch@2.3.1: {}
 
   picomatch@4.0.3: {}
+
+  picomatch@4.0.4: {}
 
   pify@2.3.0: {}
 
@@ -1468,6 +2052,12 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  postcss@8.5.14:
+    dependencies:
+      nanoid: 3.3.12
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
   prop-types@15.8.1:
     dependencies:
       loose-envify: 1.4.0
@@ -1510,6 +2100,27 @@ snapshots:
 
   reusify@1.1.0: {}
 
+  rolldown@1.0.0:
+    dependencies:
+      '@oxc-project/types': 0.129.0
+      '@rolldown/pluginutils': 1.0.0
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.0.0
+      '@rolldown/binding-darwin-arm64': 1.0.0
+      '@rolldown/binding-darwin-x64': 1.0.0
+      '@rolldown/binding-freebsd-x64': 1.0.0
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0
+      '@rolldown/binding-linux-arm64-musl': 1.0.0
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.0
+      '@rolldown/binding-linux-s390x-gnu': 1.0.0
+      '@rolldown/binding-linux-x64-gnu': 1.0.0
+      '@rolldown/binding-linux-x64-musl': 1.0.0
+      '@rolldown/binding-openharmony-arm64': 1.0.0
+      '@rolldown/binding-wasm32-wasi': 1.0.0
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0
+      '@rolldown/binding-win32-x64-msvc': 1.0.0
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
@@ -1551,12 +2162,18 @@ snapshots:
       '@img/sharp-win32-x64': 0.34.5
     optional: true
 
+  siginfo@2.0.0: {}
+
   sonner@2.0.7(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
 
   source-map-js@1.2.1: {}
+
+  stackback@0.0.2: {}
+
+  std-env@4.1.0: {}
 
   styled-jsx@5.1.6(react@19.2.5):
     dependencies:
@@ -1617,10 +2234,21 @@ snapshots:
     dependencies:
       any-promise: 1.3.0
 
+  tinybench@2.9.0: {}
+
+  tinyexec@1.1.2: {}
+
   tinyglobby@0.2.15:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
+
+  tinyglobby@0.2.16:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
+  tinyrainbow@3.1.0: {}
 
   to-regex-range@5.0.1:
     dependencies:
@@ -1641,3 +2269,47 @@ snapshots:
       picocolors: 1.1.1
 
   util-deprecate@1.0.2: {}
+
+  vite@8.0.12(@types/node@22.19.1)(jiti@1.21.7):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.14
+      rolldown: 1.0.0
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 22.19.1
+      fsevents: 2.3.3
+      jiti: 1.21.7
+
+  vitest@4.1.6(@types/node@22.19.1)(vite@8.0.12(@types/node@22.19.1)(jiti@1.21.7)):
+    dependencies:
+      '@vitest/expect': 4.1.6
+      '@vitest/mocker': 4.1.6(vite@8.0.12(@types/node@22.19.1)(jiti@1.21.7))
+      '@vitest/pretty-format': 4.1.6
+      '@vitest/runner': 4.1.6
+      '@vitest/snapshot': 4.1.6
+      '@vitest/spy': 4.1.6
+      '@vitest/utils': 4.1.6
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.2
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.1.0
+      vite: 8.0.12(@types/node@22.19.1)(jiti@1.21.7)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.19.1
+    transitivePeerDependencies:
+      - msw
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2

--- a/frontend/src/__tests__/reprocess.test.ts
+++ b/frontend/src/__tests__/reprocess.test.ts
@@ -11,8 +11,8 @@
  *   pnpm vitest run src/__tests__/reprocess.test.ts   # run this file only
  */
 
-import axios from "axios";
 import type { AxiosInstance } from "axios";
+import axios from "axios";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/__tests__/reprocess.test.ts
+++ b/frontend/src/__tests__/reprocess.test.ts
@@ -38,8 +38,6 @@ describe("reprocessImage API function", () => {
   it("calls POST /api/image/:id/reprocess and returns the response", async () => {
     const { reprocessImage } = await import("../lib/api");
 
-    const { reprocessImage } = await import("../lib/api");
-
     const mockResponse = {
       data: {
         media_id: 42,

--- a/frontend/src/__tests__/reprocess.test.ts
+++ b/frontend/src/__tests__/reprocess.test.ts
@@ -1,14 +1,14 @@
 /**
  * Frontend tests for the reprocess/retry-analysis feature.
  *
- * Uses Vitest only (no DOM/rendering needed — pure logic + API mock tests).
+ * Uses Vitest only — no DOM/React renderer needed for these unit tests.
  *
- * Install test dependency (one-time):
+ * Install test dependencies (one-time):
  *   pnpm add -D vitest
  *
  * Run with:
- *   pnpm test                               # runs all tests via npm script
- *   pnpm vitest run src/__tests__/reprocess.test.ts  # run this file only
+ *   pnpm test                                         # runs all tests
+ *   pnpm vitest run src/__tests__/reprocess.test.ts   # run this file only
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
@@ -104,30 +104,36 @@ describe("retry-button eligibility", () => {
 // ---------------------------------------------------------------------------
 
 describe("gallery card retry visibility", () => {
-  /** Mirrors gallery/page.tsx: show RotateCcw for failed or indexed-with-no-caption */
-  function galleryCardShowsRetry(status: string, caption?: string): boolean {
+  /**
+   * Mirrors gallery/page.tsx — aligned with modal:
+   * show RotateCcw for failed OR (indexed && no caption).
+   */
+  function galleryCardShowsRetry(
+    status: string,
+    caption: string | undefined,
+  ): boolean {
     return status === "failed" || (status === "indexed" && !caption);
   }
 
   it("shows retry button in gallery card for failed status", () => {
-    expect(galleryCardShowsRetry("failed")).toBe(true);
+    expect(galleryCardShowsRetry("failed", undefined)).toBe(true);
   });
 
-  it("shows retry button in gallery card for indexed status with no caption", () => {
+  it("shows retry button in gallery card for indexed with no caption", () => {
     expect(galleryCardShowsRetry("indexed", undefined)).toBe(true);
     expect(galleryCardShowsRetry("indexed", "")).toBe(true);
   });
 
-  it("does not show retry button in gallery card for indexed status with caption", () => {
+  it("does not show retry button in gallery card for indexed with caption", () => {
     expect(galleryCardShowsRetry("indexed", "a dog on a bench")).toBe(false);
   });
 
   it("does not show retry button in gallery card for pending status", () => {
-    expect(galleryCardShowsRetry("pending")).toBe(false);
+    expect(galleryCardShowsRetry("pending", undefined)).toBe(false);
   });
 
   it("does not show retry button in gallery card for processing status", () => {
-    expect(galleryCardShowsRetry("processing")).toBe(false);
+    expect(galleryCardShowsRetry("processing", undefined)).toBe(false);
   });
 });
 

--- a/frontend/src/__tests__/reprocess.test.ts
+++ b/frontend/src/__tests__/reprocess.test.ts
@@ -32,7 +32,9 @@ describe("reprocessImage API function", () => {
   beforeEach(() => {
     vi.resetAllMocks();
     // Make axios.create() return our mock instance so `api` is defined.
-    mockedAxios.create = vi.fn().mockReturnValue(apiInstanceMock as AxiosInstance);
+    mockedAxios.create = vi
+      .fn()
+      .mockReturnValue(apiInstanceMock as AxiosInstance);
   });
 
   it("calls POST /api/image/:id/reprocess and returns the response", async () => {

--- a/frontend/src/__tests__/reprocess.test.ts
+++ b/frontend/src/__tests__/reprocess.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Frontend tests for the reprocess/retry-analysis feature.
+ *
+ * Uses Vitest + @testing-library/react.
+ *
+ * Install test dependencies (one-time):
+ *   pnpm add -D vitest @vitejs/plugin-react @testing-library/react \
+ *             @testing-library/user-event jsdom msw
+ *
+ * Run with:
+ *   pnpm vitest run src/__tests__/reprocess.test.ts
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import axios from "axios";
+
+// ---------------------------------------------------------------------------
+// Unit tests: reprocessImage API function
+// ---------------------------------------------------------------------------
+
+vi.mock("axios");
+const mockedAxios = vi.mocked(axios, true);
+// Provide a mocked axios instance that `axios.create()` will return.
+const apiInstanceMock = {
+  post: vi.fn(),
+  get: vi.fn(),
+  delete: vi.fn(),
+};
+
+describe("reprocessImage API function", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    // Make axios.create() return our mock instance so `api` is defined.
+    mockedAxios.create = vi.fn().mockReturnValue(apiInstanceMock as any);
+  });
+
+  it("calls POST /api/image/:id/reprocess and returns the response", async () => {
+    const { reprocessImage } = await import("../lib/api");
+
+    const mockResponse = { data: { media_id: 42, job_id: "job-abc", status: "queued" } };
+    // api is an axios instance; mock the post method on the module-level api object
+    const { api } = await import("../lib/api");
+    vi.spyOn(api, "post").mockResolvedValueOnce(mockResponse);
+
+    const result = await reprocessImage(42);
+
+    expect(api.post).toHaveBeenCalledWith("/api/image/42/reprocess");
+    expect(result).toEqual({ media_id: 42, job_id: "job-abc", status: "queued" });
+  });
+
+  it("propagates server errors (400, 404) to the caller", async () => {
+    const { reprocessImage, api } = await import("../lib/api");
+
+    const axiosError = Object.assign(new Error("Request failed with status code 400"), {
+      response: { status: 400, data: { detail: "not eligible" } },
+    });
+    vi.spyOn(api, "post").mockRejectedValueOnce(axiosError);
+
+    await expect(reprocessImage(99)).rejects.toThrow("Request failed with status code 400");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Unit tests: eligibility logic that drives UI visibility
+// ---------------------------------------------------------------------------
+
+describe("retry-button eligibility", () => {
+  /**
+   * Mirrors the condition used in image-preview-modal.tsx and gallery/page.tsx
+   * to decide whether to show the retry button.
+   */
+  function shouldShowRetry(
+    status: string,
+    caption: string | undefined,
+  ): boolean {
+    // same logic as in image-preview-modal action bar
+    return status === "failed" || (status === "indexed" && !caption);
+  }
+
+  it("shows retry for failed images", () => {
+    expect(shouldShowRetry("failed", undefined)).toBe(true);
+  });
+
+  it("shows retry for indexed image with no caption", () => {
+    expect(shouldShowRetry("indexed", undefined)).toBe(true);
+    expect(shouldShowRetry("indexed", "")).toBe(true);
+  });
+
+  it("hides retry for indexed image with a caption", () => {
+    expect(shouldShowRetry("indexed", "a dog on a bench")).toBe(false);
+  });
+
+  it("hides retry for pending images", () => {
+    expect(shouldShowRetry("pending", undefined)).toBe(false);
+  });
+
+  it("hides retry for processing images", () => {
+    expect(shouldShowRetry("processing", undefined)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Unit tests: gallery card shows retry only for failed status
+// ---------------------------------------------------------------------------
+
+describe("gallery card retry visibility", () => {
+  /** Mirrors gallery/page.tsx: show RotateCcw only when item.status === "failed" */
+  function galleryCardShowsRetry(status: string): boolean {
+    return status === "failed";
+  }
+
+  it("shows retry button in gallery card for failed status", () => {
+    expect(galleryCardShowsRetry("failed")).toBe(true);
+  });
+
+  it("does not show retry button in gallery card for indexed status", () => {
+    expect(galleryCardShowsRetry("indexed")).toBe(false);
+  });
+
+  it("does not show retry button in gallery card for pending status", () => {
+    expect(galleryCardShowsRetry("pending")).toBe(false);
+  });
+
+  it("does not show retry button in gallery card for processing status", () => {
+    expect(galleryCardShowsRetry("processing")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Unit tests: ReprocessResponse type contract
+// ---------------------------------------------------------------------------
+
+describe("ReprocessResponse type contract", () => {
+  it("has the expected shape", async () => {
+    const { api } = await import("../lib/api");
+    const payload = { media_id: 7, job_id: "j-001", status: "queued" as const };
+    vi.spyOn(api, "post").mockResolvedValueOnce({ data: payload });
+
+    const { reprocessImage } = await import("../lib/api");
+    const result = await reprocessImage(7);
+
+    expect(typeof result.media_id).toBe("number");
+    expect(typeof result.job_id).toBe("string");
+    expect(result.status).toBe("queued");
+  });
+});

--- a/frontend/src/__tests__/reprocess.test.ts
+++ b/frontend/src/__tests__/reprocess.test.ts
@@ -1,14 +1,14 @@
 /**
  * Frontend tests for the reprocess/retry-analysis feature.
  *
- * Uses Vitest + @testing-library/react.
+ * Uses Vitest only (no DOM/rendering needed — pure logic + API mock tests).
  *
- * Install test dependencies (one-time):
- *   pnpm add -D vitest @vitejs/plugin-react @testing-library/react \
- *             @testing-library/user-event jsdom msw
+ * Install test dependency (one-time):
+ *   pnpm add -D vitest
  *
  * Run with:
- *   pnpm vitest run src/__tests__/reprocess.test.ts
+ *   pnpm test                               # runs all tests via npm script
+ *   pnpm vitest run src/__tests__/reprocess.test.ts  # run this file only
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
@@ -104,17 +104,22 @@ describe("retry-button eligibility", () => {
 // ---------------------------------------------------------------------------
 
 describe("gallery card retry visibility", () => {
-  /** Mirrors gallery/page.tsx: show RotateCcw only when item.status === "failed" */
-  function galleryCardShowsRetry(status: string): boolean {
-    return status === "failed";
+  /** Mirrors gallery/page.tsx: show RotateCcw for failed or indexed-with-no-caption */
+  function galleryCardShowsRetry(status: string, caption?: string): boolean {
+    return status === "failed" || (status === "indexed" && !caption);
   }
 
   it("shows retry button in gallery card for failed status", () => {
     expect(galleryCardShowsRetry("failed")).toBe(true);
   });
 
-  it("does not show retry button in gallery card for indexed status", () => {
-    expect(galleryCardShowsRetry("indexed")).toBe(false);
+  it("shows retry button in gallery card for indexed status with no caption", () => {
+    expect(galleryCardShowsRetry("indexed", undefined)).toBe(true);
+    expect(galleryCardShowsRetry("indexed", "")).toBe(true);
+  });
+
+  it("does not show retry button in gallery card for indexed status with caption", () => {
+    expect(galleryCardShowsRetry("indexed", "a dog on a bench")).toBe(false);
   });
 
   it("does not show retry button in gallery card for pending status", () => {

--- a/frontend/src/__tests__/reprocess.test.ts
+++ b/frontend/src/__tests__/reprocess.test.ts
@@ -11,8 +11,9 @@
  *   pnpm vitest run src/__tests__/reprocess.test.ts   # run this file only
  */
 
-import { describe, it, expect, vi, beforeEach } from "vitest";
 import axios from "axios";
+import type { AxiosInstance } from "axios";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // ---------------------------------------------------------------------------
 // Unit tests: reprocessImage API function
@@ -21,7 +22,7 @@ import axios from "axios";
 vi.mock("axios");
 const mockedAxios = vi.mocked(axios, true);
 // Provide a mocked axios instance that `axios.create()` will return.
-const apiInstanceMock = {
+const apiInstanceMock: Partial<AxiosInstance> = {
   post: vi.fn(),
   get: vi.fn(),
   delete: vi.fn(),
@@ -31,13 +32,21 @@ describe("reprocessImage API function", () => {
   beforeEach(() => {
     vi.resetAllMocks();
     // Make axios.create() return our mock instance so `api` is defined.
-    mockedAxios.create = vi.fn().mockReturnValue(apiInstanceMock as any);
+    mockedAxios.create = vi.fn().mockReturnValue(apiInstanceMock as AxiosInstance);
   });
 
   it("calls POST /api/image/:id/reprocess and returns the response", async () => {
     const { reprocessImage } = await import("../lib/api");
 
-    const mockResponse = { data: { media_id: 42, job_id: "job-abc", status: "queued" } };
+    const { reprocessImage } = await import("../lib/api");
+
+    const mockResponse = {
+      data: {
+        media_id: 42,
+        job_id: "job-abc",
+        status: "queued",
+      },
+    };
     // api is an axios instance; mock the post method on the module-level api object
     const { api } = await import("../lib/api");
     vi.spyOn(api, "post").mockResolvedValueOnce(mockResponse);
@@ -45,18 +54,27 @@ describe("reprocessImage API function", () => {
     const result = await reprocessImage(42);
 
     expect(api.post).toHaveBeenCalledWith("/api/image/42/reprocess");
-    expect(result).toEqual({ media_id: 42, job_id: "job-abc", status: "queued" });
+    expect(result).toEqual({
+      media_id: 42,
+      job_id: "job-abc",
+      status: "queued",
+    });
   });
 
   it("propagates server errors (400, 404) to the caller", async () => {
     const { reprocessImage, api } = await import("../lib/api");
 
-    const axiosError = Object.assign(new Error("Request failed with status code 400"), {
-      response: { status: 400, data: { detail: "not eligible" } },
-    });
+    const axiosError = Object.assign(
+      new Error("Request failed with status code 400"),
+      {
+        response: { status: 400, data: { detail: "not eligible" } },
+      },
+    );
     vi.spyOn(api, "post").mockRejectedValueOnce(axiosError);
 
-    await expect(reprocessImage(99)).rejects.toThrow("Request failed with status code 400");
+    await expect(reprocessImage(99)).rejects.toThrow(
+      "Request failed with status code 400",
+    );
   });
 });
 

--- a/frontend/src/app/gallery/page.tsx
+++ b/frontend/src/app/gallery/page.tsx
@@ -18,7 +18,6 @@ import Link from "next/link";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { ImagePreviewModal } from "@/components/image-preview-modal";
 import { StatusIndicator } from "@/components/status-indicator";
-import { toast } from "sonner";
 import {
   deleteImage,
   type GalleryResponse,
@@ -28,6 +27,7 @@ import {
   toggleLike,
 } from "@/lib/api";
 import { resolveMediaUrl } from "@/lib/media";
+import { toast } from "sonner";
 
 export default function GalleryPage() {
   const [page, setPage] = useState(1);
@@ -122,10 +122,10 @@ export default function GalleryPage() {
     onSuccess: ({ media_id }) => {
       queryClient.invalidateQueries({ queryKey: ["gallery"] });
       queryClient.invalidateQueries({ queryKey: ["image-detail", media_id] });
-      toast.success("Image queued for reprocessing.");
+      toast.success("Retry queued — analysis will restart shortly.");
     },
     onError: () => {
-      toast.error("Retry failed. The image may not be eligible or the queue is unavailable.");
+      toast.error("Retry failed. The queue may be unavailable — please try again.");
     },
   });
 

--- a/frontend/src/app/gallery/page.tsx
+++ b/frontend/src/app/gallery/page.tsx
@@ -16,6 +16,7 @@ import {
 import Image from "next/image";
 import Link from "next/link";
 import { useCallback, useEffect, useMemo, useState } from "react";
+import { toast } from "sonner";
 import { ImagePreviewModal } from "@/components/image-preview-modal";
 import { StatusIndicator } from "@/components/status-indicator";
 import {
@@ -27,7 +28,6 @@ import {
   toggleLike,
 } from "@/lib/api";
 import { resolveMediaUrl } from "@/lib/media";
-import { toast } from "sonner";
 
 export default function GalleryPage() {
   const [page, setPage] = useState(1);

--- a/frontend/src/app/gallery/page.tsx
+++ b/frontend/src/app/gallery/page.tsx
@@ -125,7 +125,9 @@ export default function GalleryPage() {
       toast.success("Retry queued — analysis will restart shortly.");
     },
     onError: () => {
-      toast.error("Retry failed. The queue may be unavailable — please try again.");
+      toast.error(
+        "Retry failed. The queue may be unavailable — please try again.",
+      );
     },
   });
 

--- a/frontend/src/app/gallery/page.tsx
+++ b/frontend/src/app/gallery/page.tsx
@@ -9,6 +9,7 @@ import {
   Heart,
   ImageOff,
   Loader2,
+  RotateCcw,
   Trash2,
   X,
 } from "lucide-react";
@@ -22,6 +23,7 @@ import {
   type GalleryResponse,
   getGallery,
   type MediaItem,
+  reprocessImage,
   toggleLike,
 } from "@/lib/api";
 import { resolveMediaUrl } from "@/lib/media";
@@ -111,6 +113,14 @@ export default function GalleryPage() {
     },
     onSettled: () => {
       queryClient.invalidateQueries({ queryKey: ["gallery"] });
+    },
+  });
+
+  const reprocessMutation = useMutation({
+    mutationFn: (mediaId: number) => reprocessImage(mediaId),
+    onSuccess: ({ media_id }) => {
+      queryClient.invalidateQueries({ queryKey: ["gallery"] });
+      queryClient.invalidateQueries({ queryKey: ["image-detail", media_id] });
     },
   });
 
@@ -351,6 +361,23 @@ export default function GalleryPage() {
                           >
                             <Download className="h-3.5 w-3.5" />
                           </a>
+                        )}
+                        {item.status === "failed" && (
+                          <button
+                            type="button"
+                            onClick={() => reprocessMutation.mutate(item.id)}
+                            disabled={reprocessMutation.isPending}
+                            className={`icon-button h-8 w-8 text-[#a1a4a5] ${
+                              reprocessMutation.isPending
+                                ? "cursor-not-allowed opacity-70"
+                                : ""
+                            }`}
+                            aria-label="Retry analysis"
+                          >
+                            <RotateCcw
+                              className={`h-3.5 w-3.5 ${reprocessMutation.isPending ? "animate-spin" : ""}`}
+                            />
+                          </button>
                         )}
                         <button
                           type="button"

--- a/frontend/src/app/gallery/page.tsx
+++ b/frontend/src/app/gallery/page.tsx
@@ -18,6 +18,7 @@ import Link from "next/link";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { ImagePreviewModal } from "@/components/image-preview-modal";
 import { StatusIndicator } from "@/components/status-indicator";
+import { toast } from "sonner";
 import {
   deleteImage,
   type GalleryResponse,
@@ -121,6 +122,10 @@ export default function GalleryPage() {
     onSuccess: ({ media_id }) => {
       queryClient.invalidateQueries({ queryKey: ["gallery"] });
       queryClient.invalidateQueries({ queryKey: ["image-detail", media_id] });
+      toast.success("Image queued for reprocessing.");
+    },
+    onError: () => {
+      toast.error("Retry failed. The image may not be eligible or the queue is unavailable.");
     },
   });
 
@@ -362,7 +367,8 @@ export default function GalleryPage() {
                             <Download className="h-3.5 w-3.5" />
                           </a>
                         )}
-                        {item.status === "failed" && (
+                        {(item.status === "failed" ||
+                          (item.status === "indexed" && !item.caption)) && (
                           <button
                             type="button"
                             onClick={() => reprocessMutation.mutate(item.id)}

--- a/frontend/src/components/image-preview-modal.tsx
+++ b/frontend/src/components/image-preview-modal.tsx
@@ -26,7 +26,6 @@ import {
 import { resolveMediaUrl } from "@/lib/media";
 import { formatBytes, formatDate } from "@/lib/utils";
 import { StatusIndicator } from "./status-indicator";
-import { toast } from "sonner";
 
 export type PreviewMedia = Pick<MediaItem, "id" | "filename"> &
   Partial<
@@ -156,10 +155,10 @@ export function ImagePreviewModal({
     onSuccess: ({ media_id }) => {
       queryClient.invalidateQueries({ queryKey: ["gallery"] });
       queryClient.invalidateQueries({ queryKey: ["image-detail", media_id] });
-      toast.success("Image queued for reprocessing.");
+      toast.success("Retry queued — analysis will restart shortly.");
     },
     onError: () => {
-      toast.error("Retry failed. The image may not be eligible or the queue is unavailable.");
+      toast.error("Retry failed. The queue may be unavailable — please try again.");
     },
   });
 

--- a/frontend/src/components/image-preview-modal.tsx
+++ b/frontend/src/components/image-preview-modal.tsx
@@ -15,6 +15,7 @@ import {
 import Image from "next/image";
 import Link from "next/link";
 import { useCallback, useEffect, useMemo, useState } from "react";
+import { toast } from "sonner";
 import {
   deleteImage,
   getImageDetail,
@@ -26,7 +27,6 @@ import {
 import { resolveMediaUrl } from "@/lib/media";
 import { formatBytes, formatDate } from "@/lib/utils";
 import { StatusIndicator } from "./status-indicator";
-import { toast } from "sonner";
 
 export type PreviewMedia = Pick<MediaItem, "id" | "filename"> &
   Partial<

--- a/frontend/src/components/image-preview-modal.tsx
+++ b/frontend/src/components/image-preview-modal.tsx
@@ -26,6 +26,7 @@ import {
 import { resolveMediaUrl } from "@/lib/media";
 import { formatBytes, formatDate } from "@/lib/utils";
 import { StatusIndicator } from "./status-indicator";
+import { toast } from "sonner";
 
 export type PreviewMedia = Pick<MediaItem, "id" | "filename"> &
   Partial<
@@ -158,7 +159,9 @@ export function ImagePreviewModal({
       toast.success("Retry queued — analysis will restart shortly.");
     },
     onError: () => {
-      toast.error("Retry failed. The queue may be unavailable — please try again.");
+      toast.error(
+        "Retry failed. The queue may be unavailable — please try again.",
+      );
     },
   });
 
@@ -431,7 +434,9 @@ export function ImagePreviewModal({
                     <RotateCcw
                       className={`h-4 w-4 ${reprocessMutation.isPending ? "animate-spin" : ""}`}
                     />
-                    {reprocessMutation.isPending ? "Retrying…" : "Retry Analysis"}
+                    {reprocessMutation.isPending
+                      ? "Retrying…"
+                      : "Retry Analysis"}
                   </button>
                 )}
                 <button

--- a/frontend/src/components/image-preview-modal.tsx
+++ b/frontend/src/components/image-preview-modal.tsx
@@ -8,6 +8,7 @@ import {
   Heart,
   ImageOff,
   Loader2,
+  RotateCcw,
   Trash2,
   X,
 } from "lucide-react";
@@ -19,6 +20,7 @@ import {
   getImageDetail,
   type MediaDetail,
   type MediaItem,
+  reprocessImage,
   toggleLike,
 } from "@/lib/api";
 import { resolveMediaUrl } from "@/lib/media";
@@ -145,6 +147,14 @@ export function ImagePreviewModal({
       queryClient.invalidateQueries({ queryKey: ["image-detail", id] });
       onDeleted?.(id);
       onClose();
+    },
+  });
+
+  const reprocessMutation = useMutation({
+    mutationFn: (mediaId: number) => reprocessImage(mediaId),
+    onSuccess: ({ media_id }) => {
+      queryClient.invalidateQueries({ queryKey: ["gallery"] });
+      queryClient.invalidateQueries({ queryKey: ["image-detail", media_id] });
     },
   });
 
@@ -405,6 +415,21 @@ export function ImagePreviewModal({
               </div>
             ) : (
               <div className="flex flex-wrap items-center gap-2">
+                {(status === "failed" ||
+                  (status === "indexed" && !caption)) && (
+                  <button
+                    type="button"
+                    onClick={() => reprocessMutation.mutate(media.id)}
+                    disabled={reprocessMutation.isPending}
+                    className="frost-button inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-[#a1a4a5] disabled:cursor-not-allowed disabled:opacity-70"
+                    aria-label="Retry analysis"
+                  >
+                    <RotateCcw
+                      className={`h-4 w-4 ${reprocessMutation.isPending ? "animate-spin" : ""}`}
+                    />
+                    {reprocessMutation.isPending ? "Retrying…" : "Retry Analysis"}
+                  </button>
+                )}
                 <button
                   type="button"
                   onClick={() => likeMutation.mutate(media.id)}

--- a/frontend/src/components/image-preview-modal.tsx
+++ b/frontend/src/components/image-preview-modal.tsx
@@ -26,6 +26,7 @@ import {
 import { resolveMediaUrl } from "@/lib/media";
 import { formatBytes, formatDate } from "@/lib/utils";
 import { StatusIndicator } from "./status-indicator";
+import { toast } from "sonner";
 
 export type PreviewMedia = Pick<MediaItem, "id" | "filename"> &
   Partial<
@@ -155,6 +156,10 @@ export function ImagePreviewModal({
     onSuccess: ({ media_id }) => {
       queryClient.invalidateQueries({ queryKey: ["gallery"] });
       queryClient.invalidateQueries({ queryKey: ["image-detail", media_id] });
+      toast.success("Image queued for reprocessing.");
+    },
+    onError: () => {
+      toast.error("Retry failed. The image may not be eligible or the queue is unavailable.");
     },
   });
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -249,6 +249,21 @@ export const searchImages = async (params: {
   return response.data;
 };
 
+export interface ReprocessResponse {
+  media_id: number;
+  job_id: string;
+  status: "queued";
+}
+
+export const reprocessImage = async (
+  mediaId: number,
+): Promise<ReprocessResponse> => {
+  const response = await api.post<ReprocessResponse>(
+    `/api/image/${mediaId}/reprocess`,
+  );
+  return response.data;
+};
+
 export const getClusters = async (): Promise<ClustersResponse> => {
   const response = await api.get<ClustersResponse>("/api/clusters");
   return response.data;


### PR DESCRIPTION
## Summary

## Feature:
 Add retry/reprocess for image analysis so failed or incomplete-index images can be reprocessed without duplicate uploads.
Why

Problem: Users had to delete/re-upload images to retry analysis, which is slow and error-prone.
Goal: Reset stale error state, set status to pending, and re-enqueue the existing worker job (no duplicate upload).
What changed

* Backend endpoint: backend/src/find_api/routers/gallery.py — POST /api/image/{media_id}/reprocess (eligibility checks, status reset, clear error/processed_at, enqueue [analyze_image](vscode-file://vscode-app/c:/Users/Vedansh%20Kapoor/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html)).
* Backend tests: backend/tests/test_reprocess.py and test shims backend/tests/conftest.py — in-memory SQLite + stubs for pgvector/minio/rq/redis.
* Frontend API: frontend/src/lib/api.ts — [reprocessImage(mediaId)](vscode-file://vscode-app/c:/Users/Vedansh%20Kapoor/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html).
* Frontend UI: frontend/src/components/image-preview-modal.tsx and frontend/src/app/gallery/page.tsx — “Retry Analysis” button/icon shown for failed or indexed+missing-caption as appropriate.
* Frontend tests: frontend/src/tests/reprocess.test.ts — Vitest unit tests; axios.create() mocked so [api](vscode-file://vscode-app/c:/Users/Vedansh%20Kapoor/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html) is spyable.
* Docs: docs/reprocess-retry.md — change summary and test/run instructions.


## tests 
*Backend: 9 tests (reprocess behaviors) — pass locally using the test harness and [conftest.py](vscode-file://vscode-app/c:/Users/Vedansh%20Kapoor/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html) stubs.
*Frontend: 12 unit tests — pass locally with Vitest after mocking [axios.create()](vscode-file://vscode-app/c:/Users/Vedansh%20Kapoor/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html).
Fixes #19

## Type of change

- [ ] Bug fix
- [y ] Feature
- [ ] Documentation update
- [ ] Refactor
- [ ] CI / tooling

## What changed:
* Retry flow added: Before — users had to delete/re-upload images to re-run analysis. After — backend exposes POST /api/image/{media_id}/reprocess (see backend/src/find_api/routers/gallery.py) to reset state and re-enqueue the existing worker.
* DB / worker behavior changed: Before — no safe requeue path; failed/indexed-but-incomplete rows lingered with stale error. After — endpoint sets [status="pending"](vscode-file://vscode-app/c:/Users/Vedansh%20Kapoor/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html), clears [error_message](vscode-file://vscode-app/c:/Users/Vedansh%20Kapoor/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html) and [processed_at](vscode-file://vscode-app/c:/Users/Vedansh%20Kapoor/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html), and enqueues [find_api.workers.jobs.analyze_image(media_id)](vscode-file://vscode-app/c:/Users/Vedansh%20Kapoor/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html) via the existing RQ pipeline (no duplicate upload).
* Frontend + tests added: Before — UI had no retry action. After — [reprocessImage()](vscode-file://vscode-app/c:/Users/Vedansh%20Kapoor/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html) API (frontend/src/lib/api.ts) and retry buttons/icons added in modal and gallery (frontend/src/components/image-preview-modal.tsx, frontend/src/app/gallery/page.tsx). Backend + frontend unit tests added and documentation (docs/reprocess-retry.md) included.



## How to run the tests locally

Backend (Windows PowerShell):

```powershell
Set-Location d:\gssoc\find\Find\backend
$env:PYTHONPATH = 'src'; py -m pytest tests/test_reprocess.py -q
```

Backend (Linux/macOS / POSIX):

```bash
cd backend
PYTHONPATH=src pytest tests/test_reprocess.py -q
```

Frontend (PowerShell):

```powershell
Set-Location d:\gssoc\find\Find\frontend
npm install    # or pnpm install
npx vitest run src/__tests__/reprocess.test.ts
```

Frontend (POSIX):

```bash
cd frontend
pnpm install    # or npm install
pnpm vitest run src/__tests__/reprocess.test.ts
```


List exact steps/commands used to validate this PR.

## Checklist

- [y ] I linked the related issue
- [ y] I ran required checks from CONTRIBUTING.md
- [ y] I updated docs/env notes if needed
- [ y] My PR is scoped to a single issue
- [ y] I followed commit message conventions
- [ y] I am not committing secrets or local artifacts

## GSSoC'26 checklist

- [ y] I requested issue assignment before starting
- [ y] I have meaningful commits (no spam commits)
- [ y] I am ready to explain my implementation in review comments


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add "Retry/Reprocess" action in gallery and preview (queues analysis, shows queued/error toasts, spinner/disabled state)
  * New API endpoint and client helper returning queued job info

* **Behavior**
  * Retry allowed for failed items and indexed items missing captions; other states rejected
  * Reprocess resets status and clears error/timestamp when queued

* **Tests**
  * Backend and frontend tests covering endpoint, eligibility, queueing, and UI visibility (in-memory bootstrap)

* **Documentation**
  * Reprocess feature guide and test/run instructions

* **Chores**
  * Added Vitest scripts and dev dependency

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Abhash-Chakraborty/Find/pull/85)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->