### PR TITLE
test: add backend API tests for upload, status, gallery, and search

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ Find is a local-first AI image intelligence app. Key paths:
 - `.env.example` - documented local configuration. Keep real `.env` files private.
 - `.github/workflows/ci.yml` - frontend and backend CI checks.
 
-There is no committed test directory yet. Avoid generated paths such as `frontend/.next/`, `frontend/node_modules/`, `.ruff_cache/`, `__pycache__/`, and model weights.
+Avoid generated paths such as `frontend/.next/`, `frontend/node_modules/`, `.ruff_cache/`, `__pycache__/`, and model weights.
 
 ## Build, Test, and Development Commands
 
@@ -44,6 +44,7 @@ uv run uvicorn find_api.main:app --reload
 uv run rq worker --url redis://localhost:6379 high default low
 uv run ruff check .
 uv run ruff format --check .
+uv run pytest tests/ -v
 ```
 
 Run the API and worker separately when not using Docker.
@@ -56,7 +57,7 @@ Backend code targets Python 3.12 and is checked with Ruff. Use `snake_case` for 
 
 ## Testing Guidelines
 
-No formal test suite is committed. Run the closest checks: `pnpm check && pnpm build` for frontend work and `uv run ruff check . && uv run ruff format --check .` for backend work. For integration changes, manually verify upload, job status polling, gallery, search, and clustering.
+Run the automated test suite before opening a PR: `pnpm check && pnpm build` for frontend work and `uv run ruff check . && uv run ruff format --check . && uv run pytest tests/` for backend work. For integration changes, manually verify upload, job status polling, gallery, search, and clustering.
 
 ## Commit & Pull Request Guidelines
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,6 +107,7 @@ Backend:
 cd backend
 uv run ruff check .
 uv run ruff format --check .
+uv run pytest tests/ -v
 ```
 
 ## Pull request format

--- a/GSSOC_CONTRIBUTOR_GUIDE.md
+++ b/GSSOC_CONTRIBUTOR_GUIDE.md
@@ -141,6 +141,7 @@ Backend:
 cd backend
 uv run ruff check .
 uv run ruff format --check .
+uv run pytest tests/ -v
 ```
 
 Compose validation:

--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ pnpm build
 cd backend
 uv run ruff check .
 uv run ruff format --check .
+uv run pytest tests/ -v
 ```
 
 ## Core flow
@@ -212,7 +213,7 @@ uv run ruff format --check .
         ↓
 5. Run quality checks
    Frontend:  cd frontend && pnpm check && pnpm build
-   Backend:   cd backend && uv run ruff check .
+   Backend:   cd backend && uv run ruff check . && uv run pytest tests/
         ↓
 6. Commit & push          →  git push origin feat/your-feature
         ↓

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -63,6 +63,10 @@ dev = [
   "ruff==0.1.14",
 ]
 
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = ["src"]
+
 [tool.uv.sources]
 torch = { index = "pytorch-cu121" }
 torchvision = { index = "pytorch-cu121" }

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,7 +1,7 @@
 """Shared fixtures for backend API tests.
 
-Uses in-memory SQLite and patches external services (MinIO, Redis/RQ)
-so tests run without any infrastructure.
+Uses in-memory SQLite with StaticPool and patches external services
+(MinIO, Redis/RQ) so tests run without any infrastructure.
 """
 
 from __future__ import annotations
@@ -12,20 +12,33 @@ from unittest.mock import MagicMock, patch
 import pytest
 from sqlalchemy import JSON, Text, create_engine
 from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
 
 # ---------------------------------------------------------------------------
 # Patch PostgreSQL-only column types before any model is imported.
+# Stopped explicitly in the _stop_patches fixture below.
 # ---------------------------------------------------------------------------
-patch("pgvector.sqlalchemy.Vector", lambda dim: Text()).start()
-patch("sqlalchemy.dialects.postgresql.ARRAY", lambda item_type: JSON()).start()
+_patches = [
+    patch("pgvector.sqlalchemy.Vector", lambda dim: Text()),
+    patch("sqlalchemy.dialects.postgresql.ARRAY", lambda item_type: JSON()),
+]
+for p in _patches:
+    p.start()
 
+from fastapi.testclient import TestClient  # noqa: E402
 from find_api.core.database import Base, get_db  # noqa: E402
 from find_api.main import app  # noqa: E402
 
 # ---------------------------------------------------------------------------
-# In-memory SQLite engine
+# In-memory SQLite engine with StaticPool.
+# StaticPool reuses one connection so the in-memory DB is visible across
+# the test thread and the ASGI app thread (TestClient runs a second thread).
 # ---------------------------------------------------------------------------
-_engine = create_engine("sqlite://", connect_args={"check_same_thread": False})
+_engine = create_engine(
+    "sqlite://",
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
 _TestSession = sessionmaker(bind=_engine)
 Base.metadata.create_all(bind=_engine)
 
@@ -36,9 +49,17 @@ async def _noop_lifespan(_app):
     yield
 
 
+@pytest.fixture(scope="session", autouse=True)
+def _stop_patches():
+    """Stop module-level patches after the test session ends."""
+    yield
+    for p in _patches:
+        p.stop()
+
+
 @pytest.fixture()
 def db():
-    """Provide a clean database session for each test."""
+    """Provide a clean database for each test."""
     Base.metadata.drop_all(bind=_engine)
     Base.metadata.create_all(bind=_engine)
     session = _TestSession()
@@ -53,7 +74,12 @@ def client(db):
     """TestClient with mocked storage and queue dependencies."""
 
     def _override_db():
-        yield db
+        """Create a fresh session per request (thread-safe)."""
+        session = _TestSession()
+        try:
+            yield session
+        finally:
+            session.close()
 
     app.dependency_overrides[get_db] = _override_db
     app.router.lifespan_context = _noop_lifespan
@@ -79,7 +105,3 @@ def client(db):
             yield c
 
     app.dependency_overrides.clear()
-
-
-# Re-export for convenience in test files
-from fastapi.testclient import TestClient  # noqa: E402, F401

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,85 @@
+"""Shared fixtures for backend API tests.
+
+Uses in-memory SQLite and patches external services (MinIO, Redis/RQ)
+so tests run without any infrastructure.
+"""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from unittest.mock import MagicMock, patch
+
+import pytest
+from sqlalchemy import JSON, Text, create_engine
+from sqlalchemy.orm import sessionmaker
+
+# ---------------------------------------------------------------------------
+# Patch PostgreSQL-only column types before any model is imported.
+# ---------------------------------------------------------------------------
+patch("pgvector.sqlalchemy.Vector", lambda dim: Text()).start()
+patch("sqlalchemy.dialects.postgresql.ARRAY", lambda item_type: JSON()).start()
+
+from find_api.core.database import Base, get_db  # noqa: E402
+from find_api.main import app  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# In-memory SQLite engine
+# ---------------------------------------------------------------------------
+_engine = create_engine("sqlite://", connect_args={"check_same_thread": False})
+_TestSession = sessionmaker(bind=_engine)
+Base.metadata.create_all(bind=_engine)
+
+
+@asynccontextmanager
+async def _noop_lifespan(_app):
+    """Skip real init_db / init_storage during tests."""
+    yield
+
+
+@pytest.fixture()
+def db():
+    """Provide a clean database session for each test."""
+    Base.metadata.drop_all(bind=_engine)
+    Base.metadata.create_all(bind=_engine)
+    session = _TestSession()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+@pytest.fixture()
+def client(db):
+    """TestClient with mocked storage and queue dependencies."""
+
+    def _override_db():
+        yield db
+
+    app.dependency_overrides[get_db] = _override_db
+    app.router.lifespan_context = _noop_lifespan
+
+    fake_job = MagicMock(id="test-job-123")
+    fake_queue = MagicMock()
+    fake_queue.enqueue.return_value = fake_job
+
+    with (
+        patch("find_api.routers.upload.upload_file", return_value="images/ab/abc.jpg"),
+        patch("find_api.routers.upload.get_task_queue", return_value=fake_queue),
+        patch(
+            "find_api.routers.gallery.get_file_url",
+            return_value="http://fake/img.jpg",
+        ),
+        patch("find_api.routers.gallery.delete_file"),
+        patch(
+            "find_api.routers.search.get_file_url",
+            return_value="http://fake/img.jpg",
+        ),
+    ):
+        with TestClient(app) as c:
+            yield c
+
+    app.dependency_overrides.clear()
+
+
+# Re-export for convenience in test files
+from fastapi.testclient import TestClient  # noqa: E402, F401

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -29,6 +29,7 @@ from fastapi.testclient import TestClient  # noqa: E402
 from find_api.core.database import Base, get_db  # noqa: E402
 from find_api.main import app  # noqa: E402
 
+
 # ---------------------------------------------------------------------------
 # In-memory SQLite engine with StaticPool.
 # StaticPool reuses one connection so the in-memory DB is visible across
@@ -91,7 +92,9 @@ def client(db):
 
     try:
         with (
-            patch("find_api.routers.upload.upload_file", return_value="images/ab/abc.jpg"),
+            patch(
+                "find_api.routers.upload.upload_file", return_value="images/ab/abc.jpg"
+            ),
             patch("find_api.routers.upload.get_task_queue", return_value=fake_queue),
             patch(
                 "find_api.routers.gallery.get_file_url",

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -81,6 +81,7 @@ def client(db):
         finally:
             session.close()
 
+    original_lifespan = app.router.lifespan_context
     app.dependency_overrides[get_db] = _override_db
     app.router.lifespan_context = _noop_lifespan
 
@@ -88,20 +89,22 @@ def client(db):
     fake_queue = MagicMock()
     fake_queue.enqueue.return_value = fake_job
 
-    with (
-        patch("find_api.routers.upload.upload_file", return_value="images/ab/abc.jpg"),
-        patch("find_api.routers.upload.get_task_queue", return_value=fake_queue),
-        patch(
-            "find_api.routers.gallery.get_file_url",
-            return_value="http://fake/img.jpg",
-        ),
-        patch("find_api.routers.gallery.delete_file"),
-        patch(
-            "find_api.routers.search.get_file_url",
-            return_value="http://fake/img.jpg",
-        ),
-    ):
-        with TestClient(app) as c:
-            yield c
-
-    app.dependency_overrides.clear()
+    try:
+        with (
+            patch("find_api.routers.upload.upload_file", return_value="images/ab/abc.jpg"),
+            patch("find_api.routers.upload.get_task_queue", return_value=fake_queue),
+            patch(
+                "find_api.routers.gallery.get_file_url",
+                return_value="http://fake/img.jpg",
+            ),
+            patch("find_api.routers.gallery.delete_file"),
+            patch(
+                "find_api.routers.search.get_file_url",
+                return_value="http://fake/img.jpg",
+            ),
+        ):
+            with TestClient(app) as c:
+                yield c
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+        app.router.lifespan_context = original_lifespan

--- a/backend/tests/test_gallery.py
+++ b/backend/tests/test_gallery.py
@@ -1,0 +1,101 @@
+"""Tests for GET /api/gallery — response shape and status/liked filtering."""
+
+import hashlib
+from datetime import datetime, timezone
+
+from find_api.models.media import Media
+
+
+def _seed(db, *, filename, status, liked=False, metadata_json=None):
+    """Insert a Media row into the test database."""
+    media = Media(
+        file_hash=hashlib.sha256(filename.encode()).hexdigest(),
+        minio_key=f"images/test/{filename}",
+        filename=filename,
+        content_type="image/jpeg",
+        file_size=1024,
+        status=status,
+        liked=liked,
+        width=800,
+        height=600,
+        metadata_json=metadata_json,
+        created_at=datetime.now(timezone.utc),
+    )
+    db.add(media)
+    db.commit()
+    db.refresh(media)
+    return media
+
+
+class TestGalleryResponseShape:
+    """Gallery response shape."""
+
+    def test_empty_gallery(self, client):
+        response = client.get("/api/gallery")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["items"] == []
+        assert body["total"] == 0
+        assert "skip" in body
+        assert "limit" in body
+        assert "page" in body
+
+    def test_item_keys(self, client, db):
+        _seed(db, filename="sunset.jpg", status="indexed")
+
+        response = client.get("/api/gallery")
+        item = response.json()["items"][0]
+
+        expected_keys = {
+            "id", "filename", "status", "created_at", "processed_at",
+            "width", "height", "file_size", "cluster_id", "minio_key",
+            "liked", "url",
+        }
+        assert expected_keys.issubset(item.keys())
+
+    def test_indexed_item_includes_metadata(self, client, db):
+        _seed(
+            db,
+            filename="doc.png",
+            status="indexed",
+            metadata_json={
+                "caption": "a sunset",
+                "objects": ["sun"],
+                "ocr_text": "hello",
+            },
+        )
+
+        item = client.get("/api/gallery").json()["items"][0]
+        assert item["caption"] == "a sunset"
+        assert item["objects"] == ["sun"]
+        assert item["has_text"] is True
+
+
+class TestGalleryFiltering:
+    """Status and liked filtering."""
+
+    def test_filter_by_status(self, client, db):
+        _seed(db, filename="a.jpg", status="pending")
+        _seed(db, filename="b.jpg", status="indexed")
+
+        body = client.get("/api/gallery", params={"status": "pending"}).json()
+        assert body["total"] == 1
+        assert body["items"][0]["filename"] == "a.jpg"
+
+    def test_filter_by_liked(self, client, db):
+        _seed(db, filename="fav.jpg", status="indexed", liked=True)
+        _seed(db, filename="meh.jpg", status="indexed", liked=False)
+
+        body = client.get("/api/gallery", params={"liked": True}).json()
+        assert body["total"] == 1
+        assert body["items"][0]["filename"] == "fav.jpg"
+
+    def test_pagination(self, client, db):
+        for i in range(5):
+            _seed(db, filename=f"img_{i}.jpg", status="indexed")
+
+        body = client.get("/api/gallery", params={"skip": 2, "limit": 2}).json()
+        assert body["total"] == 5
+        assert len(body["items"]) == 2
+        assert body["skip"] == 2

--- a/backend/tests/test_gallery.py
+++ b/backend/tests/test_gallery.py
@@ -48,9 +48,18 @@ class TestGalleryResponseShape:
         item = response.json()["items"][0]
 
         expected_keys = {
-            "id", "filename", "status", "created_at", "processed_at",
-            "width", "height", "file_size", "cluster_id", "minio_key",
-            "liked", "url",
+            "id",
+            "filename",
+            "status",
+            "created_at",
+            "processed_at",
+            "width",
+            "height",
+            "file_size",
+            "cluster_id",
+            "minio_key",
+            "liked",
+            "url",
         }
         assert expected_keys.issubset(item.keys())
 

--- a/backend/tests/test_search.py
+++ b/backend/tests/test_search.py
@@ -1,0 +1,81 @@
+"""Tests for GET /api/search — response shape with mocked embeddings/DB."""
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+from find_api.core.database import get_db
+from find_api.main import app
+
+
+def _mock_search(client, fake_rows):
+    """Call /api/search with a mocked embedder and mocked DB execute."""
+    mock_embedder = MagicMock()
+    mock_embedder.embed_text.return_value = [0.0] * 768
+
+    mock_db = MagicMock()
+    mock_db.execute.return_value = iter(fake_rows)
+
+    def _override():
+        yield mock_db
+
+    app.dependency_overrides[get_db] = _override
+
+    with (
+        patch("find_api.routers.search.settings", ML_MODE="mock", EMBEDDING_DIM=768),
+        patch(
+            "find_api.ml.mock_embedder.get_mock_embedder",
+            return_value=mock_embedder,
+        ),
+    ):
+        return client.get("/api/search", params={"q": "sunset"})
+
+
+class TestSearchResponseShape:
+    """Search response shape with mocked data."""
+
+    def test_search_result_shape(self, client):
+        fake_row = MagicMock(
+            id=1,
+            filename="beach.jpg",
+            minio_key="images/ab/abc.jpg",
+            status="indexed",
+            liked=False,
+            width=1920,
+            height=1080,
+            cluster_id=None,
+            similarity=0.82,
+            metadata_json='{"caption": "a beach", "objects": ["sand"]}',
+            created_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        )
+
+        response = _mock_search(client, [fake_row])
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["query"] == "sunset"
+        assert body["total"] == 1
+        assert "results" in body
+
+        result = body["results"][0]
+        assert "media_id" in result
+        assert "similarity" in result
+        assert isinstance(result["similarity"], float)
+
+        meta = result["metadata"]
+        expected = {
+            "id", "filename", "minio_key", "status", "liked",
+            "width", "height", "cluster_id", "created_at",
+            "caption", "objects", "url",
+        }
+        assert expected.issubset(meta.keys())
+
+    def test_empty_results(self, client):
+        response = _mock_search(client, [])
+
+        body = response.json()
+        assert body["results"] == []
+        assert body["total"] == 0
+
+    def test_missing_query_returns_422(self, client):
+        response = client.get("/api/search")
+        assert response.status_code == 422

--- a/backend/tests/test_search.py
+++ b/backend/tests/test_search.py
@@ -22,7 +22,11 @@ def _mock_search(client, fake_rows):
 
     try:
         with (
-            patch("find_api.routers.search.settings", ML_MODE="mock", EMBEDDING_DIM=768),
+            patch(
+                "find_api.routers.search.settings",
+                ML_MODE="mock",
+                EMBEDDING_DIM=768,
+            ),
             patch(
                 "find_api.ml.mock_embedder.get_mock_embedder",
                 return_value=mock_embedder,

--- a/backend/tests/test_search.py
+++ b/backend/tests/test_search.py
@@ -19,15 +19,17 @@ def _mock_search(client, fake_rows):
         yield mock_db
 
     app.dependency_overrides[get_db] = _override
-
-    with (
-        patch("find_api.routers.search.settings", ML_MODE="mock", EMBEDDING_DIM=768),
-        patch(
-            "find_api.ml.mock_embedder.get_mock_embedder",
-            return_value=mock_embedder,
-        ),
-    ):
-        return client.get("/api/search", params={"q": "sunset"})
+    try:
+        with (
+            patch("find_api.routers.search.settings", ML_MODE="mock", EMBEDDING_DIM=768),
+            patch(
+                "find_api.ml.mock_embedder.get_mock_embedder",
+                return_value=mock_embedder,
+            ),
+        ):
+            return client.get("/api/search", params={"q": "sunset"})
+    finally:
+        app.dependency_overrides.pop(get_db, None)
 
 
 class TestSearchResponseShape:

--- a/backend/tests/test_search.py
+++ b/backend/tests/test_search.py
@@ -19,6 +19,7 @@ def _mock_search(client, fake_rows):
         yield mock_db
 
     app.dependency_overrides[get_db] = _override
+
     try:
         with (
             patch("find_api.routers.search.settings", ML_MODE="mock", EMBEDDING_DIM=768),

--- a/backend/tests/test_search.py
+++ b/backend/tests/test_search.py
@@ -65,9 +65,18 @@ class TestSearchResponseShape:
 
         meta = result["metadata"]
         expected = {
-            "id", "filename", "minio_key", "status", "liked",
-            "width", "height", "cluster_id", "created_at",
-            "caption", "objects", "url",
+            "id",
+            "filename",
+            "minio_key",
+            "status",
+            "liked",
+            "width",
+            "height",
+            "cluster_id",
+            "created_at",
+            "caption",
+            "objects",
+            "url",
         }
         assert expected.issubset(meta.keys())
 

--- a/backend/tests/test_status.py
+++ b/backend/tests/test_status.py
@@ -1,0 +1,71 @@
+"""Tests for GET /api/status/{job_id} — job status response shape."""
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+
+class TestJobStatus:
+    """Job status response shape for various states."""
+
+    def test_queued_job(self, client):
+        fake_job = MagicMock()
+        fake_job.get_status.return_value = "queued"
+        fake_job.created_at = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        fake_job.started_at = None
+        fake_job.ended_at = None
+        fake_job.is_finished = False
+        fake_job.is_failed = False
+
+        with patch("find_api.routers.status.Job.fetch", return_value=fake_job):
+            response = client.get("/api/status/some-job-id")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["job_id"] == "some-job-id"
+        assert body["status"] == "queued"
+        assert "created_at" in body
+        assert "result" not in body
+        assert "error" not in body
+
+    def test_finished_job_includes_result(self, client):
+        fake_job = MagicMock()
+        fake_job.get_status.return_value = "finished"
+        fake_job.created_at = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        fake_job.started_at = datetime(2026, 1, 1, 0, 0, 1, tzinfo=timezone.utc)
+        fake_job.ended_at = datetime(2026, 1, 1, 0, 0, 5, tzinfo=timezone.utc)
+        fake_job.is_finished = True
+        fake_job.is_failed = False
+        fake_job.result = {"media_id": 1}
+
+        with patch("find_api.routers.status.Job.fetch", return_value=fake_job):
+            response = client.get("/api/status/done-job")
+
+        body = response.json()
+        assert body["status"] == "finished"
+        assert body["result"] == {"media_id": 1}
+
+    def test_failed_job_includes_error(self, client):
+        fake_job = MagicMock()
+        fake_job.get_status.return_value = "failed"
+        fake_job.created_at = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        fake_job.started_at = datetime(2026, 1, 1, 0, 0, 1, tzinfo=timezone.utc)
+        fake_job.ended_at = datetime(2026, 1, 1, 0, 0, 3, tzinfo=timezone.utc)
+        fake_job.is_finished = False
+        fake_job.is_failed = True
+        fake_job.exc_info = "RuntimeError: out of memory"
+
+        with patch("find_api.routers.status.Job.fetch", return_value=fake_job):
+            response = client.get("/api/status/bad-job")
+
+        body = response.json()
+        assert body["status"] == "failed"
+        assert "error" in body
+
+    def test_unknown_job_returns_404(self, client):
+        with patch(
+            "find_api.routers.status.Job.fetch",
+            side_effect=Exception("No such job"),
+        ):
+            response = client.get("/api/status/nonexistent")
+
+        assert response.status_code == 404

--- a/backend/tests/test_status.py
+++ b/backend/tests/test_status.py
@@ -40,6 +40,7 @@ class TestJobStatus:
         with patch("find_api.routers.status.Job.fetch", return_value=fake_job):
             response = client.get("/api/status/done-job")
 
+        assert response.status_code == 200
         body = response.json()
         assert body["status"] == "finished"
         assert body["result"] == {"media_id": 1}
@@ -57,6 +58,7 @@ class TestJobStatus:
         with patch("find_api.routers.status.Job.fetch", return_value=fake_job):
             response = client.get("/api/status/bad-job")
 
+        assert response.status_code == 200
         body = response.json()
         assert body["status"] == "failed"
         assert "error" in body

--- a/backend/tests/test_upload.py
+++ b/backend/tests/test_upload.py
@@ -1,0 +1,51 @@
+"""Tests for POST /api/upload — response shape and invalid input."""
+
+
+class TestUploadSuccess:
+    """Successful upload response shape."""
+
+    def test_single_image(self, client):
+        response = client.post(
+            "/api/upload",
+            files=[("files", ("photo.png", b"fake-image-bytes", "image/png"))],
+        )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert "results" in body
+        assert "total" in body
+        assert body["total"] == 1
+
+        result = body["results"][0]
+        assert result["filename"] == "photo.png"
+        assert result["status"] == "uploaded"
+        assert "media_id" in result
+        assert "job_id" in result
+
+    def test_duplicate_returns_duplicate_status(self, client):
+        data = b"same-image-bytes"
+        client.post(
+            "/api/upload",
+            files=[("files", ("a.png", data, "image/png"))],
+        )
+        response = client.post(
+            "/api/upload",
+            files=[("files", ("a.png", data, "image/png"))],
+        )
+
+        assert response.json()["results"][0]["status"] == "duplicate"
+
+
+class TestUploadInvalid:
+    """Invalid upload behavior."""
+
+    def test_non_image_rejected(self, client):
+        response = client.post(
+            "/api/upload",
+            files=[("files", ("readme.txt", b"hello", "text/plain"))],
+        )
+        assert response.status_code == 400
+
+    def test_missing_files_returns_422(self, client):
+        response = client.post("/api/upload")
+        assert response.status_code == 422

--- a/backend/tests/test_upload.py
+++ b/backend/tests/test_upload.py
@@ -24,15 +24,16 @@ class TestUploadSuccess:
 
     def test_duplicate_returns_duplicate_status(self, client):
         data = b"same-image-bytes"
-        client.post(
+        first = client.post(
             "/api/upload",
             files=[("files", ("a.png", data, "image/png"))],
         )
+        assert first.status_code == 200
         response = client.post(
             "/api/upload",
             files=[("files", ("a.png", data, "image/png"))],
         )
-
+        assert response.status_code == 200
         assert response.json()["results"][0]["status"] == "duplicate"
 
 


### PR DESCRIPTION
### Summary
Implemented a comprehensive automated testing suite for the FastAPI backend and updated repository documentation.

### Changes
- **Backend Testing**: Added 17 functional tests covering `upload`, `status`, `gallery`, and `search` endpoints.
- **Test Infrastructure**: 
    - Configured an in-memory SQLite database using `StaticPool` for thread-safe testing with `FastAPI.TestClient`.
    - Implemented a session-scoped fixture to handle mocking of external services (MinIO, Redis/RQ, ML Embedders) without infrastructure overhead.
- **Review Fixes**: 
    - Addressed thread-safety issues in database session management.
    - Improved lifecycle teardown to restore `app.lifespan_context` and clean up dependency overrides.
    - Resolved all Ruff formatting and style guide violations.
- **Documentation**: Updated `README.md`, `CONTRIBUTING.md`, `GSSOC_CONTRIBUTOR_GUIDE.md`, and `AGENTS.md` to include the `uv run pytest tests/` command and removed outdated notes about the lack of a test suite.

### Type of change
- [x] Feature (Backend tests)
- [x] Documentation update
- [x] Refactor (Test setup and teardown)
- [x] CI / tooling

### Verification
- [x] `uv run pytest tests/ -v` passes locally.
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] CI checks pass.

Fixes #23


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive tests for gallery, search, job status, and upload endpoints, covering response shapes, filtering, pagination, search results, job states, and upload behaviors (success, duplicate, invalid).

* **Chores**
  * Configured test discovery and app import for the test runner.
  * Added shared test infrastructure with isolated in-memory DB sessions, mocked external integrations, and test client setup.

* **Documentation**
  * Updated contributor and project docs to include running the backend test suite (pytest).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Abhash-Chakraborty/Find/pull/87)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->