### PR TITLE
docs: explain mock mode vs full ML mode and when captions/search are meaningful

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,6 +44,48 @@ Use the full stack only when your change needs real ML inference:
 docker compose up --build
 ```
 
+## Mock mode vs full ML mode
+
+The light stack (`docker-compose.light.yml`) runs with `ML_MODE=mock`. The worker
+records real image dimensions and EXIF data but replaces all model outputs with
+deterministic stubs:
+
+- **Captions** — a fixed placeholder string, not a real image description.
+- **Object detection** — an empty list or static stub, not real YOLO output.
+- **OCR** — an empty string, not real PaddleOCR output.
+- **Embedding vectors** — zero-filled or seeded values of the correct shape, with no
+  semantic meaning. Search results will appear but their ranking is arbitrary.
+
+### When the light stack is enough
+
+Use `docker-compose.light.yml` (mock mode) when your change involves:
+
+- Any frontend code (UI, layout, styling, components)
+- API routing, request/response shapes, validation, or error handling
+- Upload, job-status polling, gallery, like, delete, or clustering workflow
+- Documentation, CI configuration, or contributor tooling
+
+The full data pipeline — MinIO, PostgreSQL, Redis, RQ, and the worker — still runs
+end-to-end in mock mode. You can verify that data flows correctly through the system
+without any model downloads or GPU requirements.
+
+### When the full stack is required
+
+Use `docker compose up --build` (full ML mode) when your change or bug report involves:
+
+- Caption content or quality
+- Search relevance (whether the right images rank for a query)
+- Object detection output
+- OCR accuracy
+- Clustering quality or grouping logic
+- Any change to ML model parameters or the inference pipeline
+
+> ⚠️ **Do not file ML quality bugs based on mock-mode observations.** Mock output is
+> intentionally fake. Any caption or search behavior you observe in mock mode is not
+> representative of real model output and will not reproduce in full mode. Confirm all
+> ML quality claims in the full stack before opening an issue.
+
+
 ### Run manually
 
 Backend:

--- a/GSSOC_CONTRIBUTOR_GUIDE.md
+++ b/GSSOC_CONTRIBUTOR_GUIDE.md
@@ -111,7 +111,7 @@ gallery rendering all work correctly.
 - Reporting or fixing clustering quality (which images group together)
 - Testing any change to ML model parameters or the inference pipeline
 
-```
+```bash
 # Full ML stack — requires NVIDIA GPU; downloads models on first run
 docker compose up --build
 ```

--- a/GSSOC_CONTRIBUTOR_GUIDE.md
+++ b/GSSOC_CONTRIBUTOR_GUIDE.md
@@ -66,6 +66,69 @@ Use light mode for:
 - Upload/gallery/search/clustering workflow changes.
 - Documentation, CI, contributor-experience, and tooling changes.
 
+## Understanding mock mode output
+
+The light stack (`docker-compose.light.yml`) is the recommended starting point for all
+GSSoC contributors because it avoids large model downloads and GPU requirements.
+However, it runs with `ML_MODE=mock`, and understanding what that means prevents a
+common class of false bug reports.
+
+### What mock mode produces
+
+When `ML_MODE=mock` is active the worker skips all ML model loading. Instead it writes:
+
+| Metadata field | Mock output |
+|---|---|
+| Caption | A fixed placeholder string — **not** a real image description |
+| Detected objects | An empty list or a static stub |
+| OCR text | An empty string |
+| Embedding vector | A zero-filled or seeded deterministic value — **no semantic content** |
+| Image dimensions | ✅ Real (read from the actual file) |
+| EXIF data | ✅ Real (read from the actual file) |
+
+Because mock embeddings carry no semantic meaning, search results in the light stack
+are meaningless. Images may appear in search results, but their order and relevance do
+not reflect real similarity to your query.
+
+### What this means for your contribution
+
+**Use the light stack freely for:**
+
+- Frontend changes — UI, layout, styling, modals, forms
+- API and routing changes
+- Upload, gallery, search, and clustering *workflow* changes (not quality)
+- Documentation, CI, and tooling changes
+
+The full data path still runs in mock mode. Files go through MinIO, PostgreSQL,
+Redis, RQ, and the worker — so you can verify that upload, job-status polling, and
+gallery rendering all work correctly.
+
+**Switch to the full stack before:**
+
+- Making any claim about caption quality or content
+- Reporting or fixing search relevance (which images appear for a query)
+- Reporting or fixing OCR accuracy
+- Reporting or fixing clustering quality (which images group together)
+- Testing any change to ML model parameters or the inference pipeline
+
+```
+# Full ML stack — requires NVIDIA GPU; downloads models on first run
+docker compose up --build
+```
+
+### The rule: no ML quality claims from mock mode
+
+> ⚠️ **Do not report caption or search quality issues observed in mock mode.**
+>
+> If you ran `docker compose -f docker-compose.light.yml up --build` and noticed that
+> captions look wrong, search returns unrelated images, or objects are not detected —
+> that is expected mock behavior and is not a bug. Open a full-stack environment and
+> reproduce the issue there before filing a report or opening a PR that claims to fix
+> ML output quality.
+
+This protects maintainer review time and prevents changes that "fix" mock artifacts
+from accidentally landing in the production ML path.
+
 ## Full setup: real ML inference
 
 Use the full stack only when your issue needs real model behavior, real captions, real object detection, real OCR, or ML performance validation.

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Find ships two runtime modes that serve different purposes. Choosing the wrong o
 
 ### Mock mode (light stack)
 
-```
+```bash
 docker compose -f docker-compose.light.yml up --build
 ```
 
@@ -140,7 +140,7 @@ Because mock vectors have no semantic content, search results are meaningless â€
 
 ### Full ML mode (full stack)
 
-```
+```bash
 docker compose up --build
 ```
 

--- a/README.md
+++ b/README.md
@@ -108,6 +108,71 @@ Light mode is deterministic but not AI-accurate:
 - Search and clustering exercise the same API/database paths using mock embeddings.
 - Use the full stack before validating real ML quality or performance.
 
+## Mock mode vs full ML mode
+
+Find ships two runtime modes that serve different purposes. Choosing the wrong one is the most common source of contributor confusion.
+
+### Mock mode (light stack)
+
+```
+docker compose -f docker-compose.light.yml up --build
+```
+
+`ML_MODE=mock` is set automatically. The worker skips all model loading and instead records:
+
+| Field | What you get |
+|---|---|
+| Caption | A fixed placeholder string (e.g. `"mock caption"`) |
+| Detected objects | An empty list or a static stub |
+| OCR text | An empty string |
+| Embedding vector | A zero-filled or seeded deterministic vector of the correct dimension |
+| EXIF / dimensions | **Real values** extracted from the actual image file |
+
+Because mock vectors have no semantic content, search results are meaningless — results may appear but their ranking is arbitrary and does not reflect real image similarity.
+
+**Mock mode is the right choice when you are working on:**
+
+- Frontend UI, layout, or styling
+- API routing, request/response shapes, or error handling
+- Upload, job-status polling, gallery, or delete/like flows
+- Clustering pipeline logic (not cluster quality)
+- Documentation, CI, or contributor-tooling changes
+
+### Full ML mode (full stack)
+
+```
+docker compose up --build
+```
+
+The worker loads Florence-2 (captioning), YOLOv10 (object detection), PaddleOCR (text extraction), and SigLIP via `open-clip` (semantic embeddings). All metadata and vectors reflect real model output.
+
+**Full ML mode is required when you are working on or reporting:**
+
+- Caption quality or wording
+- Search relevance — whether the right images appear for a query
+- Object detection accuracy
+- OCR output correctness
+- Clustering quality (which images group together)
+- Any ML model parameter or pipeline change
+
+> ⚠️ **Do not report caption or search quality issues observed in mock mode.** Mock output is intentionally fake and will not reproduce in production. Always reproduce ML-quality claims in full mode before filing a bug.
+
+### Quick reference
+
+| Task | Use light stack? | Use full stack? |
+|---|---|---|
+| UI fix or new component | ✅ Yes | Not needed |
+| API endpoint change | ✅ Yes | Not needed |
+| Upload / gallery / clusters flow | ✅ Yes | Not needed |
+| Docs / CI / tooling | ✅ Yes | Not needed |
+| Caption looks wrong | ❌ No | ✅ Required |
+| Search returns bad results | ❌ No | ✅ Required |
+| OCR missed text | ❌ No | ✅ Required |
+| ML pipeline performance | ❌ No | ✅ Required |
+
+First run of the full stack downloads Florence-2, SigLIP, PaddleOCR, and YOLO weights (several GB). Models are cached in the `model_cache` Docker volume and reused on subsequent runs.
+
+
 ### Option C: local development without Docker
 
 #### Prerequisites


### PR DESCRIPTION
Fixes #92

## What changed
Added a clear explanation of mock mode vs full ML mode across the three suggested doc files:

- **README.md** — Added a new `## Mock mode vs full ML mode` section after Option B (fast contributor mode). Includes a table of what mock mode actually writes per field, a when-to-use-which-stack guide, and a quick reference table.

- **CONTRIBUTING.md** — Added a `## Mock mode vs full ML mode` section explaining what mock output looks like and explicitly warning contributors not to file ML quality bugs based on mock-mode observations.

- **GSSOC_CONTRIBUTOR_GUIDE.md** — Added a `## Understanding mock mode output` section targeted at beginner contributors, with a detailed breakdown of mock vs real output and a clear rule about not reporting caption/search quality issues from mock mode.

## Why
Contributors running the light stack were mistaking deterministic fake metadata and mock vectors for real AI output, leading to false bug reports about caption and search quality.

## Testing
Documentation-only change. No code was modified.
- Verified all three files render correctly in VS Code preview.
- No CI checks affected beyond the docs linting pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive mock mode versus full ML mode guidance for contributors
  * Explains what outputs are stubbed in mock mode (captions, detection, OCR, embeddings)
  * Clarifies which contributions are suitable for light mode and when to use full ML stack
  * Specifies UI, API, and workflow tasks work in mock mode
  * Warns against reporting ML quality issues based on mock mode observations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Abhash-Chakraborty/Find/pull/235?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->