### PR TITLE
fix: add contextual empty-state copy for gallery tabs

### DIFF
--- a/frontend/src/app/gallery/page.tsx
+++ b/frontend/src/app/gallery/page.tsx
@@ -86,7 +86,8 @@ function getGalleryEmptyState(
     return likedOnly
       ? {
           title: "No liked images are processing",
-          subtitle: "None of your liked images are queued or running right now.",
+          subtitle:
+            "None of your liked images are queued or running right now.",
           showUploadLink: false,
           showClearLikedOnly: true,
         }

--- a/frontend/src/app/gallery/page.tsx
+++ b/frontend/src/app/gallery/page.tsx
@@ -9,111 +9,155 @@ import {
   Heart,
   ImageOff,
   Loader2,
+  RotateCcw,
   Trash2,
   X,
 } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
-import { useCallback, useEffect, useMemo, useState } from "react";
-import { ImagePreviewModal } from "@/components/image-preview-modal";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { Suspense, useCallback, useEffect, useMemo, useState } from "react";
+import { toast } from "sonner";
+import {
+  ImagePreviewModal,
+  type PreviewMedia,
+} from "@/components/image-preview-modal";
 import { StatusIndicator } from "@/components/status-indicator";
 import {
   deleteImage,
   type GalleryResponse,
   getGallery,
-  type MediaItem,
+  getImageDetail,
+  reprocessImage,
   toggleLike,
 } from "@/lib/api";
 import { resolveMediaUrl } from "@/lib/media";
 
-type GalleryStatusFilter = "all" | "indexed" | "processing" | "failed";
+type GalleryFilter = "all" | "indexed" | "processing" | "failed";
 
-function getGalleryEmptyState(
-  filter: GalleryStatusFilter,
-  likedOnly: boolean,
-): {
+type GalleryEmptyState = {
   title: string;
   subtitle: string | null;
   showUploadLink: boolean;
-} {
+  showClearLikedOnly: boolean;
+};
+
+function getGalleryEmptyState(
+  filter: GalleryFilter,
+  likedOnly: boolean,
+): GalleryEmptyState {
   if (filter === "all") {
     if (likedOnly) {
       return {
-        title: "No liked images",
-        subtitle:
-          "Switch to All images and use the heart on items you want here.",
+        title: "No liked images yet",
+        subtitle: "Like an image to save it here.",
         showUploadLink: false,
+        showClearLikedOnly: true,
       };
     }
+
     return {
       title: "No images found",
       subtitle: null,
       showUploadLink: true,
+      showClearLikedOnly: false,
     };
   }
 
   if (filter === "indexed") {
-    if (likedOnly) {
-      return {
-        title: "No liked indexed images yet",
-        subtitle:
-          "Try uploading images or check the Processing tab for items still in progress.",
-        showUploadLink: false,
-      };
-    }
-    return {
-      title: "No indexed images yet",
-      subtitle:
-        "Try uploading images or check the Processing tab for items still in progress.",
-      showUploadLink: false,
-    };
+    return likedOnly
+      ? {
+          title: "No liked indexed images yet",
+          subtitle:
+            "Try uploading images or check the Processing tab for items still in progress.",
+          showUploadLink: false,
+          showClearLikedOnly: true,
+        }
+      : {
+          title: "No indexed images yet",
+          subtitle:
+            "Try uploading images or check the Processing tab for items still in progress.",
+          showUploadLink: false,
+          showClearLikedOnly: false,
+        };
   }
 
   if (filter === "processing") {
-    if (likedOnly) {
-      return {
-        title: "No liked images are processing",
-        subtitle:
-          "None of your liked images are queued or running right now.",
+    return likedOnly
+      ? {
+          title: "No liked images are processing",
+          subtitle: "None of your liked images are queued or running right now.",
+          showUploadLink: false,
+          showClearLikedOnly: true,
+        }
+      : {
+          title: "All clear",
+          subtitle: "No images are processing right now.",
+          showUploadLink: false,
+          showClearLikedOnly: false,
+        };
+  }
+
+  return likedOnly
+    ? {
+        title: "No failed liked images",
+        subtitle: "None of your liked images have failed recently.",
         showUploadLink: false,
+        showClearLikedOnly: true,
+      }
+    : {
+        title: "No failed images",
+        subtitle: "Nothing failed recently.",
+        showUploadLink: false,
+        showClearLikedOnly: false,
       };
-    }
-    return {
-      title: "All clear",
-      subtitle: "No images are processing right now.",
-      showUploadLink: false,
-    };
-  }
-
-  if (likedOnly) {
-    return {
-      title: "No failed liked images",
-      subtitle: "None of your liked images have failed recently.",
-      showUploadLink: false,
-    };
-  }
-
-  return {
-    title: "No failed images",
-    subtitle: "Nothing failed recently.",
-    showUploadLink: false,
-  };
 }
 
-export default function GalleryPage() {
-  const [page, setPage] = useState(1);
-  const [filter, setFilter] = useState<GalleryStatusFilter>("all");
-  const [likedOnly, setLikedOnly] = useState(false);
+const getFilterFromStatusParam = (status: string | null): GalleryFilter => {
+  if (status === "completed" || status === "indexed") {
+    return "indexed";
+  }
+
+  if (status === "processing" || status === "failed") {
+    return status;
+  }
+
+  return "all";
+};
+
+const getStatusParamFromFilter = (filter: GalleryFilter): string | null => {
+  if (filter === "all") {
+    return null;
+  }
+
+  return filter === "indexed" ? "completed" : filter;
+};
+
+function GalleryPageContent() {
   const [selectedMediaId, setSelectedMediaId] = useState<number | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<{
     id: number;
     filename?: string;
   } | null>(null);
   const [deletionError, setDeletionError] = useState<string | null>(null);
+  const [hasOpenedFromQuery, setHasOpenedFromQuery] = useState(false);
+  const [querySelectedItem, setQuerySelectedItem] =
+    useState<PreviewMedia | null>(null);
   const limit = 24;
 
   const queryClient = useQueryClient();
-
+  const pathname = usePathname();
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const filter = getFilterFromStatusParam(searchParams.get("status"));
+  const likedOnly = searchParams.get("liked") === "true";
+  const filterStateKey = `${filter}:${likedOnly}`;
+  const [pagination, setPagination] = useState({
+    filterStateKey,
+    page: 1,
+  });
+  const page =
+    pagination.filterStateKey === filterStateKey ? pagination.page : 1;
   const galleryQueryKey = useMemo(
     () => ["gallery", page, filter, likedOnly] as const,
     [page, filter, likedOnly],
@@ -129,8 +173,101 @@ export default function GalleryPage() {
         liked: likedOnly ? true : undefined,
       }),
     placeholderData: (previous) => previous,
+    refetchInterval: (query) => {
+      const gallery = query.state.data as GalleryResponse | undefined;
+
+      return gallery?.items.some(
+        (item) => item.status === "processing" || item.status === "pending",
+      )
+        ? 5000
+        : false;
+    },
   });
 
+  const buildGalleryHref = useCallback(
+    (nextState: { filter?: GalleryFilter; likedOnly?: boolean }) => {
+      const nextFilter = nextState.filter ?? filter;
+      const nextLikedOnly = nextState.likedOnly ?? likedOnly;
+      const nextParams = new URLSearchParams(searchParams.toString());
+      const statusParam = getStatusParamFromFilter(nextFilter);
+
+      if (statusParam) {
+        nextParams.set("status", statusParam);
+      } else {
+        nextParams.delete("status");
+      }
+
+      if (nextLikedOnly) {
+        nextParams.set("liked", "true");
+      } else {
+        nextParams.delete("liked");
+      }
+
+      const queryString = nextParams.toString();
+      return queryString ? `${pathname}?${queryString}` : pathname;
+    },
+    [filter, likedOnly, pathname, searchParams],
+  );
+
+  const updateGalleryParams = useCallback(
+    (nextState: { filter?: GalleryFilter; likedOnly?: boolean }) => {
+      router.push(buildGalleryHref(nextState), {
+        scroll: false,
+      });
+    },
+    [buildGalleryHref, router],
+  );
+
+  useEffect(() => {
+    if (hasOpenedFromQuery) {
+      return;
+    }
+
+    const mediaParam = searchParams.get("media");
+
+    if (!mediaParam || !data) {
+      return;
+    }
+
+    const mediaId = Number(mediaParam);
+
+    if (Number.isNaN(mediaId)) {
+      return;
+    }
+
+    const existingItem = data.items.find((item) => item.id === mediaId);
+
+    if (existingItem) {
+      setQuerySelectedItem(null);
+      setSelectedMediaId(mediaId);
+      setHasOpenedFromQuery(true);
+      return;
+    }
+
+    let cancelled = false;
+
+    const openOffPageMedia = async () => {
+      try {
+        const media = await getImageDetail(mediaId);
+        if (cancelled) {
+          return;
+        }
+        setQuerySelectedItem(media);
+        setSelectedMediaId(media.id);
+        setHasOpenedFromQuery(true);
+      } catch {
+        if (!cancelled) {
+          setHasOpenedFromQuery(true);
+        }
+      }
+    };
+
+    void openOffPageMedia();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [data, searchParams, hasOpenedFromQuery]);
   const likeMutation = useMutation({
     mutationFn: (mediaId: number) => toggleLike(mediaId),
     onSuccess: ({ id }) => {
@@ -186,12 +323,30 @@ export default function GalleryPage() {
     },
   });
 
-  const selectedItem = useMemo<MediaItem | null>(() => {
-    if (!data || selectedMediaId === null) {
+  const reprocessMutation = useMutation({
+    mutationFn: (mediaId: number) => reprocessImage(mediaId),
+    onSuccess: ({ media_id }) => {
+      queryClient.invalidateQueries({ queryKey: ["gallery"] });
+      queryClient.invalidateQueries({ queryKey: ["image-detail", media_id] });
+      toast.success("Retry queued — analysis will restart shortly.");
+    },
+    onError: () => {
+      toast.error(
+        "Retry failed. The queue may be unavailable — please try again.",
+      );
+    },
+  });
+
+  const selectedItem = useMemo<PreviewMedia | null>(() => {
+    if (selectedMediaId === null) {
       return null;
     }
-    return data.items.find((item) => item.id === selectedMediaId) ?? null;
-  }, [data, selectedMediaId]);
+
+    return (
+      data?.items.find((item) => item.id === selectedMediaId) ??
+      (querySelectedItem?.id === selectedMediaId ? querySelectedItem : null)
+    );
+  }, [data, selectedMediaId, querySelectedItem]);
 
   const selectedIndex = useMemo(() => {
     if (!data || selectedMediaId === null) {
@@ -204,10 +359,13 @@ export default function GalleryPage() {
     if (!data || selectedMediaId === null) {
       return;
     }
-    if (!data.items.some((item) => item.id === selectedMediaId)) {
+    if (
+      !data.items.some((item) => item.id === selectedMediaId) &&
+      querySelectedItem?.id !== selectedMediaId
+    ) {
       setSelectedMediaId(null);
     }
-  }, [data, selectedMediaId]);
+  }, [data, selectedMediaId, querySelectedItem]);
 
   const goToAdjacent = useCallback(
     (direction: -1 | 1) => {
@@ -228,14 +386,49 @@ export default function GalleryPage() {
     [data, selectedMediaId],
   );
 
-  const closeDetail = useCallback(() => setSelectedMediaId(null), []);
+  const closeDetail = useCallback(() => {
+    setSelectedMediaId(null);
+    setQuerySelectedItem(null);
+
+    const params = new URLSearchParams(searchParams.toString());
+
+    params.delete("media");
+
+    const queryString = params.toString();
+    const url = queryString ? `${pathname}?${queryString}` : pathname;
+
+    router.replace(url, { scroll: false });
+  }, [router, pathname, searchParams]);
 
   const filters = [
-    { label: "All", value: "all" as const },
-    { label: "Indexed", value: "indexed" as const },
-    { label: "Processing", value: "processing" as const },
-    { label: "Failed", value: "failed" as const },
-  ];
+    { label: "All", value: "all" },
+    { label: "Indexed", value: "indexed" },
+    { label: "Processing", value: "processing" },
+    { label: "Failed", value: "failed" },
+  ] satisfies Array<{ label: string; value: GalleryFilter }>;
+
+  const handleLikedOnlyChange = useCallback(() => {
+    updateGalleryParams({ likedOnly: !likedOnly });
+  }, [likedOnly, updateGalleryParams]);
+
+  const handleClearLikedOnly = useCallback(() => {
+    updateGalleryParams({ likedOnly: false });
+  }, [updateGalleryParams]);
+
+  const updatePage = useCallback(
+    (updater: (currentPage: number) => number) => {
+      setPagination((current) => {
+        const currentPage =
+          current.filterStateKey === filterStateKey ? current.page : 1;
+
+        return {
+          filterStateKey,
+          page: updater(currentPage),
+        };
+      });
+    },
+    [filterStateKey],
+  );
 
   const handleToggleLike = useCallback(
     (mediaId: number) => {
@@ -267,6 +460,7 @@ export default function GalleryPage() {
     if (!data || data.items.length > 0) {
       return null;
     }
+
     return getGalleryEmptyState(filter, likedOnly);
   }, [data, filter, likedOnly]);
 
@@ -285,13 +479,11 @@ export default function GalleryPage() {
         <div className="frost-panel delayed-enter mb-8 flex flex-col items-center justify-between gap-4 rounded-3xl px-4 py-3 md:flex-row">
           <div className="flex flex-wrap justify-center gap-1">
             {filters.map(({ label, value }) => (
-              <button
-                type="button"
+              <Link
                 key={value}
-                onClick={() => {
-                  setFilter(value);
-                  setPage(1);
-                }}
+                href={buildGalleryHref({ filter: value })}
+                scroll={false}
+                aria-current={filter === value ? "page" : undefined}
                 className={`rounded-full px-4 py-2 text-sm font-medium transition-colors ${
                   filter === value
                     ? "bg-white text-black"
@@ -299,16 +491,14 @@ export default function GalleryPage() {
                 }`}
               >
                 {label}
-              </button>
+              </Link>
             ))}
           </div>
 
           <button
             type="button"
-            onClick={() => {
-              setLikedOnly((previous) => !previous);
-              setPage(1);
-            }}
+            aria-pressed={likedOnly}
+            onClick={handleLikedOnlyChange}
             className={`inline-flex items-center gap-2 rounded-full px-4 py-2 text-xs font-medium transition-colors ${
               likedOnly
                 ? "border border-[var(--red-soft)] bg-[var(--red-soft)] text-[#ff9bab]"
@@ -333,21 +523,33 @@ export default function GalleryPage() {
         )}
 
         {emptyGalleryCopy && (
-          <div className="frost-panel mx-auto max-w-md rounded-3xl px-8 py-16 text-center">
-            <ImageOff className="mx-auto mb-4 h-12 w-12 text-[#5f6568]" />
-            <p className="mb-2 text-[#f0f0f0]">{emptyGalleryCopy.title}</p>
-            {emptyGalleryCopy.showUploadLink ? (
-              <Link
-                href="/upload"
-                className="text-sm text-[#3b9eff] hover:underline"
-              >
-                Upload your first images
-              </Link>
-            ) : emptyGalleryCopy.subtitle ? (
-              <p className="text-sm leading-6 text-[#a1a4a5]">
-                {emptyGalleryCopy.subtitle}
-              </p>
-            ) : null}
+          <div className="w-full">
+            <div className="frost-panel mx-auto rounded-3xl px-8 py-16 text-center">
+              <ImageOff className="mx-auto mb-4 h-12 w-12 text-[#5f6568]" />
+              <p className="mb-2 text-[#f0f0f0]">{emptyGalleryCopy.title}</p>
+              {emptyGalleryCopy.subtitle && (
+                <p className="mb-4 text-sm text-[#a1a4a5]">
+                  {emptyGalleryCopy.subtitle}
+                </p>
+              )}
+              {emptyGalleryCopy.showUploadLink && (
+                <Link
+                  href="/upload"
+                  className="text-sm text-[#3b9eff] hover:underline"
+                >
+                  Upload your first images
+                </Link>
+              )}
+              {emptyGalleryCopy.showClearLikedOnly && (
+                <button
+                  type="button"
+                  onClick={handleClearLikedOnly}
+                  className="text-sm text-[#3b9eff] hover:underline"
+                >
+                  View all images
+                </button>
+              )}
+            </div>
           </div>
         )}
 
@@ -366,7 +568,10 @@ export default function GalleryPage() {
                     <button
                       type="button"
                       className="relative block aspect-square w-full overflow-hidden bg-white/[0.025] text-left focus:outline-none"
-                      onClick={() => setSelectedMediaId(item.id)}
+                      onClick={() => {
+                        setQuerySelectedItem(null);
+                        setSelectedMediaId(item.id);
+                      }}
                       aria-label={`View ${item.filename}`}
                     >
                       {imageSrc ? (
@@ -437,6 +642,24 @@ export default function GalleryPage() {
                             <Download className="h-3.5 w-3.5" />
                           </a>
                         )}
+                        {(item.status === "failed" ||
+                          (item.status === "indexed" && !item.caption)) && (
+                          <button
+                            type="button"
+                            onClick={() => reprocessMutation.mutate(item.id)}
+                            disabled={reprocessMutation.isPending}
+                            className={`icon-button h-8 w-8 text-[#a1a4a5] ${
+                              reprocessMutation.isPending
+                                ? "cursor-not-allowed opacity-70"
+                                : ""
+                            }`}
+                            aria-label="Retry analysis"
+                          >
+                            <RotateCcw
+                              className={`h-3.5 w-3.5 ${reprocessMutation.isPending ? "animate-spin" : ""}`}
+                            />
+                          </button>
+                        )}
                         <button
                           type="button"
                           onClick={() =>
@@ -463,7 +686,9 @@ export default function GalleryPage() {
               <div className="mt-12 flex items-center justify-center gap-6">
                 <button
                   type="button"
-                  onClick={() => setPage((current) => Math.max(1, current - 1))}
+                  onClick={() =>
+                    updatePage((current) => Math.max(1, current - 1))
+                  }
                   disabled={page === 1}
                   className="icon-button disabled:cursor-not-allowed disabled:opacity-30"
                 >
@@ -474,7 +699,7 @@ export default function GalleryPage() {
                 </span>
                 <button
                   type="button"
-                  onClick={() => setPage((current) => current + 1)}
+                  onClick={() => updatePage((current) => current + 1)}
                   disabled={page >= Math.ceil(data.total / limit)}
                   className="icon-button disabled:cursor-not-allowed disabled:opacity-30"
                 >
@@ -501,6 +726,7 @@ export default function GalleryPage() {
           onDeleted={(mediaId) => {
             if (selectedMediaId === mediaId) {
               setSelectedMediaId(null);
+              setQuerySelectedItem(null);
             }
           }}
         />
@@ -554,5 +780,12 @@ export default function GalleryPage() {
         </div>
       )}
     </div>
+  );
+}
+export default function GalleryPage() {
+  return (
+    <Suspense fallback={null}>
+      <GalleryPageContent />
+    </Suspense>
   );
 }

--- a/frontend/src/app/gallery/page.tsx
+++ b/frontend/src/app/gallery/page.tsx
@@ -26,11 +26,83 @@ import {
 } from "@/lib/api";
 import { resolveMediaUrl } from "@/lib/media";
 
+type GalleryStatusFilter = "all" | "indexed" | "processing" | "failed";
+
+function getGalleryEmptyState(
+  filter: GalleryStatusFilter,
+  likedOnly: boolean,
+): {
+  title: string;
+  subtitle: string | null;
+  showUploadLink: boolean;
+} {
+  if (filter === "all") {
+    if (likedOnly) {
+      return {
+        title: "No liked images",
+        subtitle:
+          "Switch to All images and use the heart on items you want here.",
+        showUploadLink: false,
+      };
+    }
+    return {
+      title: "No images found",
+      subtitle: null,
+      showUploadLink: true,
+    };
+  }
+
+  if (filter === "indexed") {
+    if (likedOnly) {
+      return {
+        title: "No liked indexed images yet",
+        subtitle:
+          "Try uploading images or check the Processing tab for items still in progress.",
+        showUploadLink: false,
+      };
+    }
+    return {
+      title: "No indexed images yet",
+      subtitle:
+        "Try uploading images or check the Processing tab for items still in progress.",
+      showUploadLink: false,
+    };
+  }
+
+  if (filter === "processing") {
+    if (likedOnly) {
+      return {
+        title: "No liked images are processing",
+        subtitle:
+          "None of your liked images are queued or running right now.",
+        showUploadLink: false,
+      };
+    }
+    return {
+      title: "All clear",
+      subtitle: "No images are processing right now.",
+      showUploadLink: false,
+    };
+  }
+
+  if (likedOnly) {
+    return {
+      title: "No failed liked images",
+      subtitle: "None of your liked images have failed recently.",
+      showUploadLink: false,
+    };
+  }
+
+  return {
+    title: "No failed images",
+    subtitle: "Nothing failed recently.",
+    showUploadLink: false,
+  };
+}
+
 export default function GalleryPage() {
   const [page, setPage] = useState(1);
-  const [filter, setFilter] = useState<
-    "all" | "indexed" | "processing" | "failed"
-  >("all");
+  const [filter, setFilter] = useState<GalleryStatusFilter>("all");
   const [likedOnly, setLikedOnly] = useState(false);
   const [selectedMediaId, setSelectedMediaId] = useState<number | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<{
@@ -191,6 +263,13 @@ export default function GalleryPage() {
     setDeleteTarget(null);
   }, []);
 
+  const emptyGalleryCopy = useMemo(() => {
+    if (!data || data.items.length > 0) {
+      return null;
+    }
+    return getGalleryEmptyState(filter, likedOnly);
+  }, [data, filter, likedOnly]);
+
   return (
     <div className="page-shell">
       <div className="container-shell py-10 md:py-14">
@@ -253,16 +332,22 @@ export default function GalleryPage() {
           </div>
         )}
 
-        {data && data.items.length === 0 && (
+        {emptyGalleryCopy && (
           <div className="frost-panel mx-auto max-w-md rounded-3xl px-8 py-16 text-center">
             <ImageOff className="mx-auto mb-4 h-12 w-12 text-[#5f6568]" />
-            <p className="mb-2 text-[#f0f0f0]">No images found</p>
-            <Link
-              href="/upload"
-              className="text-sm text-[#3b9eff] hover:underline"
-            >
-              Upload your first images
-            </Link>
+            <p className="mb-2 text-[#f0f0f0]">{emptyGalleryCopy.title}</p>
+            {emptyGalleryCopy.showUploadLink ? (
+              <Link
+                href="/upload"
+                className="text-sm text-[#3b9eff] hover:underline"
+              >
+                Upload your first images
+              </Link>
+            ) : emptyGalleryCopy.subtitle ? (
+              <p className="text-sm leading-6 text-[#a1a4a5]">
+                {emptyGalleryCopy.subtitle}
+              </p>
+            ) : null}
           </div>
         )}
 


### PR DESCRIPTION
## Summary

Implements contextual empty-state messaging for the Gallery tabs based on the active filter/status.

Previously, the Gallery always displayed the same generic empty-state copy ("No images found" with an upload CTA), which was confusing for the Processing and Failed tabs where an empty state is usually expected and positive.

This update introduces tab-aware empty-state titles and descriptions while keeping the existing gallery layout behavior unchanged.

Fixes #16

## Type of change

* [x] Bug fix
* [ ] Feature
* [ ] Documentation update
* [ ] Refactor
* [ ] CI / tooling

## What changed

* Added contextual empty-state copy for:

  * All
  * Indexed
  * Processing
  * Failed
  * Liked + status filter combinations

* Updated Processing and Failed tabs to avoid showing upload-focused messaging when there are no matching images.

* Kept the implementation scoped only to empty-state behavior and messaging without modifying gallery layout/alignment logic from #15.

## Screenshots / recordings (for UI changes)

Included screenshots for:

* All tab empty state
* Indexed tab empty state
* Processing tab empty state
* Failed tab empty state
* Liked + Failed filter empty state

## How to test

1. Start the frontend application:

   ```bash
   npm install
   npm run dev
   ```

2. Open:

   ```text
   http://localhost:3000/gallery
   ```

3. Verify the following behaviors:

   * All tab shows generic "No images found" upload messaging.
   * Indexed tab shows indexed-specific guidance.
   * Processing tab shows "All clear" style messaging when empty.
   * Failed tab shows "No failed images" messaging when empty.
   * Liked-only + status filter combinations display contextual empty-state copy.

4. Upload/process images and confirm:

   * Empty states disappear when matching images exist.
   * Filtered tabs correctly show relevant images.

5. Run validation checks:

   ```bash
   npm run lint
   npm run type-check
   ```

## Checklist

* [x] I linked the related issue
* [x] I ran required checks from CONTRIBUTING.md
* [ ] I updated docs/env notes if needed
* [x] My PR is scoped to a single issue
* [x] I followed commit message conventions
* [x] I am not committing secrets or local artifacts

## GSSoC'26 checklist

* [x] I requested issue assignment before starting
* [x] I have meaningful commits (no spam commits)
* [x] I am ready to explain my implementation in review comments


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Gallery now displays context-aware empty state messages that adapt based on active filters (status type and liked-only preference). The upload prompt visibility and messaging automatically adjust based on the current filter selection for improved user guidance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Abhash-Chakraborty/Find/pull/121?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->