### PR TITLE
fix: disable recluster button while clustering job is active

### DIFF
--- a/frontend/src/app/clusters/page.tsx
+++ b/frontend/src/app/clusters/page.tsx
@@ -123,6 +123,8 @@ export default function ClustersPage() {
   const activeJobStatus = clusterJobQuery.data?.status;
   const isJobActive =
     activeJobStatus === "queued" || activeJobStatus === "started";
+  const isClusterActionBusy =
+    clusterMutation.isPending || clusterJobQuery.isFetching || isJobActive;
   const filteredMembers =
     selectedClusterQuery.data?.members.filter((member) =>
       member.filename.toLowerCase().includes(filterText.toLowerCase()),
@@ -158,15 +160,15 @@ export default function ClustersPage() {
             <button
               type="button"
               onClick={() => clusterMutation.mutate()}
-              disabled={clusterMutation.isPending || clusterJobQuery.isFetching || isJobActive}
+              disabled={isClusterActionBusy}
               className="white-pill px-5 py-2.5 text-sm font-semibold disabled:cursor-not-allowed disabled:opacity-50"
             >
-              {clusterMutation.isPending || clusterJobQuery.isFetching || isJobActive ? (
+              {isClusterActionBusy ? (
                 <Loader2 className="h-4 w-4 animate-spin" />
               ) : (
                 <Play className="h-4 w-4" />
               )}
-              {isJobActive ? "Clustering..." : "Re-cluster"}
+              {isClusterActionBusy ? "Clustering..." : "Re-cluster"}
             </button>
           </div>
         </div>
@@ -211,11 +213,15 @@ export default function ClustersPage() {
             <button
               type="button"
               onClick={() => clusterMutation.mutate()}
-              disabled={clusterMutation.isPending}
+              disabled={isClusterActionBusy}
               className="white-pill px-5 py-2.5 text-sm font-semibold disabled:cursor-not-allowed disabled:opacity-50"
             >
-              <Play className="h-4 w-4" />
-              Run clustering
+              {isClusterActionBusy ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <Play className="h-4 w-4" />
+              )}
+              {isClusterActionBusy ? "Clustering..." : "Run clustering"}
             </button>
           </div>
         )}

--- a/frontend/src/app/clusters/page.tsx
+++ b/frontend/src/app/clusters/page.tsx
@@ -158,15 +158,15 @@ export default function ClustersPage() {
             <button
               type="button"
               onClick={() => clusterMutation.mutate()}
-              disabled={clusterMutation.isPending || clusterJobQuery.isFetching}
+              disabled={clusterMutation.isPending || clusterJobQuery.isFetching || isJobActive}
               className="white-pill px-5 py-2.5 text-sm font-semibold disabled:cursor-not-allowed disabled:opacity-50"
             >
-              {clusterMutation.isPending || clusterJobQuery.isFetching ? (
+              {clusterMutation.isPending || clusterJobQuery.isFetching || isJobActive ? (
                 <Loader2 className="h-4 w-4 animate-spin" />
               ) : (
                 <Play className="h-4 w-4" />
               )}
-              Re-cluster
+              {isJobActive ? "Clustering..." : "Re-cluster"}
             </button>
           </div>
         </div>


### PR DESCRIPTION
Fixes #73

### Changes made
- Disabled Re-cluster button when job status is `queued` or `started`
- Shows loading spinner while job is active
- Button label changes to "Clustering..." during active job
- Re-enables button when job finishes or fails
- Refresh button remains unaffected

### Related issue
Closes #73

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Clusters page buttons now use a unified "busy" state: when clustering is active or status is pending, buttons are disabled, show a spinner instead of the play icon, and display "Clustering...". Both the main "Re-cluster" and the empty-state "Run clustering" buttons reflect this behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Abhash-Chakraborty/Find/pull/104?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->