### PR TITLE
docs: add troubleshooting steps for stuck image processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,35 @@ Repeated clustering attempts without adding or reindexing images are unlikely to
 
 ## Troubleshooting
 
+### Images stuck in processing
+
+When an image is marked as `processing`, the upload has been accepted and queued for background analysis by the worker. The worker reads the file from MinIO, extracts metadata, generates embeddings, updates the database row, and then queues clustering.
+
+If an image looks stuck:
+
+- Confirm the stack is running:
+
+```bash
+docker compose ps
+```
+
+- Inspect the worker logs first:
+
+```bash
+docker compose logs --tail=200 worker
+```
+
+- Check the API logs for upload, storage, or queue errors:
+
+```bash
+docker compose logs --tail=200 api
+```
+
+- Confirm Redis and MinIO are healthy in `docker compose ps`.
+- Do not retry or manually reprocess while the image is still `processing`.
+- Retry/reprocess only after the item has moved to `failed`.
+- `WORKER_TIMEOUT` controls the analysis job timeout. After the recovery flow marks an abandoned item as `failed`, the existing retry/reprocess action can be used.
+
 ### Slow first run
 
 - Model downloads happen on the first startup of the full stack.


### PR DESCRIPTION
## Summary

Added troubleshooting documentation for images that appear stuck in `processing`. This explains what `processing` means in the current worker flow and what users should inspect before retrying.

Fixes #128

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Documentation update
- [ ] Refactor
- [ ] CI / tooling

## What changed

- Added a Troubleshooting subsection for images stuck in `processing`
- Documented worker health checks, worker logs, retry guidance, and pending timeout behavior after the recovery flow is implemented

## Screenshots / recordings (for UI changes)

Not applicable. This is a documentation-only change.

## How to test

Docs-only change; verified README renders correctly and the troubleshooting section is not duplicated.

## Checklist

- [x] I linked the related issue
- [ ] I ran required checks from CONTRIBUTING.md
- [x] I updated docs/env notes if needed
- [x] My PR is scoped to a single issue
- [x] I followed commit message conventions
- [x] I am not committing secrets or local artifacts

## GSSoC'26 checklist

- [x] I requested issue assignment before starting
- [x] I have meaningful commits (no spam commits)
- [x] I am ready to explain my implementation in review comments

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive troubleshooting guide for images stuck in processing state, including explanation of the processing workflow, diagnostic checklist for system health verification, and recovery procedures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Abhash-Chakraborty/Find/pull/137?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->