### PR TITLE
ci: enforce PR issue ownership triage gate

### DIFF
--- a/.github/workflows/pr-triage.yml
+++ b/.github/workflows/pr-triage.yml
@@ -16,10 +16,13 @@ jobs:
           script: |
             const NEEDS_LINKED_ISSUE_LABEL = "needs linked issue";
             const DO_NOT_MERGE_LABEL = "do-not-merge";
+            const DEPENDENCIES_LABEL = "dependencies";
+            const MAX_LINKED_ISSUES_TO_CHECK = 10;
 
             const pr = context.payload.pull_request;
             const body = pr.body || "";
             const prAuthor = pr.user?.login;
+            const isDependabot = prAuthor === "dependabot[bot]";
 
             // Always gate new/updated PRs until maintainers explicitly remove it.
             await github.rest.issues.addLabels({
@@ -28,10 +31,33 @@ jobs:
               labels: [DO_NOT_MERGE_LABEL],
             });
 
+            // Dependabot PRs normally do not have project issues attached.
+            // Keep them gated for maintainer review, but do not mark them as missing an issue.
+            if (isDependabot) {
+              await github.rest.issues.addLabels({
+                ...context.repo,
+                issue_number: pr.number,
+                labels: [DEPENDENCIES_LABEL],
+              });
+
+              try {
+                await github.rest.issues.removeLabel({
+                  ...context.repo,
+                  issue_number: pr.number,
+                  name: NEEDS_LINKED_ISSUE_LABEL,
+                });
+              } catch (e) {
+                if (e.status !== 404) throw e;
+              }
+
+              return;
+            }
+
             // Parse linked issues via closing keywords, e.g. "Fixes #123".
             const matches = [...body.matchAll(/\b(?:fix|fixes|fixed|close|closes|closed|resolve|resolves|resolved)\b\s*:?\s*#(\d+)\b/gi)];
             const linkedIssueNumbers = [...new Set(matches.map((m) => Number(m[1])))]
-              .filter((n) => Number.isInteger(n) && n > 0);
+              .filter((n) => Number.isInteger(n) && n > 0)
+              .slice(0, MAX_LINKED_ISSUES_TO_CHECK);
 
             const hasLinkedIssue = linkedIssueNumbers.length > 0;
 
@@ -58,10 +84,18 @@ jobs:
             // Assign the PR only if the PR author is assigned to at least one linked issue.
             let authorAssignedToLinkedIssue = false;
             for (const issueNumber of linkedIssueNumbers) {
-              const linkedIssue = await github.rest.issues.get({
-                ...context.repo,
-                issue_number: issueNumber,
-              });
+              let linkedIssue;
+              try {
+                linkedIssue = await github.rest.issues.get({
+                  ...context.repo,
+                  issue_number: issueNumber,
+                });
+              } catch (e) {
+                if (e.status === 404) {
+                  continue;
+                }
+                throw e;
+              }
 
               const assignees = (linkedIssue.data.assignees || []).map((a) => a.login);
               if (prAuthor && assignees.includes(prAuthor)) {

--- a/.github/workflows/pr-triage.yml
+++ b/.github/workflows/pr-triage.yml
@@ -2,10 +2,9 @@ name: PR Triage
 
 on:
   pull_request_target:
-    types: [opened, edited, reopened, synchronize]
+    types: [opened, reopened, synchronize]
 
 permissions:
-  pull-requests: write
   issues: write
 
 jobs:
@@ -15,24 +14,71 @@ jobs:
       - uses: actions/github-script@v7
         with:
           script: |
-            const label = "needs linked issue";
-            const body = context.payload.pull_request.body || "";
-            const hasLink = /\b(?:fix|fixes|fixed|close|closes|closed|resolve|resolves|resolved)\b\s*:?\s*#\d+/i.test(body);
+            const NEEDS_LINKED_ISSUE_LABEL = "needs linked issue";
+            const DO_NOT_MERGE_LABEL = "do-not-merge";
 
-            if (!hasLink) {
+            const pr = context.payload.pull_request;
+            const body = pr.body || "";
+            const prAuthor = pr.user?.login;
+
+            // Always gate new/updated PRs until maintainers explicitly remove it.
+            await github.rest.issues.addLabels({
+              ...context.repo,
+              issue_number: pr.number,
+              labels: [DO_NOT_MERGE_LABEL],
+            });
+
+            // Parse linked issues via closing keywords, e.g. "Fixes #123".
+            const matches = [...body.matchAll(/\b(?:fix|fixes|fixed|close|closes|closed|resolve|resolves|resolved)\b\s*:?\s*#(\d+)\b/gi)];
+            const linkedIssueNumbers = [...new Set(matches.map((m) => Number(m[1])))]
+              .filter((n) => Number.isInteger(n) && n > 0);
+
+            const hasLinkedIssue = linkedIssueNumbers.length > 0;
+
+            if (!hasLinkedIssue) {
               await github.rest.issues.addLabels({
                 ...context.repo,
-                issue_number: context.issue.number,
-                labels: [label],
+                issue_number: pr.number,
+                labels: [NEEDS_LINKED_ISSUE_LABEL],
               });
-            } else {
-              try {
-                await github.rest.issues.removeLabel({
-                  ...context.repo,
-                  issue_number: context.issue.number,
-                  name: label,
-                });
-              } catch (e) {
-                if (e.status !== 404) throw e;
+              return;
+            }
+
+            // Keep this existing signal in sync with linked-issue detection.
+            try {
+              await github.rest.issues.removeLabel({
+                ...context.repo,
+                issue_number: pr.number,
+                name: NEEDS_LINKED_ISSUE_LABEL,
+              });
+            } catch (e) {
+              if (e.status !== 404) throw e;
+            }
+
+            // Assign the PR only if the PR author is assigned to at least one linked issue.
+            let authorAssignedToLinkedIssue = false;
+            for (const issueNumber of linkedIssueNumbers) {
+              const linkedIssue = await github.rest.issues.get({
+                ...context.repo,
+                issue_number: issueNumber,
+              });
+
+              const assignees = (linkedIssue.data.assignees || []).map((a) => a.login);
+              if (prAuthor && assignees.includes(prAuthor)) {
+                authorAssignedToLinkedIssue = true;
+                break;
               }
+            }
+
+            if (!authorAssignedToLinkedIssue || !prAuthor) {
+              return;
+            }
+
+            const currentPrAssignees = (pr.assignees || []).map((a) => a.login);
+            if (!currentPrAssignees.includes(prAuthor)) {
+              await github.rest.issues.addAssignees({
+                ...context.repo,
+                issue_number: pr.number,
+                assignees: [prAuthor],
+              });
             }

--- a/docs/pr-triage-dry-run.md
+++ b/docs/pr-triage-dry-run.md
@@ -1,0 +1,63 @@
+# PR triage automation dry-run checklist
+
+This repository uses `.github/workflows/pr-triage.yml` to enforce baseline PR ownership checks.
+
+## Trigger points
+
+The workflow runs on `pull_request_target` for:
+
+- `opened`
+- `reopened`
+- `synchronize`
+
+It intentionally does **not** run on `edited` to reduce unnecessary runs.
+
+## What it enforces
+
+1. Adds `do-not-merge` to every triggered PR event.
+2. Detects linked issues using closing keywords in PR body (`Fixes #123`, `Closes #123`, `Resolves #123`).
+3. If no linked issue is found:
+   - Adds `needs linked issue`.
+   - Does not assign the PR.
+4. If linked issue(s) exist:
+   - Removes `needs linked issue` if present.
+   - Assigns the PR to the PR author **only if** the author is assigned on at least one linked issue.
+5. Never closes PRs.
+6. Never removes `do-not-merge` automatically.
+
+## Manual verification matrix
+
+### Case A: No linked issue in PR body
+
+Expected:
+
+- `do-not-merge` is present.
+- `needs linked issue` is present.
+- PR remains open.
+- PR assignees are unchanged.
+
+### Case B: Linked issue exists and PR author is assigned on that issue
+
+Expected:
+
+- `do-not-merge` is present.
+- `needs linked issue` is absent.
+- PR remains open.
+- PR author is assigned to the PR.
+
+### Case C: Linked issue exists but PR author is **not** assigned on that issue
+
+Expected:
+
+- `do-not-merge` is present.
+- `needs linked issue` is absent.
+- PR remains open.
+- PR is **not** auto-assigned to PR author.
+
+## Permissions
+
+The workflow is scoped to minimal required permissions:
+
+- `issues: write`
+
+No source checkout is used, and no build/test jobs run in this workflow.

--- a/docs/pr-triage-dry-run.md
+++ b/docs/pr-triage-dry-run.md
@@ -22,8 +22,14 @@ It intentionally does **not** run on `edited` to reduce unnecessary runs.
 4. If linked issue(s) exist:
    - Removes `needs linked issue` if present.
    - Assigns the PR to the PR author **only if** the author is assigned on at least one linked issue.
-5. Never closes PRs.
-6. Never removes `do-not-merge` automatically.
+5. If the PR author is `dependabot[bot]`:
+   - Adds `dependencies`.
+   - Removes `needs linked issue` if present.
+   - Does not assign the PR.
+6. Ignores missing or invalid issue references instead of failing the workflow.
+7. Checks only the first 10 unique linked issue references to keep API usage bounded.
+8. Never closes PRs.
+9. Never removes `do-not-merge` automatically.
 
 ## Manual verification matrix
 
@@ -53,6 +59,24 @@ Expected:
 - `needs linked issue` is absent.
 - PR remains open.
 - PR is **not** auto-assigned to PR author.
+
+### Case D: Dependabot dependency PR
+
+Expected:
+
+- `do-not-merge` is present.
+- `dependencies` is present.
+- `needs linked issue` is absent.
+- PR remains open.
+- PR assignees are unchanged.
+
+### Case E: PR body references a missing issue
+
+Expected:
+
+- Workflow does not fail just because one referenced issue is missing.
+- Valid linked issues are still checked.
+- If no valid linked issue assigns the PR author, PR assignees are unchanged.
 
 ## Permissions
 


### PR DESCRIPTION
## Summary
- add the default `do-not-merge` label on PR open/reopen/synchronize
- keep `needs linked issue` in sync for normal contributor PRs
- assign the PR to the author only when a linked issue exists and that same author is assigned to it
- keep Dependabot PRs out of the linked-issue requirement and label them as `dependencies`
- cap linked-issue lookups and ignore missing issue references so the workflow stays reliable
- document the dry-run checklist in `docs/pr-triage-dry-run.md`

## Scope
- no GSSoC scoring labels are added by the workflow
- no PRs are closed automatically
- `do-not-merge` is never removed automatically; maintainers remove it after review
- designed to coexist with existing `needs linked issue` and issue-approval workflows

## Validation
- `git diff --check`
- workflow script smoke checks
- extracted GitHub Script syntax check with `node --check`

Closes #180
Closes #181