### PR TITLE
feat: add bulk delete for selected gallery images

### DIFF
--- a/backend/src/find_api/core/config.py
+++ b/backend/src/find_api/core/config.py
@@ -16,6 +16,8 @@ class Settings(BaseSettings):
     # API
     API_HOST: str = "0.0.0.0"
     API_PORT: int = 8000
+    # When set, DELETE /api/image/{id} requires matching X-API-Key header.
+    DELETE_API_KEY: Optional[str] = None
 
     # Database
     DATABASE_URL: str = "postgresql://find:find123@localhost:5432/find"

--- a/backend/src/find_api/core/config.py
+++ b/backend/src/find_api/core/config.py
@@ -16,9 +16,6 @@ class Settings(BaseSettings):
     # API
     API_HOST: str = "0.0.0.0"
     API_PORT: int = 8000
-    # When set, DELETE /api/image/{id} requires matching X-API-Key header.
-    DELETE_API_KEY: Optional[str] = None
-
     # Database
     DATABASE_URL: str = "postgresql://find:find123@localhost:5432/find"
 

--- a/backend/src/find_api/routers/gallery.py
+++ b/backend/src/find_api/routers/gallery.py
@@ -8,6 +8,7 @@ from typing import Literal, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import RedirectResponse
+from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 from sqlalchemy import desc
 
@@ -24,6 +25,24 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 GalleryStatus = Literal["pending", "processing", "indexed", "failed"]
+
+
+class BulkDeleteRequest(BaseModel):
+    """Request body for deleting multiple media records."""
+
+    media_ids: list[int] = Field(..., min_length=1, max_length=200)
+
+
+class BulkDeleteResponse(BaseModel):
+    """Summary of a bulk delete request."""
+
+    message: str
+    deleted_ids: list[int]
+    missing_ids: list[int]
+    failed_ids: list[int]
+    deleted_count: int
+    missing_count: int
+    failed_count: int
 
 
 def build_thumbnail_url(media_id: int) -> str:
@@ -323,32 +342,30 @@ def reprocess_image(media_id: int, db: Session = Depends(get_db)):
     return {"media_id": media_id, "job_id": job.id, "status": "queued"}
 
 
-def _remove_media_id_from_clusters(db: Session, media_id: int) -> None:
-    """Drop a deleted media id from every cluster that references it."""
+def _remove_media_ids_from_clusters(db: Session, media_ids: set[int]) -> None:
+    """Drop deleted media ids from every cluster that references them."""
+    if not media_ids:
+        return
+
     cluster_query = db.query(Cluster)
     if db.bind is not None and db.bind.dialect.name == "postgresql":
-        cluster_query = cluster_query.filter(Cluster.member_ids.any(media_id))
+        cluster_query = cluster_query.filter(
+            Cluster.member_ids.overlap(list(media_ids))
+        )
 
     for cluster in cluster_query.all():
         current_members = cluster.member_ids or []
-        if media_id not in current_members:
+        if not any(member_id in media_ids for member_id in current_members):
             continue
         cluster.member_ids = [
-            member_id for member_id in current_members if member_id != media_id
+            member_id for member_id in current_members if member_id not in media_ids
         ]
         cluster.member_count = len(cluster.member_ids)
 
 
-@router.delete("/image/{media_id}")
-def delete_image(media_id: int, db: Session = Depends(get_db)):
-    media = db.query(Media).filter(Media.id == media_id).first()
-    if not media:
-        raise HTTPException(404, "Image not found")
-
-    try:
-        delete_file(media.minio_key)
-    except Exception as exc:  # noqa: BLE001
-        raise HTTPException(500, f"Failed to delete file from storage: {exc}") from exc
+def _delete_media_files(media: Media) -> None:
+    """Delete original storage object and best-effort thumbnail object."""
+    delete_file(media.minio_key)
 
     if media.thumbnail_key:
         try:
@@ -361,11 +378,71 @@ def delete_image(media_id: int, db: Session = Depends(get_db)):
                 exc,
             )
 
+
+@router.delete("/image/{media_id}")
+def delete_image(media_id: int, db: Session = Depends(get_db)):
+    media = db.query(Media).filter(Media.id == media_id).first()
+    if not media:
+        raise HTTPException(404, "Image not found")
+
+    try:
+        _delete_media_files(media)
+    except Exception as exc:  # noqa: BLE001
+        raise HTTPException(500, f"Failed to delete file from storage: {exc}") from exc
+
     db.delete(media)
     db.flush()
 
-    _remove_media_id_from_clusters(db, media_id)
+    _remove_media_ids_from_clusters(db, {media_id})
 
     db.commit()
 
     return {"message": "Image deleted", "id": media_id}
+
+
+@router.post("/images/bulk-delete", response_model=BulkDeleteResponse)
+def bulk_delete_images(
+    request: BulkDeleteRequest,
+    db: Session = Depends(get_db),
+):
+    requested_ids = list(dict.fromkeys(request.media_ids))
+    media_rows = db.query(Media).filter(Media.id.in_(requested_ids)).all()
+    media_by_id = {media.id: media for media in media_rows}
+    missing_ids = [
+        media_id for media_id in requested_ids if media_id not in media_by_id
+    ]
+    deleted_ids: list[int] = []
+    failed_ids: list[int] = []
+
+    for media_id in requested_ids:
+        media = media_by_id.get(media_id)
+        if media is None:
+            continue
+
+        try:
+            _delete_media_files(media)
+        except Exception as exc:  # noqa: BLE001
+            failed_ids.append(media_id)
+            logger.warning(
+                "Failed to delete media %s during bulk delete: %s", media_id, exc
+            )
+            continue
+
+        db.delete(media)
+        deleted_ids.append(media_id)
+
+    if deleted_ids:
+        db.flush()
+        _remove_media_ids_from_clusters(db, set(deleted_ids))
+
+    db.commit()
+
+    return {
+        "message": "Bulk delete completed",
+        "deleted_ids": deleted_ids,
+        "missing_ids": missing_ids,
+        "failed_ids": failed_ids,
+        "deleted_count": len(deleted_ids),
+        "missing_count": len(missing_ids),
+        "failed_count": len(failed_ids),
+    }

--- a/backend/src/find_api/routers/gallery.py
+++ b/backend/src/find_api/routers/gallery.py
@@ -4,8 +4,8 @@ Gallery endpoint for browsing images
 
 import json
 import logging
-from typing import Literal, Optional
-from fastapi import APIRouter, Depends, Query, HTTPException
+from typing import Annotated, Literal, Optional
+from fastapi import APIRouter, Depends, Header, Query, HTTPException
 from fastapi.responses import RedirectResponse
 from sqlalchemy.orm import Session
 from sqlalchemy import desc
@@ -322,8 +322,37 @@ def reprocess_image(media_id: int, db: Session = Depends(get_db)):
     return {"media_id": media_id, "job_id": job.id, "status": "queued"}
 
 
+def _remove_media_id_from_clusters(db: Session, media_id: int) -> None:
+    """Drop a deleted media id from every cluster that references it."""
+    for cluster in db.query(Cluster).all():
+        current_members = cluster.member_ids or []
+        if media_id not in current_members:
+            continue
+        cluster.member_ids = [
+            member_id for member_id in current_members if member_id != media_id
+        ]
+        cluster.member_count = len(cluster.member_ids)
+
+
+def require_delete_auth(
+    x_api_key: Annotated[Optional[str], Header(alias="X-API-Key")] = None,
+) -> None:
+    """Optional API-key guard for destructive deletes (off when DELETE_API_KEY unset)."""
+    required_key = settings.DELETE_API_KEY
+    if not required_key:
+        return
+    if not x_api_key:
+        raise HTTPException(status_code=401, detail="Unauthorized")
+    if x_api_key != required_key:
+        raise HTTPException(status_code=403, detail="Forbidden")
+
+
 @router.delete("/image/{media_id}")
-def delete_image(media_id: int, db: Session = Depends(get_db)):
+def delete_image(
+    media_id: int,
+    db: Session = Depends(get_db),
+    _: None = Depends(require_delete_auth),
+):
     media = db.query(Media).filter(Media.id == media_id).first()
     if not media:
         raise HTTPException(404, "Image not found")
@@ -347,14 +376,7 @@ def delete_image(media_id: int, db: Session = Depends(get_db)):
     db.delete(media)
     db.flush()
 
-    clusters = db.query(Cluster).filter(Cluster.member_ids.contains([media_id])).all()
-    for cluster in clusters:
-        current_members = cluster.member_ids or []
-        if media_id in current_members:
-            cluster.member_ids = [
-                member_id for member_id in current_members if member_id != media_id
-            ]
-            cluster.member_count = len(cluster.member_ids)
+    _remove_media_id_from_clusters(db, media_id)
 
     db.commit()
 

--- a/backend/src/find_api/routers/gallery.py
+++ b/backend/src/find_api/routers/gallery.py
@@ -4,8 +4,9 @@ Gallery endpoint for browsing images
 
 import json
 import logging
-from typing import Annotated, Literal, Optional
-from fastapi import APIRouter, Depends, Header, Query, HTTPException
+from typing import Literal, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import RedirectResponse
 from sqlalchemy.orm import Session
 from sqlalchemy import desc
@@ -324,7 +325,11 @@ def reprocess_image(media_id: int, db: Session = Depends(get_db)):
 
 def _remove_media_id_from_clusters(db: Session, media_id: int) -> None:
     """Drop a deleted media id from every cluster that references it."""
-    for cluster in db.query(Cluster).all():
+    cluster_query = db.query(Cluster)
+    if db.bind is not None and db.bind.dialect.name == "postgresql":
+        cluster_query = cluster_query.filter(Cluster.member_ids.any(media_id))
+
+    for cluster in cluster_query.all():
         current_members = cluster.member_ids or []
         if media_id not in current_members:
             continue
@@ -334,25 +339,8 @@ def _remove_media_id_from_clusters(db: Session, media_id: int) -> None:
         cluster.member_count = len(cluster.member_ids)
 
 
-def require_delete_auth(
-    x_api_key: Annotated[Optional[str], Header(alias="X-API-Key")] = None,
-) -> None:
-    """Optional API-key guard for destructive deletes (off when DELETE_API_KEY unset)."""
-    required_key = settings.DELETE_API_KEY
-    if not required_key:
-        return
-    if not x_api_key:
-        raise HTTPException(status_code=401, detail="Unauthorized")
-    if x_api_key != required_key:
-        raise HTTPException(status_code=403, detail="Forbidden")
-
-
 @router.delete("/image/{media_id}")
-def delete_image(
-    media_id: int,
-    db: Session = Depends(get_db),
-    _: None = Depends(require_delete_auth),
-):
+def delete_image(media_id: int, db: Session = Depends(get_db)):
     media = db.query(Media).filter(Media.id == media_id).first()
     if not media:
         raise HTTPException(404, "Image not found")

--- a/backend/tests/test_gallery.py
+++ b/backend/tests/test_gallery.py
@@ -303,3 +303,77 @@ class TestDeleteImage:
         assert cluster.member_ids == [first.id, third.id]
         assert cluster.member_count == 2
         assert db.query(Media).filter(Media.id == second.id).first() is None
+
+
+class TestBulkDeleteImages:
+    """POST /api/images/bulk-delete"""
+
+    def test_bulk_delete_removes_rows_storage_and_cluster_members(self, client, db):
+        first = _seed(db, filename="bulk-a.jpg", status="indexed")
+        second = _seed(db, filename="bulk-b.jpg", status="indexed")
+        third = _seed(db, filename="bulk-c.jpg", status="indexed")
+        cluster = _seed_cluster(db, member_ids=[first.id, second.id, third.id])
+
+        with patch("find_api.routers.gallery.delete_file") as mock_delete_file:
+            response = client.post(
+                "/api/images/bulk-delete",
+                json={"media_ids": [first.id, second.id]},
+            )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["deleted_ids"] == [first.id, second.id]
+        assert body["deleted_count"] == 2
+        assert body["missing_ids"] == []
+        assert body["failed_ids"] == []
+        assert db.query(Media).filter(Media.id.in_([first.id, second.id])).all() == []
+        db.refresh(cluster)
+        assert cluster.member_ids == [third.id]
+        assert cluster.member_count == 1
+        mock_delete_file.assert_any_call(first.minio_key)
+        mock_delete_file.assert_any_call(first.thumbnail_key)
+        mock_delete_file.assert_any_call(second.minio_key)
+        mock_delete_file.assert_any_call(second.thumbnail_key)
+
+    def test_bulk_delete_reports_missing_ids_without_failing_valid_deletes(
+        self, client, db
+    ):
+        media = _seed(db, filename="bulk-existing.jpg", status="indexed")
+
+        with patch("find_api.routers.gallery.delete_file"):
+            response = client.post(
+                "/api/images/bulk-delete",
+                json={"media_ids": [media.id, 99999]},
+            )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["deleted_ids"] == [media.id]
+        assert body["missing_ids"] == [99999]
+        assert body["failed_ids"] == []
+        assert db.query(Media).filter(Media.id == media.id).first() is None
+
+    def test_bulk_delete_reports_storage_failures_and_keeps_failed_rows(
+        self, client, db
+    ):
+        first = _seed(db, filename="bulk-fail-a.jpg", status="indexed")
+        second = _seed(db, filename="bulk-fail-b.jpg", status="indexed")
+
+        def fail_first_delete(key: str) -> None:
+            if key == first.minio_key:
+                raise RuntimeError("storage unavailable")
+
+        with patch(
+            "find_api.routers.gallery.delete_file", side_effect=fail_first_delete
+        ):
+            response = client.post(
+                "/api/images/bulk-delete",
+                json={"media_ids": [first.id, second.id]},
+            )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["deleted_ids"] == [second.id]
+        assert body["failed_ids"] == [first.id]
+        assert db.query(Media).filter(Media.id == first.id).first() is not None
+        assert db.query(Media).filter(Media.id == second.id).first() is None

--- a/backend/tests/test_gallery.py
+++ b/backend/tests/test_gallery.py
@@ -1,9 +1,11 @@
-"""Tests for GET /api/gallery — response shape and status/liked filtering."""
+"""Tests for gallery endpoints — list/detail/delete and related behavior."""
 
 import hashlib
 from datetime import datetime, timezone
 from unittest.mock import patch
 
+from find_api.core.config import settings
+from find_api.models.cluster import Cluster
 from find_api.models.media import Media
 
 
@@ -31,6 +33,21 @@ def _seed(db, *, filename, status, liked=False, metadata_json=None):
     db.commit()
     db.refresh(media)
     return media
+
+
+def _seed_cluster(db, *, member_ids: list[int]) -> Cluster:
+    cluster = Cluster(
+        cluster_type="general",
+        member_ids=member_ids,
+        member_count=len(member_ids),
+        label="Test cluster",
+        description="Cluster used in tests",
+        created_at=datetime.now(timezone.utc),
+    )
+    db.add(cluster)
+    db.commit()
+    db.refresh(cluster)
+    return cluster
 
 
 class TestGalleryResponseShape:
@@ -250,3 +267,81 @@ class TestGalleryFiltering:
         assert body["total"] == 5
         assert len(body["items"]) == 2
         assert body["skip"] == 2
+
+
+class TestDeleteImage:
+    """DELETE /api/image/{media_id}"""
+
+    def test_delete_success_removes_db_row_and_minio_objects(self, client, db):
+        media = _seed(db, filename="delete-me.jpg", status="indexed")
+
+        with patch("find_api.routers.gallery.delete_file") as mock_delete_file:
+            response = client.delete(f"/api/image/{media.id}")
+
+        assert response.status_code == 200
+        assert response.json() == {"message": "Image deleted", "id": media.id}
+        assert db.query(Media).filter(Media.id == media.id).first() is None
+        mock_delete_file.assert_any_call(media.minio_key)
+        mock_delete_file.assert_any_call(media.thumbnail_key)
+
+    def test_delete_not_found_returns_404(self, client):
+        response = client.delete("/api/image/99999")
+
+        assert response.status_code == 404
+        assert response.json()["detail"] == "Image not found"
+
+    def test_delete_updates_cluster_member_ids(self, client, db):
+        first = _seed(db, filename="cluster-a.jpg", status="indexed")
+        second = _seed(db, filename="cluster-b.jpg", status="indexed")
+        third = _seed(db, filename="cluster-c.jpg", status="indexed")
+        cluster = _seed_cluster(db, member_ids=[first.id, second.id, third.id])
+
+        response = client.delete(f"/api/image/{second.id}")
+
+        assert response.status_code == 200
+        db.refresh(cluster)
+        assert cluster.member_ids == [first.id, third.id]
+        assert cluster.member_count == 2
+        assert db.query(Media).filter(Media.id == second.id).first() is None
+
+    def test_delete_unauthorized_without_api_key_when_configured(
+        self, client, db, monkeypatch
+    ):
+        monkeypatch.setattr(settings, "DELETE_API_KEY", "test-delete-key")
+        media = _seed(db, filename="protected.jpg", status="indexed")
+
+        response = client.delete(f"/api/image/{media.id}")
+
+        assert response.status_code == 401
+        assert response.json()["detail"] == "Unauthorized"
+        assert db.query(Media).filter(Media.id == media.id).first() is not None
+
+    def test_delete_forbidden_with_invalid_api_key_when_configured(
+        self, client, db, monkeypatch
+    ):
+        monkeypatch.setattr(settings, "DELETE_API_KEY", "test-delete-key")
+        media = _seed(db, filename="protected-2.jpg", status="indexed")
+
+        response = client.delete(
+            f"/api/image/{media.id}",
+            headers={"X-API-Key": "wrong-key"},
+        )
+
+        assert response.status_code == 403
+        assert response.json()["detail"] == "Forbidden"
+        assert db.query(Media).filter(Media.id == media.id).first() is not None
+
+    def test_delete_succeeds_with_valid_api_key_when_configured(
+        self, client, db, monkeypatch
+    ):
+        monkeypatch.setattr(settings, "DELETE_API_KEY", "test-delete-key")
+        media = _seed(db, filename="protected-3.jpg", status="indexed")
+
+        with patch("find_api.routers.gallery.delete_file"):
+            response = client.delete(
+                f"/api/image/{media.id}",
+                headers={"X-API-Key": "test-delete-key"},
+            )
+
+        assert response.status_code == 200
+        assert db.query(Media).filter(Media.id == media.id).first() is None

--- a/backend/tests/test_gallery.py
+++ b/backend/tests/test_gallery.py
@@ -4,7 +4,6 @@ import hashlib
 from datetime import datetime, timezone
 from unittest.mock import patch
 
-from find_api.core.config import settings
 from find_api.models.cluster import Cluster
 from find_api.models.media import Media
 
@@ -296,52 +295,11 @@ class TestDeleteImage:
         third = _seed(db, filename="cluster-c.jpg", status="indexed")
         cluster = _seed_cluster(db, member_ids=[first.id, second.id, third.id])
 
-        response = client.delete(f"/api/image/{second.id}")
+        with patch("find_api.routers.gallery.delete_file"):
+            response = client.delete(f"/api/image/{second.id}")
 
         assert response.status_code == 200
         db.refresh(cluster)
         assert cluster.member_ids == [first.id, third.id]
         assert cluster.member_count == 2
         assert db.query(Media).filter(Media.id == second.id).first() is None
-
-    def test_delete_unauthorized_without_api_key_when_configured(
-        self, client, db, monkeypatch
-    ):
-        monkeypatch.setattr(settings, "DELETE_API_KEY", "test-delete-key")
-        media = _seed(db, filename="protected.jpg", status="indexed")
-
-        response = client.delete(f"/api/image/{media.id}")
-
-        assert response.status_code == 401
-        assert response.json()["detail"] == "Unauthorized"
-        assert db.query(Media).filter(Media.id == media.id).first() is not None
-
-    def test_delete_forbidden_with_invalid_api_key_when_configured(
-        self, client, db, monkeypatch
-    ):
-        monkeypatch.setattr(settings, "DELETE_API_KEY", "test-delete-key")
-        media = _seed(db, filename="protected-2.jpg", status="indexed")
-
-        response = client.delete(
-            f"/api/image/{media.id}",
-            headers={"X-API-Key": "wrong-key"},
-        )
-
-        assert response.status_code == 403
-        assert response.json()["detail"] == "Forbidden"
-        assert db.query(Media).filter(Media.id == media.id).first() is not None
-
-    def test_delete_succeeds_with_valid_api_key_when_configured(
-        self, client, db, monkeypatch
-    ):
-        monkeypatch.setattr(settings, "DELETE_API_KEY", "test-delete-key")
-        media = _seed(db, filename="protected-3.jpg", status="indexed")
-
-        with patch("find_api.routers.gallery.delete_file"):
-            response = client.delete(
-                f"/api/image/{media.id}",
-                headers={"X-API-Key": "test-delete-key"},
-            )
-
-        assert response.status_code == 200
-        assert db.query(Media).filter(Media.id == media.id).first() is None

--- a/frontend/src/__tests__/gallery-cards.test.tsx
+++ b/frontend/src/__tests__/gallery-cards.test.tsx
@@ -2,7 +2,7 @@
 // Uses Vitest and React Testing Library
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import * as api from "@/lib/api";
 import GalleryPage from "../app/gallery/page";
@@ -160,5 +160,45 @@ describe("Gallery card states (light mode)", () => {
     );
     const retryBtn = screen.getByLabelText("Retry analysis");
     expect(retryBtn).toBeInTheDocument();
+  });
+
+  it("can bulk delete selected gallery cards", async () => {
+    vi.mocked(api.getGallery).mockResolvedValue({
+      items: mockItems,
+      total: 3,
+      page: 1,
+      limit: 24,
+    });
+    vi.mocked(api.deleteImagesBulk).mockResolvedValue({
+      message: "Bulk delete completed",
+      deleted_ids: [1, 2],
+      missing_ids: [],
+      failed_ids: [],
+      deleted_count: 2,
+      missing_count: 0,
+      failed_count: 0,
+    });
+
+    renderWithClient(<GalleryPage />);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Select image1.jpg")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByLabelText("Select image1.jpg"));
+    fireEvent.click(screen.getByLabelText("Select image2.jpg"));
+    fireEvent.click(screen.getByRole("button", { name: "Delete selected" }));
+    const deleteButtons = screen.getAllByRole("button", {
+      name: "Delete selected",
+    });
+    const confirmButton = deleteButtons.at(-1);
+    if (!confirmButton) {
+      throw new Error("Expected delete confirmation button");
+    }
+    fireEvent.click(confirmButton);
+
+    await waitFor(() => {
+      expect(api.deleteImagesBulk).toHaveBeenCalledWith([1, 2]);
+    });
   });
 });

--- a/frontend/src/app/gallery/page.tsx
+++ b/frontend/src/app/gallery/page.tsx
@@ -8,6 +8,7 @@ import {
 } from "@tanstack/react-query";
 import axios from "axios";
 import {
+  Check,
   Download,
   Eye,
   Heart,
@@ -31,6 +32,7 @@ import { StatusIndicator } from "@/components/status-indicator";
 import {
   api,
   deleteImage,
+  deleteImagesBulk,
   type GalleryResponse,
   getGallery,
   getImageDetail,
@@ -169,10 +171,12 @@ const getStatusParamFromFilter = (filter: GalleryFilter): string | null => {
  */
 function GalleryPageContent() {
   const [selectedMediaId, setSelectedMediaId] = useState<number | null>(null);
+  const [selectedIds, setSelectedIds] = useState<Set<number>>(() => new Set());
   const [deleteTarget, setDeleteTarget] = useState<{
     id: number;
     filename?: string;
   } | null>(null);
+  const [bulkDeleteOpen, setBulkDeleteOpen] = useState(false);
   const [deletionError, setDeletionError] = useState<string | null>(null);
   const [hasOpenedFromQuery, setHasOpenedFromQuery] = useState(false);
   const [querySelectedItem, setQuerySelectedItem] =
@@ -231,6 +235,64 @@ function GalleryPageContent() {
   );
 
   const total = data?.pages[0]?.total ?? 0;
+  const selectedItems = useMemo(
+    () => allItems.filter((item) => selectedIds.has(item.id)),
+    [allItems, selectedIds],
+  );
+  const selectedCount = selectedIds.size;
+  const areAllVisibleSelected =
+    allItems.length > 0 && allItems.every((item) => selectedIds.has(item.id));
+
+  const removeMediaFromGalleryCache = useCallback(
+    (
+      mediaIds: Iterable<number>,
+      previousData?: InfiniteData<GalleryResponse>,
+    ) => {
+      const idsToRemove = new Set(mediaIds);
+      if (idsToRemove.size === 0) {
+        return previousData;
+      }
+
+      const source = previousData ?? data;
+      if (!source) {
+        return previousData;
+      }
+
+      return {
+        ...source,
+        pages: source.pages.map((page) => {
+          const removedFromPage = page.items.filter((item) =>
+            idsToRemove.has(item.id),
+          ).length;
+
+          return {
+            ...page,
+            items: page.items.filter((item) => !idsToRemove.has(item.id)),
+            total: Math.max(0, page.total - removedFromPage),
+          };
+        }),
+      };
+    },
+    [data],
+  );
+
+  useEffect(() => {
+    setSelectedIds((current) => {
+      if (current.size === 0) {
+        return current;
+      }
+
+      const visibleIds = new Set(allItems.map((item) => item.id));
+      const next = new Set<number>();
+      for (const mediaId of current) {
+        if (visibleIds.has(mediaId)) {
+          next.add(mediaId);
+        }
+      }
+
+      return next.size === current.size ? current : next;
+    });
+  }, [allItems]);
 
   const buildGalleryHref = useCallback(
     (nextState: { filter?: GalleryFilter; likedOnly?: boolean }) => {
@@ -331,26 +393,21 @@ function GalleryPageContent() {
       setDeletionError(null);
       await queryClient.cancelQueries({ queryKey: galleryQueryKey });
       const previousData =
-        queryClient.getQueryData<InfiniteData<GalleryResponse, number>>(
+        queryClient.getQueryData<InfiniteData<GalleryResponse>>(
           galleryQueryKey,
         );
 
-      queryClient.setQueryData<InfiniteData<GalleryResponse, number>>(
+      queryClient.setQueryData<InfiniteData<GalleryResponse>>(
         galleryQueryKey,
-        (old) => {
-          if (!old) return old;
-          return {
-            ...old,
-            pages: old.pages.map((page) => ({
-              ...page,
-              items: page.items.filter((item) => item.id !== mediaId),
-              total: Math.max(0, page.total - 1),
-            })),
-          };
-        },
+        (old) => removeMediaFromGalleryCache([mediaId], old),
       );
 
       setSelectedMediaId((current) => (current === mediaId ? null : current));
+      setSelectedIds((current) => {
+        const next = new Set(current);
+        next.delete(mediaId);
+        return next;
+      });
       return { previousData };
     },
     onError: (mutationError, _variables, context) => {
@@ -369,6 +426,70 @@ function GalleryPageContent() {
     },
     onSettled: () => {
       queryClient.invalidateQueries({ queryKey: ["gallery-infinite"] });
+      queryClient.invalidateQueries({ queryKey: ["clusters"] });
+      queryClient.invalidateQueries({ queryKey: ["people"] });
+    },
+  });
+
+  const bulkDeleteMutation = useMutation({
+    mutationFn: (mediaIds: number[]) => deleteImagesBulk(mediaIds),
+    onMutate: async (mediaIds: number[]) => {
+      setDeletionError(null);
+      await queryClient.cancelQueries({ queryKey: galleryQueryKey });
+      const previousData =
+        queryClient.getQueryData<InfiniteData<GalleryResponse>>(
+          galleryQueryKey,
+        );
+
+      queryClient.setQueryData<InfiniteData<GalleryResponse>>(
+        galleryQueryKey,
+        (old) => removeMediaFromGalleryCache(mediaIds, old),
+      );
+
+      setSelectedIds((current) => {
+        const next = new Set(current);
+        for (const mediaId of mediaIds) {
+          next.delete(mediaId);
+        }
+        return next;
+      });
+      setSelectedMediaId((current) =>
+        current !== null && mediaIds.includes(current) ? null : current,
+      );
+
+      return { previousData };
+    },
+    onError: (mutationError, _variables, context) => {
+      if (context?.previousData) {
+        queryClient.setQueryData(galleryQueryKey, context.previousData);
+      }
+
+      const message =
+        mutationError instanceof Error
+          ? mutationError.message
+          : "Failed to delete selected images. Please try again.";
+      setDeletionError(message);
+    },
+    onSuccess: (result) => {
+      if (result.failed_count > 0) {
+        toast.error(
+          `Deleted ${result.deleted_count} image${result.deleted_count === 1 ? "" : "s"}, but ${result.failed_count} failed.`,
+        );
+        return;
+      }
+
+      const missingNote =
+        result.missing_count > 0
+          ? ` (${result.missing_count} already gone)`
+          : "";
+      toast.success(
+        `Deleted ${result.deleted_count} image${result.deleted_count === 1 ? "" : "s"}${missingNote}.`,
+      );
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ["gallery-infinite"] });
+      queryClient.invalidateQueries({ queryKey: ["clusters"] });
+      queryClient.invalidateQueries({ queryKey: ["people"] });
     },
   });
 
@@ -408,32 +529,24 @@ function GalleryPageContent() {
       await queryClient.cancelQueries({ queryKey: galleryQueryKey });
 
       const previousData =
-        queryClient.getQueryData<InfiniteData<GalleryResponse, number>>(
+        queryClient.getQueryData<InfiniteData<GalleryResponse>>(
           galleryQueryKey,
         );
 
-      queryClient.setQueryData<InfiniteData<GalleryResponse, number>>(
+      queryClient.setQueryData<InfiniteData<GalleryResponse>>(
         galleryQueryKey,
-        (old) => {
-          if (!old) {
-            return old;
-          }
-
-          return {
-            ...old,
-            pages: old.pages.map((page) => ({
-              ...page,
-              items: page.items.filter((item) => item.id !== mediaId),
-              total: Math.max(0, page.total - 1),
-            })),
-          };
-        },
+        (old) => removeMediaFromGalleryCache([mediaId], old),
       );
 
       if (selectedMediaId === mediaId) {
         setSelectedMediaId(null);
         setQuerySelectedItem(null);
       }
+      setSelectedIds((current) => {
+        const next = new Set(current);
+        next.delete(mediaId);
+        return next;
+      });
 
       return { previousData };
     },
@@ -534,6 +647,40 @@ function GalleryPageContent() {
     updateGalleryParams({ likedOnly: false });
   }, [updateGalleryParams]);
 
+  const handleToggleSelection = useCallback((mediaId: number) => {
+    setSelectedIds((current) => {
+      const next = new Set(current);
+      if (next.has(mediaId)) {
+        next.delete(mediaId);
+      } else {
+        next.add(mediaId);
+      }
+      return next;
+    });
+  }, []);
+
+  const handleSelectVisible = useCallback(() => {
+    setSelectedIds((current) => {
+      const next = new Set(current);
+      for (const item of allItems) {
+        next.add(item.id);
+      }
+      return next;
+    });
+  }, [allItems]);
+
+  const handleClearSelection = useCallback(() => {
+    setSelectedIds(new Set());
+  }, []);
+
+  const handleToggleVisibleSelection = useCallback(() => {
+    if (areAllVisibleSelected) {
+      handleClearSelection();
+      return;
+    }
+    handleSelectVisible();
+  }, [areAllVisibleSelected, handleClearSelection, handleSelectVisible]);
+
   const handleToggleLike = useCallback(
     (mediaId: number) => {
       likeMutation.mutate(mediaId);
@@ -555,6 +702,17 @@ function GalleryPageContent() {
     deleteMutation.mutate(deleteTarget.id);
     setDeleteTarget(null);
   }, [deleteMutation, deleteTarget]);
+
+  const confirmBulkDelete = useCallback(() => {
+    const mediaIds = Array.from(selectedIds);
+    if (mediaIds.length === 0) {
+      setBulkDeleteOpen(false);
+      return;
+    }
+
+    bulkDeleteMutation.mutate(mediaIds);
+    setBulkDeleteOpen(false);
+  }, [bulkDeleteMutation, selectedIds]);
 
   const cancelDelete = useCallback(() => {
     setDeleteTarget(null);
@@ -663,6 +821,50 @@ function GalleryPageContent() {
 
         {allItems.length > 0 && (
           <>
+            <div className="frost-panel mb-4 flex flex-col gap-3 rounded-2xl px-4 py-3 md:flex-row md:items-center md:justify-between">
+              <div className="flex flex-wrap items-center gap-2">
+                <button
+                  type="button"
+                  onClick={handleToggleVisibleSelection}
+                  aria-pressed={areAllVisibleSelected}
+                  className="frost-button inline-flex items-center gap-2 px-3 py-2 text-xs font-medium"
+                >
+                  <Check className="h-3.5 w-3.5" />
+                  {areAllVisibleSelected ? "Clear visible" : "Select visible"}
+                </button>
+                {selectedCount > 0 && (
+                  <button
+                    type="button"
+                    onClick={handleClearSelection}
+                    className="frost-button px-3 py-2 text-xs font-medium"
+                  >
+                    Clear selection
+                  </button>
+                )}
+              </div>
+
+              <div className="flex flex-wrap items-center gap-3">
+                <span className="text-xs text-[color:var(--silver)]">
+                  {selectedCount > 0
+                    ? `${selectedCount} selected`
+                    : `${allItems.length} shown`}
+                </span>
+                <button
+                  type="button"
+                  onClick={() => setBulkDeleteOpen(true)}
+                  disabled={
+                    selectedCount === 0 ||
+                    deleteMutation.isPending ||
+                    bulkDeleteMutation.isPending
+                  }
+                  className="inline-flex items-center gap-2 rounded-full border border-[var(--red-soft)] bg-[var(--red-soft)] px-4 py-2 text-xs font-semibold text-[#ff9bab] transition hover:bg-[#ff2047]/25 disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  <Trash2 className="h-3.5 w-3.5" />
+                  Delete selected
+                </button>
+              </div>
+            </div>
+
             <div className="grid grid-cols-2 gap-3 md:grid-cols-3 lg:grid-cols-5 xl:grid-cols-6">
               {allItems.map((item) => {
                 const imageSrc = resolveMediaUrl(
@@ -673,12 +875,36 @@ function GalleryPageContent() {
                 );
                 const originalUrl = resolveMediaUrl(item.url, item.minio_key);
                 const downloadUrl = originalUrl ?? item.url ?? "";
+                const isSelected = selectedIds.has(item.id);
 
                 return (
                   <article
                     key={item.id}
-                    className="frost-panel card-hover group relative overflow-hidden rounded-2xl"
+                    className={`frost-panel card-hover group relative overflow-hidden rounded-2xl ${
+                      isSelected ? "ring-2 ring-[color:var(--blue)]" : ""
+                    }`}
                   >
+                    <button
+                      type="button"
+                      onClick={() => handleToggleSelection(item.id)}
+                      className={`absolute left-3 top-3 z-10 grid h-8 w-8 place-items-center rounded-full border backdrop-blur-md transition ${
+                        isSelected
+                          ? "border-[color:var(--blue)] bg-[color:var(--blue)] text-white"
+                          : "border-white/30 bg-black/45 text-white hover:bg-black/65"
+                      }`}
+                      aria-label={
+                        isSelected
+                          ? `Deselect ${item.filename}`
+                          : `Select ${item.filename}`
+                      }
+                      aria-pressed={isSelected}
+                    >
+                      {isSelected ? (
+                        <Check className="h-4 w-4" />
+                      ) : (
+                        <span className="h-3.5 w-3.5 rounded-full border border-current" />
+                      )}
+                    </button>
                     <button
                       type="button"
                       className="relative block aspect-square w-full overflow-hidden bg-[color:var(--surface-soft)] text-left focus:outline-none"
@@ -854,12 +1080,68 @@ function GalleryPageContent() {
           hasPrevious={selectedIndex > 0}
           hasNext={selectedIndex >= 0 && selectedIndex < allItems.length - 1}
           onDeleted={(mediaId) => {
+            queryClient.setQueryData<InfiniteData<GalleryResponse>>(
+              galleryQueryKey,
+              (old) => removeMediaFromGalleryCache([mediaId], old),
+            );
+            setSelectedIds((current) => {
+              const next = new Set(current);
+              next.delete(mediaId);
+              return next;
+            });
             if (selectedMediaId === mediaId) {
               setSelectedMediaId(null);
               setQuerySelectedItem(null);
             }
           }}
         />
+      )}
+
+      {bulkDeleteOpen && (
+        <div className="fixed inset-0 z-[60] flex items-center justify-center bg-black/80 px-4 backdrop-blur-lg">
+          <div className="frost-panel page-enter w-full max-w-md rounded-3xl p-6">
+            <h2 className="text-lg font-semibold text-[color:var(--near-white)]">
+              Delete selected images?
+            </h2>
+            <p className="mt-2 text-sm leading-6 text-[color:var(--silver)]">
+              {selectedCount} selected image{selectedCount === 1 ? "" : "s"}{" "}
+              will be permanently removed from the gallery, search results, and
+              clusters. This action cannot be undone.
+            </p>
+            {selectedItems.length > 0 && (
+              <div className="mt-4 max-h-32 overflow-y-auto rounded-2xl border border-[var(--frost)] bg-[color:var(--surface-soft)] p-3">
+                <ul className="space-y-1 text-xs text-[color:var(--silver)]">
+                  {selectedItems.slice(0, 6).map((item) => (
+                    <li key={item.id} className="truncate">
+                      {item.filename}
+                    </li>
+                  ))}
+                  {selectedItems.length > 6 && (
+                    <li>+{selectedItems.length - 6} more</li>
+                  )}
+                </ul>
+              </div>
+            )}
+            <div className="mt-6 flex justify-end gap-3">
+              <button
+                type="button"
+                onClick={() => setBulkDeleteOpen(false)}
+                className="frost-button px-4 py-2 text-sm font-medium"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={confirmBulkDelete}
+                disabled={bulkDeleteMutation.isPending}
+                className="inline-flex items-center gap-2 rounded-full border border-[var(--red-soft)] bg-[var(--red-soft)] px-4 py-2 text-sm font-medium text-[#ff9bab] transition hover:bg-[#ff2047]/25 disabled:cursor-not-allowed disabled:opacity-70"
+              >
+                <Trash2 className="h-4 w-4" />
+                {bulkDeleteMutation.isPending ? "Deleting" : "Delete selected"}
+              </button>
+            </div>
+          </div>
+        </div>
       )}
 
       {deleteTarget && (

--- a/frontend/src/app/gallery/page.tsx
+++ b/frontend/src/app/gallery/page.tsx
@@ -821,18 +821,18 @@ function GalleryPageContent() {
 
         {allItems.length > 0 && (
           <>
-            <div className="frost-panel mb-4 flex flex-col gap-3 rounded-2xl px-4 py-3 md:flex-row md:items-center md:justify-between">
-              <div className="flex flex-wrap items-center gap-2">
-                <button
-                  type="button"
-                  onClick={handleToggleVisibleSelection}
-                  aria-pressed={areAllVisibleSelected}
-                  className="frost-button inline-flex items-center gap-2 px-3 py-2 text-xs font-medium"
-                >
-                  <Check className="h-3.5 w-3.5" />
-                  {areAllVisibleSelected ? "Clear visible" : "Select visible"}
-                </button>
-                {selectedCount > 0 && (
+            {selectedCount > 0 && (
+              <div className="frost-panel mb-4 flex flex-col gap-3 rounded-2xl px-4 py-3 md:flex-row md:items-center md:justify-between">
+                <div className="flex flex-wrap items-center gap-2">
+                  <button
+                    type="button"
+                    onClick={handleToggleVisibleSelection}
+                    aria-pressed={areAllVisibleSelected}
+                    className="frost-button inline-flex items-center gap-2 px-3 py-2 text-xs font-medium"
+                  >
+                    <Check className="h-3.5 w-3.5" />
+                    {areAllVisibleSelected ? "Clear visible" : "Select visible"}
+                  </button>
                   <button
                     type="button"
                     onClick={handleClearSelection}
@@ -840,30 +840,26 @@ function GalleryPageContent() {
                   >
                     Clear selection
                   </button>
-                )}
-              </div>
+                </div>
 
-              <div className="flex flex-wrap items-center gap-3">
-                <span className="text-xs text-[color:var(--silver)]">
-                  {selectedCount > 0
-                    ? `${selectedCount} selected`
-                    : `${allItems.length} shown`}
-                </span>
-                <button
-                  type="button"
-                  onClick={() => setBulkDeleteOpen(true)}
-                  disabled={
-                    selectedCount === 0 ||
-                    deleteMutation.isPending ||
-                    bulkDeleteMutation.isPending
-                  }
-                  className="inline-flex items-center gap-2 rounded-full border border-[var(--red-soft)] bg-[var(--red-soft)] px-4 py-2 text-xs font-semibold text-[#ff9bab] transition hover:bg-[#ff2047]/25 disabled:cursor-not-allowed disabled:opacity-50"
-                >
-                  <Trash2 className="h-3.5 w-3.5" />
-                  Delete selected
-                </button>
+                <div className="flex flex-wrap items-center gap-3">
+                  <span className="text-xs text-[color:var(--silver)]">
+                    {selectedCount} selected
+                  </span>
+                  <button
+                    type="button"
+                    onClick={() => setBulkDeleteOpen(true)}
+                    disabled={
+                      deleteMutation.isPending || bulkDeleteMutation.isPending
+                    }
+                    className="inline-flex items-center gap-2 rounded-full border border-[var(--red-soft)] bg-[var(--red-soft)] px-4 py-2 text-xs font-semibold text-[#ff9bab] transition hover:bg-[#ff2047]/25 disabled:cursor-not-allowed disabled:opacity-50"
+                  >
+                    <Trash2 className="h-3.5 w-3.5" />
+                    Delete selected
+                  </button>
+                </div>
               </div>
-            </div>
+            )}
 
             <div className="grid grid-cols-2 gap-3 md:grid-cols-3 lg:grid-cols-5 xl:grid-cols-6">
               {allItems.map((item) => {

--- a/frontend/src/components/image-preview-modal.tsx
+++ b/frontend/src/components/image-preview-modal.tsx
@@ -292,6 +292,7 @@ export function ImagePreviewModal({
       setLikedOverride(liked);
       onLikedChange?.(id, liked);
       queryClient.invalidateQueries({ queryKey: ["gallery"] });
+      queryClient.invalidateQueries({ queryKey: ["gallery-infinite"] });
       queryClient.invalidateQueries({ queryKey: ["image-detail", id] });
     },
   });
@@ -300,7 +301,9 @@ export function ImagePreviewModal({
     mutationFn: (mediaId: number) => deleteImage(mediaId),
     onSuccess: ({ id }) => {
       queryClient.invalidateQueries({ queryKey: ["gallery"] });
+      queryClient.invalidateQueries({ queryKey: ["gallery-infinite"] });
       queryClient.invalidateQueries({ queryKey: ["clusters"] });
+      queryClient.invalidateQueries({ queryKey: ["people"] });
       queryClient.invalidateQueries({ queryKey: ["image-detail", id] });
       onDeleted?.(id);
       onClose();
@@ -311,6 +314,7 @@ export function ImagePreviewModal({
     mutationFn: (mediaId: number) => reprocessImage(mediaId),
     onSuccess: ({ media_id }) => {
       queryClient.invalidateQueries({ queryKey: ["gallery"] });
+      queryClient.invalidateQueries({ queryKey: ["gallery-infinite"] });
       queryClient.invalidateQueries({ queryKey: ["image-detail", media_id] });
       toast.success("Retry queued — analysis will restart shortly.");
     },

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -96,6 +96,16 @@ export interface GalleryResponse {
   limit: number;
 }
 
+export interface BulkDeleteResponse {
+  message: string;
+  deleted_ids: number[];
+  missing_ids: number[];
+  failed_ids: number[];
+  deleted_count: number;
+  missing_count: number;
+  failed_count: number;
+}
+
 export interface ClusterSample {
   id: number;
   filename: string;
@@ -266,6 +276,18 @@ export const deleteImage = async (
 ): Promise<{ id: number; message: string }> => {
   const response = await api.delete<{ id: number; message: string }>(
     `/api/image/${mediaId}`,
+  );
+  return response.data;
+};
+
+export const deleteImagesBulk = async (
+  mediaIds: number[],
+): Promise<BulkDeleteResponse> => {
+  const response = await api.post<BulkDeleteResponse>(
+    "/api/images/bulk-delete",
+    {
+      media_ids: mediaIds,
+    },
   );
   return response.data;
 };


### PR DESCRIPTION
Closes #178

## What changed
- Added a backend `POST /api/images/bulk-delete` endpoint for deleting selected media ids in one request.
- Added Gallery multi-select controls with select visible, clear selection, and delete selected actions.
- Added a confirmation dialog that shows the selected count before bulk deletion.
- Keeps Gallery cache updated immediately after single delete, modal delete, move-to-vault, and bulk delete so refresh is not needed.
- Invalidates clusters and people after deletion because deleted media can appear there too.
- Keeps cluster `member_ids` and `member_count` in sync when images are deleted.
- Handles missing ids and per-image storage failures in the bulk delete response.

## Tested
- `uv run ruff check src/find_api/core/config.py src/find_api/routers/gallery.py tests/test_gallery.py`
- `uv run ruff format --check src/find_api/core/config.py src/find_api/routers/gallery.py tests/test_gallery.py`
- `uv run pytest tests/test_gallery.py -q`
- `pnpm exec biome check src/app/gallery/page.tsx src/components/image-preview-modal.tsx src/lib/api.ts src/__tests__/gallery-cards.test.tsx`
- `pnpm exec vitest run src/__tests__/gallery-cards.test.tsx`
- `pnpm build`