### PR TITLE
refactor: migrate Pydantic response configs to ConfigDict

### DIFF
--- a/backend/src/find_api/routers/feedback.py
+++ b/backend/src/find_api/routers/feedback.py
@@ -3,7 +3,7 @@ from datetime import datetime
 import logging
 
 from fastapi import APIRouter, Depends, HTTPException
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 from sqlalchemy.orm import Session
 
 from find_api.core.database import get_db
@@ -49,8 +49,7 @@ class PersonFeedbackResponse(BaseModel):
     status: str
     created_at: datetime
 
-    class Config:
-        from_attributes = True
+    model_config = ConfigDict(from_attributes=True)
 
 
 class GeneralFeedbackRequest(BaseModel):
@@ -77,9 +76,7 @@ class GeneralFeedbackResponse(BaseModel):
     extra_metadata: Optional[dict[str, Any]]
     created_at: datetime
 
-    class Config:
-        from_attributes = True
-
+    model_config = ConfigDict(from_attributes=True)
 
 # ─── Person Cluster Feedback Endpoints ────────────────────────────────────
 

--- a/backend/src/find_api/routers/feedback.py
+++ b/backend/src/find_api/routers/feedback.py
@@ -78,6 +78,7 @@ class GeneralFeedbackResponse(BaseModel):
 
     model_config = ConfigDict(from_attributes=True)
 
+
 # ─── Person Cluster Feedback Endpoints ────────────────────────────────────
 
 

--- a/backend/src/find_api/routers/people.py
+++ b/backend/src/find_api/routers/people.py
@@ -5,7 +5,7 @@ People router - API endpoints for person groups and face clusters
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 from sqlalchemy import func
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 from typing import List, Optional
 
 from find_api.core.database import get_db
@@ -34,8 +34,7 @@ class PersonResponse(BaseModel):
     sample_media_ids: List[int]
     thumbnail_url: Optional[str] = None
 
-    class Config:
-        from_attributes = True
+    model_config = ConfigDict(from_attributes=True)
 
 
 class PersonUpdate(BaseModel):


### PR DESCRIPTION
## Summary

Migrates deprecated Pydantic V1 class-based `Config` to the modern `ConfigDict` pattern in `people.py` and `feedback.py`, resolving deprecation warnings surfaced during test runs.

## Changes

- `backend/src/find_api/routers/people.py` — replaced `class Config` with `model_config = ConfigDict(from_attributes=True)` in `PersonResponse`
- `backend/src/find_api/routers/feedback.py` — same fix applied to both `PersonFeedbackResponse` and `GeneralFeedbackResponse`

## Why

Pydantic V2 deprecated class-based `Config` and will remove it in V3. These warnings were showing up on every test run:
```
PydanticDeprecatedSince20: Support for class-based `config` is deprecated, use ConfigDict instead.
```

## Testing

All 18 existing tests in `test_people.py` and `test_feedback.py` pass with no regressions.

## Related

Warnings discovered while investigating issue 174.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated backend response model configurations to a new configuration style.
  * No API endpoints or response fields were changed; behavior seen by users remains the same.
  * Maintenance-only change; improves internal alignment with current library conventions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


Closes #303