### PR TITLE
fix: clear media query & persist filter in URL

### DIFF
--- a/frontend/src/app/gallery/page.tsx
+++ b/frontend/src/app/gallery/page.tsx
@@ -248,6 +248,13 @@ function GalleryPageContent() {
   const closeDetail = useCallback(() => {
     setSelectedMediaId(null);
     setQuerySelectedItem(null);
+
+    // Remove stale media query parameter from URL
+    const url = new URL(window.location.href);
+    if (url.searchParams.has("media")) {
+      url.searchParams.delete("media");
+      window.history.replaceState({}, "", url.toString());
+    }
   }, []);
 
   const filters = [

--- a/frontend/src/app/gallery/page.tsx
+++ b/frontend/src/app/gallery/page.tsx
@@ -37,8 +37,16 @@ function GalleryPageContent() {
   const [page, setPage] = useState(1);
   const [filter, setFilter] = useState<
     "all" | "indexed" | "processing" | "failed"
-  >("all");
-  const [likedOnly, setLikedOnly] = useState(false);
+  >(() => {
+    const param = searchParams.get("filter");
+    if (param && ["indexed", "processing", "failed"].includes(param)) {
+      return param as "indexed" | "processing" | "failed";
+    }
+    return "all";
+  });
+  const [likedOnly, setLikedOnly] = useState(() => {
+    return searchParams.get("liked") === "true";
+  });
   const [selectedMediaId, setSelectedMediaId] = useState<number | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<{
     id: number;
@@ -56,6 +64,36 @@ function GalleryPageContent() {
     () => ["gallery", page, filter, likedOnly] as const,
     [page, filter, likedOnly],
   );
+
+  // Sync filter and likedOnly to URL search params
+  useEffect(() => {
+    const url = new URL(window.location.href);
+    let changed = false;
+
+    if (filter !== "all") {
+      if (url.searchParams.get("filter") !== filter) {
+        url.searchParams.set("filter", filter);
+        changed = true;
+      }
+    } else if (url.searchParams.has("filter")) {
+      url.searchParams.delete("filter");
+      changed = true;
+    }
+
+    if (likedOnly) {
+      if (url.searchParams.get("liked") !== "true") {
+        url.searchParams.set("liked", "true");
+        changed = true;
+      }
+    } else if (url.searchParams.has("liked")) {
+      url.searchParams.delete("liked");
+      changed = true;
+    }
+
+    if (changed) {
+      window.history.replaceState({}, "", url.toString());
+    }
+  }, [filter, likedOnly]);
 
   const { data, isLoading, error } = useQuery<GalleryResponse, Error>({
     queryKey: galleryQueryKey,


### PR DESCRIPTION
## Summary
- **#90**: Clear stale `media` query parameter when preview modal closes
- **#89**: Persist gallery tab filter and liked-only toggle in URL

## Changes
- `frontend/src/app/gallery/page.tsx`:
  - In `closeDetail()`, remove `media` query param via `window.history.replaceState()`
  - Read initial `filter` and `likedOnly` from URL search params on mount
  - Sync `filter` and `likedOnly` to URL when they change

Fixes #89, Fixes #90