### PR TITLE
Fix: refresh expired MinIO preview URLs before images break (#22)

### DIFF
--- a/frontend/src/app/clusters/page.tsx
+++ b/frontend/src/app/clusters/page.tsx
@@ -59,13 +59,16 @@ export default function ClustersPage() {
   const { data, isLoading, error, isFetching } = useQuery({
     queryKey: ["clusters"],
     queryFn: getClusters,
-    refetchInterval: clusterJobId ? 4000 : 10000,
+    refetchInterval: clusterJobId ? 4000 : 1000 * 60 * 50,
+    staleTime: 1000 * 60 * 45,
   });
 
   const selectedClusterQuery = useQuery({
     queryKey: ["cluster-detail", selectedClusterId],
     queryFn: () => getClusterDetail(selectedClusterId as number),
     enabled: selectedClusterId !== null,
+    staleTime: 1000 * 60 * 45,
+    refetchInterval: 1000 * 60 * 50,
   });
 
   const clusterJobQuery = useQuery({

--- a/frontend/src/app/clusters/page.tsx
+++ b/frontend/src/app/clusters/page.tsx
@@ -17,7 +17,11 @@ import {
   getJobStatus,
   triggerClustering,
 } from "@/lib/api";
-import { resolveMediaUrl } from "@/lib/media";
+import {
+  MINIO_URL_REFRESH_INTERVAL_MS,
+  MINIO_URL_STALE_TIME_MS,
+  resolveMediaUrl,
+} from "@/lib/media";
 
 function formatJobStatus(status?: string) {
   switch (status) {
@@ -59,16 +63,16 @@ export default function ClustersPage() {
   const { data, isLoading, error, isFetching } = useQuery({
     queryKey: ["clusters"],
     queryFn: getClusters,
-    refetchInterval: clusterJobId ? 4000 : 1000 * 60 * 50,
-    staleTime: 1000 * 60 * 45,
+    refetchInterval: clusterJobId ? 4000 : 10000,
+    staleTime: MINIO_URL_STALE_TIME_MS,
   });
 
   const selectedClusterQuery = useQuery({
     queryKey: ["cluster-detail", selectedClusterId],
     queryFn: () => getClusterDetail(selectedClusterId as number),
     enabled: selectedClusterId !== null,
-    staleTime: 1000 * 60 * 45,
-    refetchInterval: 1000 * 60 * 50,
+    staleTime: MINIO_URL_STALE_TIME_MS,
+    refetchInterval: MINIO_URL_REFRESH_INTERVAL_MS,
   });
 
   const clusterJobQuery = useQuery({

--- a/frontend/src/app/gallery/page.tsx
+++ b/frontend/src/app/gallery/page.tsx
@@ -174,6 +174,7 @@ function GalleryPageContent() {
         liked: likedOnly ? true : undefined,
       }),
     placeholderData: (previous) => previous,
+    staleTime: 1000 * 60 * 45, // 45 minutes to refresh before 1hr MinIO expiry
     refetchInterval: (query) => {
       const gallery = query.state.data as GalleryResponse | undefined;
 
@@ -181,7 +182,7 @@ function GalleryPageContent() {
         (item) => item.status === "processing" || item.status === "pending",
       )
         ? 5000
-        : false;
+        : 1000 * 60 * 50; // 50 minutes fallback
     },
   });
 

--- a/frontend/src/app/gallery/page.tsx
+++ b/frontend/src/app/gallery/page.tsx
@@ -31,7 +31,11 @@ import {
   reprocessImage,
   toggleLike,
 } from "@/lib/api";
-import { resolveMediaUrl } from "@/lib/media";
+import {
+  MINIO_URL_REFRESH_INTERVAL_MS,
+  MINIO_URL_STALE_TIME_MS,
+  resolveMediaUrl,
+} from "@/lib/media";
 
 type GalleryFilter = "all" | "indexed" | "processing" | "failed";
 
@@ -174,7 +178,7 @@ function GalleryPageContent() {
         liked: likedOnly ? true : undefined,
       }),
     placeholderData: (previous) => previous,
-    staleTime: 1000 * 60 * 45, // 45 minutes to refresh before 1hr MinIO expiry
+    staleTime: MINIO_URL_STALE_TIME_MS,
     refetchInterval: (query) => {
       const gallery = query.state.data as GalleryResponse | undefined;
 
@@ -182,7 +186,7 @@ function GalleryPageContent() {
         (item) => item.status === "processing" || item.status === "pending",
       )
         ? 5000
-        : 1000 * 60 * 50; // 50 minutes fallback
+        : MINIO_URL_REFRESH_INTERVAL_MS;
     },
   });
 

--- a/frontend/src/app/search/page.tsx
+++ b/frontend/src/app/search/page.tsx
@@ -8,7 +8,7 @@ import {
   Search as SearchIcon,
 } from "lucide-react";
 import Image from "next/image";
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ImagePreviewModal } from "@/components/image-preview-modal";
 import { StatusIndicator } from "@/components/status-indicator";
 import { searchImages } from "@/lib/api";
@@ -30,6 +30,20 @@ export default function SearchPage() {
     mutationFn: (searchQuery: string) =>
       searchImages({ query: searchQuery, limit: 24 }),
   });
+
+  useEffect(() => {
+    const activeQuery = searchMutation.data?.query;
+    if (!activeQuery) return;
+
+    const intervalId = setInterval(
+      () => {
+        searchMutation.mutate(activeQuery);
+      },
+      1000 * 60 * 50,
+    ); // 50 mins
+
+    return () => clearInterval(intervalId);
+  }, [searchMutation.data?.query, searchMutation]);
 
   const handleSearch = (event: React.FormEvent) => {
     event.preventDefault();

--- a/frontend/src/app/search/page.tsx
+++ b/frontend/src/app/search/page.tsx
@@ -30,17 +30,18 @@ export default function SearchPage() {
     mutationFn: (searchQuery: string) =>
       searchImages({ query: searchQuery, limit: 24 }),
   });
+  const activeQuery = searchMutation.data?.query;
+  const { mutate } = searchMutation;
 
   useEffect(() => {
-    const activeQuery = searchMutation.data?.query;
     if (!activeQuery) return;
 
     const intervalId = setInterval(() => {
-      searchMutation.mutate(activeQuery);
+      mutate(activeQuery);
     }, MINIO_URL_REFRESH_INTERVAL_MS);
 
     return () => clearInterval(intervalId);
-  }, [searchMutation.data?.query, searchMutation.mutate]);
+  }, [activeQuery, mutate]);
 
   const handleSearch = (event: React.FormEvent) => {
     event.preventDefault();

--- a/frontend/src/app/search/page.tsx
+++ b/frontend/src/app/search/page.tsx
@@ -12,7 +12,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ImagePreviewModal } from "@/components/image-preview-modal";
 import { StatusIndicator } from "@/components/status-indicator";
 import { searchImages } from "@/lib/api";
-import { resolveMediaUrl } from "@/lib/media";
+import { MINIO_URL_REFRESH_INTERVAL_MS, resolveMediaUrl } from "@/lib/media";
 
 const examples = [
   "sunset over mountains",
@@ -39,11 +39,11 @@ export default function SearchPage() {
       () => {
         searchMutation.mutate(activeQuery);
       },
-      1000 * 60 * 50,
-    ); // 50 mins
+      MINIO_URL_REFRESH_INTERVAL_MS,
+    );
 
     return () => clearInterval(intervalId);
-  }, [searchMutation.data?.query, searchMutation]);
+  }, [searchMutation.data?.query, searchMutation.mutate]);
 
   const handleSearch = (event: React.FormEvent) => {
     event.preventDefault();

--- a/frontend/src/app/search/page.tsx
+++ b/frontend/src/app/search/page.tsx
@@ -35,12 +35,9 @@ export default function SearchPage() {
     const activeQuery = searchMutation.data?.query;
     if (!activeQuery) return;
 
-    const intervalId = setInterval(
-      () => {
-        searchMutation.mutate(activeQuery);
-      },
-      MINIO_URL_REFRESH_INTERVAL_MS,
-    );
+    const intervalId = setInterval(() => {
+      searchMutation.mutate(activeQuery);
+    }, MINIO_URL_REFRESH_INTERVAL_MS);
 
     return () => clearInterval(intervalId);
   }, [searchMutation.data?.query, searchMutation.mutate]);

--- a/frontend/src/components/image-preview-modal.tsx
+++ b/frontend/src/components/image-preview-modal.tsx
@@ -24,7 +24,11 @@ import {
   reprocessImage,
   toggleLike,
 } from "@/lib/api";
-import { resolveMediaUrl } from "@/lib/media";
+import {
+  MINIO_URL_REFRESH_INTERVAL_MS,
+  MINIO_URL_STALE_TIME_MS,
+  resolveMediaUrl,
+} from "@/lib/media";
 import { formatBytes, formatDate } from "@/lib/utils";
 import { StatusIndicator } from "./status-indicator";
 
@@ -95,6 +99,8 @@ export function ImagePreviewModal({
     queryKey: ["image-detail", media.id],
     queryFn: () => getImageDetail(media.id),
     enabled: media.id !== null,
+    staleTime: MINIO_URL_STALE_TIME_MS,
+    refetchInterval: MINIO_URL_REFRESH_INTERVAL_MS,
   });
 
   useEffect(() => {

--- a/frontend/src/lib/media.ts
+++ b/frontend/src/lib/media.ts
@@ -5,6 +5,9 @@ const bucket = process.env.NEXT_PUBLIC_MINIO_BUCKET ?? "images";
 const minioBaseUrl =
   process.env.NEXT_PUBLIC_MINIO_URL ?? "http://localhost:9000";
 
+export const MINIO_URL_STALE_TIME_MS = 1000 * 60 * 45; // 45 minutes
+export const MINIO_URL_REFRESH_INTERVAL_MS = 1000 * 60 * 50; // 50 minutes
+
 function buildEncodedUrl(objectKey?: string | null) {
   if (!objectKey) {
     return null;


### PR DESCRIPTION
Resolves #22. 

**Changes**:
- Added `staleTime: 45m` and `refetchInterval: 50m` to `useQuery` configurations in Gallery and Clusters pages.
- Added a targeted `useEffect` interval to automatically refresh `useMutation` search results.
- Guarantees React Query automatically fetches fresh MinIO presigned links gracefully in the background before the default 1-hour expiration limit is reached.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Clusters list refreshes more efficiently: faster updates while jobs are active and reduced polling when idle; cluster details refresh on a steady cadence.
  * Gallery refreshes more responsively while items are processing, with a lightweight background refresh when idle.
  * Search results now auto-refresh on a regular interval to keep results current.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Abhash-Chakraborty/Find/pull/156?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->