### PR TITLE
fix: remove stale media query param when preview modal closes

### DIFF
--- a/frontend/pnpm-workspace.yaml
+++ b/frontend/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  sharp: set this to true or false

--- a/frontend/src/app/gallery/page.tsx
+++ b/frontend/src/app/gallery/page.tsx
@@ -15,7 +15,7 @@ import {
 } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
-import { useSearchParams } from "next/navigation";
+import {usePathname,useRouter,useSearchParams,} from "next/navigation";
 import { Suspense, useCallback, useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 import {
@@ -32,7 +32,7 @@ import {
   toggleLike,
 } from "@/lib/api";
 import { resolveMediaUrl } from "@/lib/media";
-import { useRouter, usePathname } from "next/navigation";
+
 
 function GalleryPageContent() {
   const [page, setPage] = useState(1);
@@ -249,17 +249,17 @@ function GalleryPageContent() {
   );
 
   const closeDetail = useCallback(() => {
-  setSelectedMediaId(null);
-  setQuerySelectedItem(null);
+    setSelectedMediaId(null);
+    setQuerySelectedItem(null);
 
-  const params = new URLSearchParams(searchParams.toString());
+    const params = new URLSearchParams(searchParams.toString());
 
-  params.delete("media");
+    params.delete("media");
 
-  const queryString = params.toString();
-  const url = queryString ? `${pathname}?${queryString}` : pathname;
+    const queryString = params.toString();
+    const url = queryString ? `${pathname}?${queryString}` : pathname;
 
-  router.replace(url, { scroll: false });
+    router.replace(url, { scroll: false });
 }, [router, pathname, searchParams]);
 
   const filters = [

--- a/frontend/src/app/gallery/page.tsx
+++ b/frontend/src/app/gallery/page.tsx
@@ -32,6 +32,7 @@ import {
   toggleLike,
 } from "@/lib/api";
 import { resolveMediaUrl } from "@/lib/media";
+import { useRouter, usePathname } from "next/navigation";
 
 function GalleryPageContent() {
   const [page, setPage] = useState(1);
@@ -51,6 +52,8 @@ function GalleryPageContent() {
   const limit = 24;
 
   const queryClient = useQueryClient();
+  const router = useRouter();
+  const pathname = usePathname();
   const searchParams = useSearchParams();
   const galleryQueryKey = useMemo(
     () => ["gallery", page, filter, likedOnly] as const,
@@ -246,9 +249,18 @@ function GalleryPageContent() {
   );
 
   const closeDetail = useCallback(() => {
-    setSelectedMediaId(null);
-    setQuerySelectedItem(null);
-  }, []);
+  setSelectedMediaId(null);
+  setQuerySelectedItem(null);
+
+  const params = new URLSearchParams(searchParams.toString());
+
+  params.delete("media");
+
+  const queryString = params.toString();
+  const url = queryString ? `${pathname}?${queryString}` : pathname;
+
+  router.replace(url, { scroll: false });
+}, [router, pathname, searchParams]);
 
   const filters = [
     { label: "All", value: "all" as const },


### PR DESCRIPTION
## Summary

Fixes #90

Closing the gallery preview modal now removes the stale `media` query parameter while preserving the rest of the current gallery URL state.

## What changed

- remove `media` from the URL when the preview modal closes
- preserve existing gallery params such as status and liked filters
- use `router.replace` so closing the modal does not add a new history entry

## How to test

1. Open `/gallery?status=processing&liked=true&media=123` with a valid media id.
2. Close the preview modal.
3. Confirm the URL becomes `/gallery?status=processing&liked=true`.
4. Confirm the gallery filter state stays unchanged after closing.
5. Open a direct duplicate-upload gallery link and confirm the preview still opens correctly.

## Checklist

- [x] I linked the related issue
- [x] My PR is scoped to a single issue
- [x] I preserved existing gallery URL state