### PR TITLE
fix(backend): add thread-safe concurrent model loading with per-model locking

### DIFF
--- a/backend/src/find_api/core/model_manager.py
+++ b/backend/src/find_api/core/model_manager.py
@@ -87,7 +87,9 @@ class ModelManager:
                         logger.info(f"Model loaded successfully: {name}")
                     except Exception as e:
                         logger.exception("Failed to load model %s", name)
-                        self.failed_models[name] = e
+                        # Clear traceback to avoid retaining frame locals
+                        # in this long-lived singleton cache.
+                        self.failed_models[name] = e.with_traceback(None)
                         raise
 
         return self.models[name]

--- a/backend/src/find_api/core/model_manager.py
+++ b/backend/src/find_api/core/model_manager.py
@@ -4,6 +4,7 @@ Model Manager for efficient GPU resource management
 
 import asyncio
 import logging
+import threading
 from typing import Any, Callable, Dict
 
 logger = logging.getLogger(__name__)
@@ -30,6 +31,8 @@ class ModelManager:
         self.models: Dict[str, Any] = {}
         self.failed_models: Dict[str, Exception] = {}
         self.gpu_lock = asyncio.Lock()
+        self.lock = threading.Lock()
+        self.model_locks: Dict[str, threading.Lock] = {}
         self._initialized = True
         logger.info("ModelManager initialized with GPU Lock")
 
@@ -65,14 +68,27 @@ class ModelManager:
             raise self.failed_models[name]
 
         if name not in self.models:
-            logger.info(f"Loading model: {name}")
-            try:
-                self.models[name] = loader()
-                logger.info(f"Model loaded successfully: {name}")
-            except Exception as e:
-                logger.exception("Failed to load model %s", name)
-                self.failed_models[name] = e
-                raise
+            # Get or create the fine-grained lock for this model name
+            with self.lock:
+                if name not in self.model_locks:
+                    self.model_locks[name] = threading.Lock()
+                model_lock = self.model_locks[name]
+
+            # Acquire the model-specific lock to prevent concurrent load attempts
+            with model_lock:
+                # Double-check inside the lock
+                if name in self.failed_models:
+                    raise self.failed_models[name]
+
+                if name not in self.models:
+                    logger.info(f"Loading model: {name}")
+                    try:
+                        self.models[name] = loader()
+                        logger.info(f"Model loaded successfully: {name}")
+                    except Exception as e:
+                        logger.exception("Failed to load model %s", name)
+                        self.failed_models[name] = e
+                        raise
 
         return self.models[name]
 

--- a/backend/src/find_api/core/model_manager.py
+++ b/backend/src/find_api/core/model_manager.py
@@ -28,6 +28,7 @@ class ModelManager:
             return
 
         self.models: Dict[str, Any] = {}
+        self.failed_models: Dict[str, Exception] = {}
         self.gpu_lock = asyncio.Lock()
         self._initialized = True
         logger.info("ModelManager initialized with GPU Lock")
@@ -56,13 +57,21 @@ class ModelManager:
         Returns:
             The model instance
         """
+        if name in self.failed_models:
+            logger.warning(
+                "Model %s previously failed to load. Raising cached exception to avoid retries.",
+                name,
+            )
+            raise self.failed_models[name]
+
         if name not in self.models:
             logger.info(f"Loading model: {name}")
             try:
                 self.models[name] = loader()
                 logger.info(f"Model loaded successfully: {name}")
-            except Exception:
+            except Exception as e:
                 logger.exception("Failed to load model %s", name)
+                self.failed_models[name] = e
                 raise
 
         return self.models[name]

--- a/backend/tests/test_model_manager.py
+++ b/backend/tests/test_model_manager.py
@@ -81,3 +81,92 @@ def test_multiple_models_isolated(fresh_model_manager):
     good_model_cached = fresh_model_manager.get_model("model-good", success_loader)
     assert good_model_cached == "good-model"
     success_loader.assert_not_called()
+
+
+def test_get_model_concurrent_loading(fresh_model_manager):
+    """Verify that concurrent threads loading the same model only trigger the loader once and receive the same instance."""
+    import threading
+    import time
+
+    call_count = 0
+    call_count_lock = threading.Lock()
+
+    def slow_loader():
+        nonlocal call_count
+        time.sleep(0.05)  # stretch race condition window
+        with call_count_lock:
+            call_count += 1
+        return "concurrent-success-model"
+
+    results = []
+    threads = []
+    barrier = threading.Barrier(10)
+
+    def worker():
+        barrier.wait()  # lock-step trigger
+        try:
+            model = fresh_model_manager.get_model("concurrent-model", slow_loader)
+            results.append((model, None))
+        except Exception as e:
+            results.append((None, e))
+
+    for _ in range(10):
+        t = threading.Thread(target=worker)
+        threads.append(t)
+        t.start()
+
+    for t in threads:
+        t.join()
+
+    assert len(results) == 10
+    for model, err in results:
+        assert err is None
+        assert model == "concurrent-success-model"
+
+    # Loader must be called exactly once
+    assert call_count == 1
+
+
+def test_get_model_concurrent_failure(fresh_model_manager):
+    """Verify that concurrent threads loading a failing model only trigger the loader once and all raise the same cached exception."""
+    import threading
+    import time
+
+    call_count = 0
+    call_count_lock = threading.Lock()
+
+    def slow_failing_loader():
+        nonlocal call_count
+        time.sleep(0.05)  # stretch race condition window
+        with call_count_lock:
+            call_count += 1
+        raise RuntimeError("Fatal loading failure")
+
+    results = []
+    threads = []
+    barrier = threading.Barrier(10)
+
+    def worker():
+        barrier.wait()  # lock-step trigger
+        try:
+            fresh_model_manager.get_model("concurrent-fail-model", slow_failing_loader)
+            results.append((True, None))
+        except Exception as e:
+            results.append((False, e))
+
+    for _ in range(10):
+        t = threading.Thread(target=worker)
+        threads.append(t)
+        t.start()
+
+    for t in threads:
+        t.join()
+
+    assert len(results) == 10
+    for success, err in results:
+        assert not success
+        assert isinstance(err, RuntimeError)
+        assert str(err) == "Fatal loading failure"
+
+    # Failing loader must be executed exactly once
+    assert call_count == 1

--- a/backend/tests/test_model_manager.py
+++ b/backend/tests/test_model_manager.py
@@ -1,0 +1,83 @@
+import pytest
+from unittest.mock import MagicMock
+from find_api.core.model_manager import ModelManager, get_model_manager
+
+
+@pytest.fixture
+def fresh_model_manager():
+    """Provide a fresh instance of ModelManager for each test.
+
+    Since ModelManager is a singleton, we temporarily bypass the singleton instance
+    creation in the fixture to ensure a completely clean state.
+    """
+    # Create a new instance bypassing the singleton cache in __new__
+    manager = object.__new__(ModelManager)
+    manager._initialized = False
+    manager.__init__()
+    return manager
+
+
+def test_model_manager_singleton():
+    """Verify that ModelManager behaves as a singleton under normal usage."""
+    m1 = get_model_manager()
+    m2 = get_model_manager()
+    assert m1 is m2
+
+
+def test_get_model_success(fresh_model_manager):
+    """Verify that a successful model loader caches and returns the model correctly."""
+    loader_mock = MagicMock(return_value="fake-florence-model")
+
+    # First call: invokes loader
+    model = fresh_model_manager.get_model("test-model", loader_mock)
+    assert model == "fake-florence-model"
+    loader_mock.assert_called_once()
+
+    # Second call: returns cached model without calling loader again
+    loader_mock.reset_mock()
+    model_cached = fresh_model_manager.get_model("test-model", loader_mock)
+    assert model_cached == "fake-florence-model"
+    loader_mock.assert_not_called()
+
+
+def test_get_model_failure_caches_exception(fresh_model_manager):
+    """Verify that a failing model loader caches the exception and raises it on retries."""
+    loader_mock = MagicMock(side_effect=RuntimeError("CUDA OOM or loading error"))
+
+    # First call: raises the exception and caches it
+    with pytest.raises(RuntimeError, match="CUDA OOM or loading error"):
+        fresh_model_manager.get_model("failing-model", loader_mock)
+    loader_mock.assert_called_once()
+
+    # Second call: raises the same exception without executing loader again
+    loader_mock.reset_mock()
+    with pytest.raises(RuntimeError, match="CUDA OOM or loading error"):
+        fresh_model_manager.get_model("failing-model", loader_mock)
+    loader_mock.assert_not_called()
+
+
+def test_multiple_models_isolated(fresh_model_manager):
+    """Verify that multiple models have isolated loading, caching, and error states."""
+    success_loader = MagicMock(return_value="good-model")
+    fail_loader = MagicMock(side_effect=ValueError("Invalid configuration"))
+
+    # Load failing model
+    with pytest.raises(ValueError, match="Invalid configuration"):
+        fresh_model_manager.get_model("model-bad", fail_loader)
+
+    # Load successful model (should load fine, isolated from the failed model)
+    good_model = fresh_model_manager.get_model("model-good", success_loader)
+    assert good_model == "good-model"
+    success_loader.assert_called_once()
+
+    # Re-access failing model (should raise cached exception, no load attempt)
+    fail_loader.reset_mock()
+    with pytest.raises(ValueError, match="Invalid configuration"):
+        fresh_model_manager.get_model("model-bad", fail_loader)
+    fail_loader.assert_not_called()
+
+    # Re-access successful model (should return cached model, no load attempt)
+    success_loader.reset_mock()
+    good_model_cached = fresh_model_manager.get_model("model-good", success_loader)
+    assert good_model_cached == "good-model"
+    success_loader.assert_not_called()


### PR DESCRIPTION
## Summary

Closes #194

### Problem

\ModelManager.get_model()\ has two concurrency issues:

1. **No failure caching** (fixed in first commit): When a model fails to load (e.g. CUDA OOM, incompatible hardware), every subsequent call re-invokes the expensive \loader()\, wasting CPU and memory on doomed retries.

2. **Race condition on concurrent loads** (fixed in second commit): When multiple worker threads call \get_model()\ for the same unloaded model simultaneously, there is a race window where **every thread executes the expensive \loader()\ function**. On a 4 GB VRAM GPU this causes redundant CUDA allocations leading to OOM crashes.

### Fix

#### Commit 1: Cache failed model loads
- Added \self.failed_models\ dict to cache exceptions from failed \loader()\ calls
- Subsequent calls for a failed model immediately raise the cached exception without retrying

#### Commit 2: Thread-safe double-checked locking
- Added **per-model fine-grained locking** with a double-checked locking pattern
- A lightweight main \	hreading.Lock\ guards creation of per-model locks in \self.model_locks\
- Each model name gets its own \	hreading.Lock\, so loading model A never blocks loading model B
- Inside the model-specific lock, both \self.failed_models\ and \self.models\ are re-checked before invoking \loader()\
- After the first thread completes (success or failure), all queued threads immediately read from cache

### Changes

| File | What changed |
|------|-------------|
| \ackend/src/find_api/core/model_manager.py\ | Added \	hreading\ import, \self.lock\, \self.model_locks\ dict, double-checked locking in \get_model()\, and \self.failed_models\ exception cache |
| \ackend/tests/test_model_manager.py\ | Added 6 tests: singleton behavior, success caching, failure caching, multi-model isolation, and **2 multi-threaded stress tests** using \	hreading.Barrier(10)\ to verify loader is called exactly once under concurrent access |

### Testing

All 6 tests pass:

\\\
tests/test_model_manager.py ......    [100%]
======================== 6 passed in 0.13s ========================
\\\

### Design notes

- **Zero API surface change**: \get_model(name, loader)\ signature is unchanged - all callers (\captioner.py\, \clip_embedder.py\, \ace_detector.py\, \object_detector.py\, \ocr.py\) work without modification
- **Fine-grained, not global**: Different models load in parallel; only same-name concurrent loads are serialized
- **No new dependencies**: Uses only \	hreading\ from the Python standard library