### PR TITLE
fix: add contextual empty state for liked gallery

### DIFF
--- a/frontend/src/app/gallery/page.tsx
+++ b/frontend/src/app/gallery/page.tsx
@@ -254,37 +254,37 @@ export default function GalleryPage() {
         )}
 
         {data && data.items.length === 0 && (
-        <div className="w-full">
-          <div className="frost-panel mx-auto rounded-3xl px-8 py-16 text-center">
-            <ImageOff className="mx-auto mb-4 h-12 w-12 text-[#5f6568]" />
-            {likedOnly ? (
-              <>
-                <p className="mb-2 text-[#f0f0f0]">No liked images yet</p>
-                <p className="mb-4 text-sm text-[#a1a4a5]">
-                  Like an image to save it here.
-                </p>
-                <button
-                  type="button"
-                  onClick={() => setLikedOnly(false)}
-                  className="text-sm text-[#3b9eff] hover:underline"
-                >
-                  View all images
-                </button>
-              </>
-            ) : (
-              <>
-                <p className="mb-2 text-[#f0f0f0]">No images found</p>
-                <Link
-                  href="/upload"
-                  className="text-sm text-[#3b9eff] hover:underline"
-                >
-                  Upload your first images
-                </Link>
-              </>
-            )}
+          <div className="w-full">
+            <div className="frost-panel mx-auto rounded-3xl px-8 py-16 text-center">
+              <ImageOff className="mx-auto mb-4 h-12 w-12 text-[#5f6568]" />
+              {likedOnly ? (
+                <>
+                  <p className="mb-2 text-[#f0f0f0]">No liked images yet</p>
+                  <p className="mb-4 text-sm text-[#a1a4a5]">
+                    Like an image to save it here.
+                  </p>
+                  <button
+                    type="button"
+                    onClick={() => setLikedOnly(false)}
+                    className="text-sm text-[#3b9eff] hover:underline"
+                  >
+                    View all images
+                  </button>
+                </>
+              ) : (
+                <>
+                  <p className="mb-2 text-[#f0f0f0]">No images found</p>
+                  <Link
+                    href="/upload"
+                    className="text-sm text-[#3b9eff] hover:underline"
+                  >
+                    Upload your first images
+                  </Link>
+                </>
+              )}
+            </div>
           </div>
-        </div>
-      )}
+        )}
 
         {data && data.items.length > 0 && (
           <>

--- a/frontend/src/app/gallery/page.tsx
+++ b/frontend/src/app/gallery/page.tsx
@@ -254,19 +254,37 @@ export default function GalleryPage() {
         )}
 
         {data && data.items.length === 0 && (
-          <div className="w-full">
-            <div className="frost-panel mx-auto rounded-3xl px-8 py-16 text-center">
-              <ImageOff className="mx-auto mb-4 h-12 w-12 text-[#5f6568]" />
-              <p className="mb-2 text-[#f0f0f0]">No images found</p>
-              <Link
-                href="/upload"
-                className="text-sm text-[#3b9eff] hover:underline"
-              >
-                Upload your first images
-              </Link>
-            </div>
+        <div className="w-full">
+          <div className="frost-panel mx-auto rounded-3xl px-8 py-16 text-center">
+            <ImageOff className="mx-auto mb-4 h-12 w-12 text-[#5f6568]" />
+            {likedOnly ? (
+              <>
+                <p className="mb-2 text-[#f0f0f0]">No liked images yet</p>
+                <p className="mb-4 text-sm text-[#a1a4a5]">
+                  Like an image to save it here.
+                </p>
+                <button
+                  type="button"
+                  onClick={() => setLikedOnly(false)}
+                  className="text-sm text-[#3b9eff] hover:underline"
+                >
+                  View all images
+                </button>
+              </>
+            ) : (
+              <>
+                <p className="mb-2 text-[#f0f0f0]">No images found</p>
+                <Link
+                  href="/upload"
+                  className="text-sm text-[#3b9eff] hover:underline"
+                >
+                  Upload your first images
+                </Link>
+              </>
+            )}
           </div>
-        )}
+        </div>
+      )}
 
         {data && data.items.length > 0 && (
           <>


### PR DESCRIPTION
## Summary

When the gallery is filtered to liked images and no liked images exist, the empty state incorrectly showed "No images found" with an upload prompt. This is confusing because images may already exist but none are liked.

This fix adds a contextual empty state that correctly handles both cases.

Fixes #69 

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Documentation update
- [ ] Refactor
- [ ] CI / tooling

## What changed

- Added a conditional check on `likedOnly` inside the empty state block in `frontend/src/app/gallery/page.tsx`
- When `likedOnly` is true and no items are returned, shows "No liked images yet" with a "View all images" button that clears the filter
- Keeps the original "No images found" + upload prompt for the true empty gallery state
- No backend changes

## Screenshots / recordings (for UI changes)
### Before
<img width="1366" height="599" alt="screenshot-2026-05-15-16-44-14" src="https://github.com/user-attachments/assets/52882896-adc6-4edd-a0d2-d8c24f8948b6" />

### After
<img width="1366" height="599" alt="screenshot-2026-05-15-19-20-02" src="https://github.com/user-attachments/assets/5fa31427-501c-4db7-b48c-1993cf7f3747" />

### Video
https://github.com/user-attachments/assets/d114d094-a826-4fd7-b56d-957526bf1aa7

## How to test

1. Start the app: `docker compose -f docker-compose.light.yml up --build`
2. Upload one or more images
3. Open `http://localhost:3000/gallery`
4. Click the heart/liked filter - ensure no images are liked
5. Confirm: **"No liked images yet"** message appears with a "View all images" button
6. Click "View all images" - confirm filter clears and gallery shows all images
7. Confirm: unliked/unfiltered empty gallery still shows "No images found" with upload link

## Checklist

- [x] I linked the related issue
- [x] I ran required checks from CONTRIBUTING.md
- [ ] I updated docs/env notes if needed - N/A
- [x] My PR is scoped to a single issue
- [x] I followed commit message conventions
- [x] I am not committing secrets or local artifacts

## GSSoC'26 checklist

- [x] I requested issue assignment before starting
- [x] I have meaningful commits (no spam commits)
- [x] I am ready to explain my implementation in review comments

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved gallery empty-state messaging: when filtering to liked images with no results, users see a “No liked images yet” message with a button to view all images; when there are no images overall, the original “No images found” message and upload prompt remain.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Abhash-Chakraborty/Find/pull/88)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->