### PR TITLE
feat: add copy button for OCR text in image preview modal

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
 ml = [
   "torch==2.8.0",
   "torchvision==0.23.0",
-  "transformers>=5.0.0rc3,<6",
+  "transformers>=4.40,<5",
   "open-clip-torch>=2.24.0",
   "opencv-python-headless==4.9.0.80",
   "ultralytics>=8.2.0",

--- a/backend/src/find_api/core/model_manager.py
+++ b/backend/src/find_api/core/model_manager.py
@@ -372,6 +372,13 @@ class ModelManager:
             self._clear_model_failure_locked(name)
             self.publish_status()
 
+    def clear_model_failures(self, names: list[str] | tuple[str, ...]) -> None:
+        """Allow multiple known-unavailable models to be retried."""
+        with self._lock:
+            for name in names:
+                self._clear_model_failure_locked(name)
+            self.publish_status()
+
     def clear(self) -> None:
         """Clear cached models and failures for tests or controlled reloads."""
         self.reset_for_tests()

--- a/backend/src/find_api/routers/gallery.py
+++ b/backend/src/find_api/routers/gallery.py
@@ -334,7 +334,10 @@ def reprocess_image(media_id: int, db: Session = Depends(get_db)):
 
     try:
         job = get_task_queue().enqueue(
-            analyze_image, media.id, job_timeout=settings.WORKER_TIMEOUT
+            analyze_image,
+            media.id,
+            True,
+            job_timeout=settings.WORKER_TIMEOUT,
         )
         media.analysis_job_id = job.id
         db.commit()

--- a/backend/src/find_api/workers/jobs.py
+++ b/backend/src/find_api/workers/jobs.py
@@ -30,6 +30,7 @@ except Exception as e:
     logger.error(f"Failed to start model cleanup thread in worker: {e}")
 
 FACE_CLUSTER_NAME_MATCH_THRESHOLD = 0.72
+ANALYSIS_MODEL_NAMES = ("yolo", "florence-2", "paddleocr", "siglip", "insightface")
 
 
 def cosine_similarity(left: np.ndarray, right: np.ndarray) -> float:
@@ -88,7 +89,7 @@ def generate_thumbnail_for_media(media_id: int):
         db.close()
 
 
-def analyze_image(media_id: int):
+def analyze_image(media_id: int, clear_model_failures: bool = False):
     """
     Main worker job to analyze an uploaded image
     """
@@ -105,6 +106,9 @@ def analyze_image(media_id: int):
     metadata = None
 
     try:
+        if clear_model_failures:
+            get_model_manager().clear_model_failures(ANALYSIS_MODEL_NAMES)
+
         set_stage(job, "loading image")
 
         media = db.query(Media).filter(Media.id == media_id).first()

--- a/backend/tests/test_model_manager.py
+++ b/backend/tests/test_model_manager.py
@@ -73,6 +73,22 @@ def test_clearing_model_failure_allows_retry(manager):
     assert calls["count"] == 2
 
 
+def test_clearing_multiple_model_failures_allows_retry(manager):
+    def broken_loader():
+        raise RuntimeError("load failed")
+
+    with pytest.raises(ModelUnavailableError):
+        manager.get_model("caption-model", broken_loader)
+    with pytest.raises(ModelUnavailableError):
+        manager.get_model("embedding-model", broken_loader)
+
+    manager.clear_model_failures(("caption-model", "embedding-model"))
+
+    assert "caption-model" not in manager.unavailable_models
+    assert "embedding-model" not in manager.unavailable_models
+    assert manager.failed_loads == {}
+
+
 def test_config_key_change_allows_retry(manager):
     calls = {"count": 0}
 

--- a/backend/tests/test_reprocess.py
+++ b/backend/tests/test_reprocess.py
@@ -278,6 +278,34 @@ class TestReprocessEndpoint:
 
         assert call_args[0][0] is analyze_image
         assert call_args[0][1] == media.id
+        assert call_args[0][2] is True
+
+    @patch("find_api.routers.gallery.get_task_queue")
+    def test_reprocess_requests_model_failure_clear(self, mock_queue, client):
+        """Retrying analysis must let the worker reload previously failed models."""
+        mock_job = MagicMock()
+        mock_job.id = "fake-job-clear-model-state"
+        mock_queue.return_value.enqueue.return_value = mock_job
+
+        media = make_media(
+            status="indexed",
+            metadata_json={
+                "caption": "",
+                "stage_status": {
+                    "captioning": {
+                        "status": "failed",
+                        "error": "ModelUnavailableError",
+                    }
+                },
+            },
+        )
+
+        resp = client.post(f"/api/image/{media.id}/reprocess")
+
+        assert resp.status_code == 200
+        mock_queue.return_value.enqueue.assert_called_once()
+        call_args = mock_queue.return_value.enqueue.call_args
+        assert call_args[0][2] is True
 
     @patch("find_api.routers.gallery.get_task_queue")
     def test_repeated_reprocess_allowed(self, mock_queue, client):

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -659,7 +659,7 @@ requires-dist = [
     { name = "timm", marker = "extra == 'ml'", specifier = ">=0.9.16" },
     { name = "torch", marker = "extra == 'ml'", specifier = "==2.8.0", index = "https://download.pytorch.org/whl/cu128" },
     { name = "torchvision", marker = "extra == 'ml'", specifier = "==0.23.0", index = "https://download.pytorch.org/whl/cu128" },
-    { name = "transformers", marker = "extra == 'ml'", specifier = ">=5.0.0rc3,<6" },
+    { name = "transformers", marker = "extra == 'ml'", specifier = ">=4.40,<5" },
     { name = "ultralytics", marker = "extra == 'ml'", specifier = ">=8.2.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.43.0,<0.44" },
 ]
@@ -834,22 +834,21 @@ wheels = [
 
 [[package]]
 name = "huggingface-hub"
-version = "1.16.1"
+version = "0.36.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "filelock" },
     { name = "fsspec" },
-    { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
-    { name = "httpx" },
+    { name = "hf-xet", marker = "platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
     { name = "packaging" },
     { name = "pyyaml" },
+    { name = "requests" },
     { name = "tqdm" },
-    { name = "typer" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/48/0f/ed994dbade67a54407c28cab96ef845e0e6d25500be56aca6394f8bfc9dd/huggingface_hub-1.16.1.tar.gz", hash = "sha256:7f1dc4c5ec21aed69be630ad0c3378616be16f3de1a47b141c0e812965d9c832", size = 792534, upload-time = "2026-05-21T18:40:00.908Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7c/b7/8cb61d2eece5fb05a83271da168186721c450eb74e3c31f7ef3169fa475b/huggingface_hub-0.36.2.tar.gz", hash = "sha256:1934304d2fb224f8afa3b87007d58501acfda9215b334eed53072dd5e815ff7a", size = 649782, upload-time = "2026-02-06T09:24:13.098Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/49/79/621a7dbb80c70974f73a597275351ebe03ce5bc65cb5f8f4acb5859252bc/huggingface_hub-1.16.1-py3-none-any.whl", hash = "sha256:64340de934b9ce37857ef85a82de72f5629e8a270f9119eabb12bf495eb53c22", size = 668176, upload-time = "2026-05-21T18:39:58.596Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/af/48ac8483240de756d2438c380746e7130d1c6f75802ef22f3c6d49982787/huggingface_hub-0.36.2-py3-none-any.whl", hash = "sha256:48f0c8eac16145dfce371e9d2d7772854a4f591bcb56c9cf548accf531d54270", size = 566395, upload-time = "2026-02-06T09:24:11.133Z" },
 ]
 
 [[package]]
@@ -2325,15 +2324,6 @@ wheels = [
 ]
 
 [[package]]
-name = "shellingham"
-version = "1.5.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
-]
-
-[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2541,22 +2531,23 @@ wheels = [
 
 [[package]]
 name = "transformers"
-version = "5.9.0"
+version = "4.57.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "filelock" },
     { name = "huggingface-hub" },
     { name = "numpy" },
     { name = "packaging" },
     { name = "pyyaml" },
     { name = "regex" },
+    { name = "requests" },
     { name = "safetensors" },
     { name = "tokenizers" },
     { name = "tqdm" },
-    { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/51/58/7f843608f2e8421f86bb97060b54649be6239ec612b82bf9d41e65c26c00/transformers-5.9.0.tar.gz", hash = "sha256:25997cb8fa6053533171634b6162d7df54346530ec2aa9b42bb834e63668c842", size = 8642240, upload-time = "2026-05-20T14:50:49.278Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c4/35/67252acc1b929dc88b6602e8c4a982e64f31e733b804c14bc24b47da35e6/transformers-4.57.6.tar.gz", hash = "sha256:55e44126ece9dc0a291521b7e5492b572e6ef2766338a610b9ab5afbb70689d3", size = 10134912, upload-time = "2026-01-16T10:38:39.284Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/02/ca/2eaa5359f2ccb8c2e1656bc26305ad0cf438aa392ce4b29ae67a315c186e/transformers-5.9.0-py3-none-any.whl", hash = "sha256:1d19509bcff7028ebc6b277d71caa712e8353778463d38764237d14b42b52788", size = 10787648, upload-time = "2026-05-20T14:50:45.337Z" },
+    { url = "https://files.pythonhosted.org/packages/03/b8/e484ef633af3887baeeb4b6ad12743363af7cce68ae51e938e00aaa0529d/transformers-4.57.6-py3-none-any.whl", hash = "sha256:4c9e9de11333ddfe5114bc872c9f370509198acf0b87a832a0ab9458e2bd0550", size = 11993498, upload-time = "2026-01-16T10:38:31.289Z" },
 ]
 
 [[package]]
@@ -2568,21 +2559,6 @@ dependencies = [
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d0/66/b1eb52839f563623d185f0927eb3530ee4d5ffe9d377cdaf5346b306689e/triton-3.4.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:31c1d84a5c0ec2c0f8e8a072d7fd150cab84a9c239eaddc6706c081bfae4eb04", size = 155560068, upload-time = "2025-07-30T19:58:37.081Z" },
-]
-
-[[package]]
-name = "typer"
-version = "0.25.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "annotated-doc" },
-    { name = "click" },
-    { name = "rich" },
-    { name = "shellingham" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/e4/51/9aed62104cea109b820bbd6c14245af756112017d309da813ef107d42e7e/typer-0.25.1.tar.gz", hash = "sha256:9616eb8853a09ffeabab1698952f33c6f29ffdbceb4eaeecf571880e8d7664cc", size = 122276, upload-time = "2026-04-30T19:32:16.964Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3f/f9/2b3ff4e56e5fa7debfaf9eb135d0da96f3e9a1d5b27222223c7296336e5f/typer-0.25.1-py3-none-any.whl", hash = "sha256:75caa44ed46a03fb2dab8808753ffacdbfea88495e74c85a28c5eefcf5f39c89", size = 58409, upload-time = "2026-04-30T19:32:18.271Z" },
 ]
 
 [[package]]

--- a/frontend/src/components/image-preview-modal.tsx
+++ b/frontend/src/components/image-preview-modal.tsx
@@ -2,9 +2,9 @@
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
+  Check,
   ChevronLeft,
   ChevronRight,
-  Check,
   Copy,
   Download,
   Heart,

--- a/frontend/src/components/image-preview-modal.tsx
+++ b/frontend/src/components/image-preview-modal.tsx
@@ -512,14 +512,14 @@ export function ImagePreviewModal({
               <h3 className="mb-2 text-xs font-semibold uppercase text-[color:var(--muted)]">
                 Caption
               </h3>
-              <div className="space-y-3 rounded-2xl border border-[var(--frost)] bg-[color:var(--surface-soft)] p-4">
+              <div className="min-w-0 space-y-3 overflow-hidden rounded-2xl border border-[var(--frost)] bg-[color:var(--surface-soft)] p-4">
                 {status === "pending" || status === "processing" ? (
                   <p className="text-sm text-[color:var(--silver)] flex items-center gap-2">
                     <Loader2 className="h-3.5 w-3.5 animate-spin text-[color:var(--blue)]" />
                     Generating caption...
                   </p>
                 ) : captionStage?.status === "failed" ? (
-                  <p className="text-sm text-[#ff9bab] font-medium leading-6">
+                  <p className="min-w-0 break-words text-sm font-medium leading-6 text-[#ff9bab] [overflow-wrap:anywhere]">
                     Captioning failed: {captionStage.error || "Unknown error"}
                   </p>
                 ) : caption ? (
@@ -552,7 +552,7 @@ export function ImagePreviewModal({
               <h3 className="mb-2 text-xs font-semibold uppercase text-[color:var(--muted)]">
                 Metadata
               </h3>
-              <div className="space-y-3 rounded-2xl border border-[var(--frost)] bg-[color:var(--surface-soft)] p-4">
+              <div className="min-w-0 space-y-3 overflow-hidden rounded-2xl border border-[var(--frost)] bg-[color:var(--surface-soft)] p-4">
                 {status === "pending" || status === "processing" ? (
                   <div>
                     <p className="mb-2 text-xs font-medium uppercase text-[color:var(--muted)]">
@@ -568,7 +568,7 @@ export function ImagePreviewModal({
                     <p className="mb-2 text-xs font-medium uppercase text-[color:var(--muted)]">
                       Detected objects
                     </p>
-                    <p className="text-sm text-[#ff9bab] font-medium">
+                    <p className="min-w-0 break-words text-sm font-medium text-[#ff9bab] [overflow-wrap:anywhere]">
                       Object detection failed:{" "}
                       {objectDetectionStage.error || "Unknown error"}
                     </p>
@@ -645,7 +645,7 @@ export function ImagePreviewModal({
                     <p className="mb-2 text-xs font-medium uppercase text-[color:var(--muted)]">
                       OCR text
                     </p>
-                    <p className="text-sm text-[#ff9bab] font-medium">
+                    <p className="min-w-0 break-words text-sm font-medium text-[#ff9bab] [overflow-wrap:anywhere]">
                       OCR failed: {ocrStage.error || "Unknown error"}
                     </p>
                   </div>
@@ -751,7 +751,7 @@ export function ImagePreviewModal({
             )}
 
             {detailData?.error && (
-              <p className="rounded-2xl border border-[var(--red-soft)] bg-[var(--red-soft)] p-3 text-sm text-[#ff9bab]">
+              <p className="min-w-0 break-words rounded-2xl border border-[var(--red-soft)] bg-[var(--red-soft)] p-3 text-sm text-[#ff9bab] [overflow-wrap:anywhere]">
                 {detailData.error}
               </p>
             )}

--- a/frontend/src/components/image-preview-modal.tsx
+++ b/frontend/src/components/image-preview-modal.tsx
@@ -2,9 +2,9 @@
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
-  Check,
   ChevronLeft,
   ChevronRight,
+  Check,
   Copy,
   Download,
   Heart,
@@ -669,13 +669,9 @@ export function ImagePreviewModal({
                         className="frost-button px-2 py-1 text-xs text-[color:var(--silver)]"
                         aria-label={
                           ocrCopied
-                          ? "OCR text copied to clipboard"
-                          : "Copy OCR text to clipboard"
-                          }
-  
-    
-    
-
+                            ? "OCR text copied to clipboard"
+                            : "Copy OCR text to clipboard"
+                        }
                       >
                         {ocrCopied ? (
                           <Check className="h-3 w-3 text-[color:var(--green)]" />

--- a/frontend/src/components/image-preview-modal.tsx
+++ b/frontend/src/components/image-preview-modal.tsx
@@ -218,7 +218,14 @@ export function ImagePreviewModal({
   const queryClient = useQueryClient();
   const [likedOverride, setLikedOverride] = useState<boolean | null>(null);
   const [confirmingDelete, setConfirmingDelete] = useState(false);
+  const [captionCopied, setCaptionCopied] = useState(false);
   const [ocrCopied, setOcrCopied] = useState(false);
+
+  useEffect(() => {
+    if (!captionCopied) return;
+    const id = setTimeout(() => setCaptionCopied(false), 2000);
+    return () => clearTimeout(id);
+  }, [captionCopied]);
 
   useEffect(() => {
     if (!ocrCopied) return;
@@ -509,9 +516,38 @@ export function ImagePreviewModal({
             </section>
 
             <section className="mb-6">
-              <h3 className="mb-2 text-xs font-semibold uppercase text-[color:var(--muted)]">
-                Caption
-              </h3>
+              <div className="mb-2 flex items-center justify-between gap-2">
+                <h3 className="text-xs font-semibold uppercase text-[color:var(--muted)]">
+                  Caption
+                </h3>
+                {caption ? (
+                  <button
+                    type="button"
+                    onClick={async () => {
+                      try {
+                        await navigator.clipboard.writeText(caption);
+                        setCaptionCopied(true);
+                        toast.success("Caption copied to clipboard");
+                      } catch {
+                        toast.error("Failed to copy caption");
+                      }
+                    }}
+                    className="frost-button px-2 py-1 text-xs text-[color:var(--silver)]"
+                    aria-label={
+                      captionCopied
+                        ? "Caption copied to clipboard"
+                        : "Copy caption to clipboard"
+                    }
+                  >
+                    {captionCopied ? (
+                      <Check className="h-3 w-3 text-[color:var(--green)]" />
+                    ) : (
+                      <Copy className="h-3 w-3" />
+                    )}
+                    {captionCopied ? "Copied" : "Copy"}
+                  </button>
+                ) : null}
+              </div>
               <div className="min-w-0 space-y-3 overflow-hidden rounded-2xl border border-[var(--frost)] bg-[color:var(--surface-soft)] p-4">
                 {status === "pending" || status === "processing" ? (
                   <p className="text-sm text-[color:var(--silver)] flex items-center gap-2">

--- a/frontend/src/components/image-preview-modal.tsx
+++ b/frontend/src/components/image-preview-modal.tsx
@@ -703,7 +703,7 @@ export function ImagePreviewModal({
                 <h3 className="mb-2 text-xs font-semibold uppercase text-[color:var(--muted)]">
                   Analysis Stages
                 </h3>
-                <div className="rounded-2xl border border-[var(--frost)] bg-[color:var(--surface-soft)] p-4 space-y-3">
+                <div className="space-y-3 overflow-hidden rounded-2xl border border-[var(--frost)] bg-[color:var(--surface-soft)] p-4">
                   {ANALYSIS_STAGE_ORDER.filter(
                     (stage) => displayStageStatus[stage],
                   ).map((stage) => {
@@ -726,20 +726,20 @@ export function ImagePreviewModal({
                     return (
                       <div
                         key={stage}
-                        className="flex flex-col gap-1 text-sm border-b border-[var(--frost-soft)] pb-3 last:border-b-0 last:pb-0"
+                        className="flex min-w-0 flex-col gap-1 border-b border-[var(--frost-soft)] pb-3 text-sm last:border-b-0 last:pb-0"
                       >
-                        <div className="flex items-center justify-between">
-                          <span className="font-medium text-[color:var(--near-white)]">
+                        <div className="flex min-w-0 items-center justify-between gap-3">
+                          <span className="min-w-0 break-words font-medium text-[color:var(--near-white)]">
                             {prettyName}
                           </span>
                           <span
-                            className={`text-[10px] font-semibold uppercase px-2 py-0.5 rounded-full border ${statusClass}`}
+                            className={`shrink-0 rounded-full border px-2 py-0.5 text-[10px] font-semibold uppercase ${statusClass}`}
                           >
                             {info.status}
                           </span>
                         </div>
                         {info.status === "failed" && info.error && (
-                          <p className="text-xs text-[#ff9bab] mt-1 pl-1 leading-normal">
+                          <p className="mt-1 min-w-0 break-words pl-1 text-xs leading-normal text-[#ff9bab] [overflow-wrap:anywhere]">
                             Error: {info.error}
                           </p>
                         )}

--- a/frontend/src/components/image-preview-modal.tsx
+++ b/frontend/src/components/image-preview-modal.tsx
@@ -4,6 +4,8 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   ChevronLeft,
   ChevronRight,
+  Check,
+  Copy,
   Download,
   Heart,
   ImageOff,
@@ -216,6 +218,7 @@ export function ImagePreviewModal({
   const queryClient = useQueryClient();
   const [likedOverride, setLikedOverride] = useState<boolean | null>(null);
   const [confirmingDelete, setConfirmingDelete] = useState(false);
+  const [ocrCopied, setOcrCopied] = useState(false);
 
   const detailQuery = useQuery<MediaDetail, Error>({
     queryKey: ["image-detail", media.id],
@@ -642,9 +645,33 @@ export function ImagePreviewModal({
                   </div>
                 ) : ocrText ? (
                   <div className="border-t border-[var(--frost-soft)] pt-3">
-                    <p className="mb-2 text-xs font-medium uppercase text-[color:var(--muted)]">
-                      OCR text
-                    </p>
+                    <div className="mb-2 flex items-center justify-between gap-2">
+                      <p className="text-xs font-medium uppercase text-[color:var(--muted)]">
+                        OCR text
+                      </p>
+                      <button
+                        type="button"
+                        onClick={async () => {
+                          try {
+                            await navigator.clipboard.writeText(ocrText);
+                            setOcrCopied(true);
+                            toast.success("OCR text copied to clipboard");
+                            setTimeout(() => setOcrCopied(false), 2000);
+                          } catch {
+                            toast.error("Failed to copy OCR text");
+                          }
+                        }}
+                        className="frost-button px-2 py-1 text-xs text-[color:var(--silver)]"
+                        aria-label="Copy OCR text to clipboard"
+                      >
+                        {ocrCopied ? (
+                          <Check className="h-3 w-3 text-[color:var(--green)]" />
+                        ) : (
+                          <Copy className="h-3 w-3" />
+                        )}
+                        {ocrCopied ? "Copied" : "Copy"}
+                      </button>
+                    </div>
                     <p className="max-h-36 overflow-y-auto whitespace-pre-wrap text-sm leading-6 text-[color:var(--near-white)]">
                       {ocrText}
                     </p>

--- a/frontend/src/components/image-preview-modal.tsx
+++ b/frontend/src/components/image-preview-modal.tsx
@@ -2,9 +2,9 @@
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
+  Check,
   ChevronLeft,
   ChevronRight,
-  Check,
   Copy,
   Download,
   Heart,
@@ -667,7 +667,15 @@ export function ImagePreviewModal({
                           }
                         }}
                         className="frost-button px-2 py-1 text-xs text-[color:var(--silver)]"
-                        aria-label={ocrCopied ? "OCR text copied to clipboard" : "Copy OCR text to clipboard"}
+                        aria-label={
+                          ocrCopied
+                          ? "OCR text copied to clipboard"
+                          : "Copy OCR text to clipboard"
+                          }
+  
+    
+    
+
                       >
                         {ocrCopied ? (
                           <Check className="h-3 w-3 text-[color:var(--green)]" />

--- a/frontend/src/components/image-preview-modal.tsx
+++ b/frontend/src/components/image-preview-modal.tsx
@@ -2,9 +2,9 @@
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
-  Check,
   ChevronLeft,
   ChevronRight,
+  Check,
   Copy,
   Download,
   Heart,
@@ -219,6 +219,12 @@ export function ImagePreviewModal({
   const [likedOverride, setLikedOverride] = useState<boolean | null>(null);
   const [confirmingDelete, setConfirmingDelete] = useState(false);
   const [ocrCopied, setOcrCopied] = useState(false);
+
+  useEffect(() => {
+    if (!ocrCopied) return;
+    const id = setTimeout(() => setOcrCopied(false), 2000);
+    return () => clearTimeout(id);
+  }, [ocrCopied]);
 
   const detailQuery = useQuery<MediaDetail, Error>({
     queryKey: ["image-detail", media.id],
@@ -656,13 +662,12 @@ export function ImagePreviewModal({
                             await navigator.clipboard.writeText(ocrText);
                             setOcrCopied(true);
                             toast.success("OCR text copied to clipboard");
-                            setTimeout(() => setOcrCopied(false), 2000);
                           } catch {
                             toast.error("Failed to copy OCR text");
                           }
                         }}
                         className="frost-button px-2 py-1 text-xs text-[color:var(--silver)]"
-                        aria-label="Copy OCR text to clipboard"
+                        aria-label={ocrCopied ? "OCR text copied to clipboard" : "Copy OCR text to clipboard"}
                       >
                         {ocrCopied ? (
                           <Check className="h-3 w-3 text-[color:var(--green)]" />


### PR DESCRIPTION
Closes #29

## What this PR does
Adds a copy button to the OCR text section in the image preview modal, 
allowing users to quickly copy extracted text from screenshots, documents, 
and scanned images to their clipboard.

## Changes made
- Added a Copy button next to the OCR text label
- Button only appears when OCR text is available
- On success: button switches to a "Copied ✓" state for 2 seconds and shows a toast notification
- On failure: shows an error toast notification
- Used existing `frost-button` styling and `--green` CSS variable to stay consistent with the codebase

## Acceptance criteria checklist
- [x] Copy action appears only when OCR text is available
- [x] Clicking it copies the full OCR text to clipboard
- [x] Success/failure feedback is accessible and clear
- [x] The OCR section remains readable on mobile

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * One-click copy for both image captions and extracted OCR text in the preview modal with Copy → Copied feedback and toast success/error messages.
  * Reprocess now clears prior model-failure state so re-analyzing an image will retry previously-failed models.

* **Style**
  * Improved wrapping and layout for Analysis Stages and various metadata/error messages to prevent overflow on narrow screens.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Abhash-Chakraborty/Find/pull/285?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->