### PR TITLE
fix: guard hybrid embedding normalization

### DIFF
--- a/backend/src/find_api/ml/mock_embedder.py
+++ b/backend/src/find_api/ml/mock_embedder.py
@@ -14,23 +14,22 @@ from find_api.core.config import settings
 class MockEmbedder:
     """Generate stable vectors without loading external ML models."""
 
-def _safe_normalize(self, vector: np.ndarray) -> np.ndarray:
-    """Safely normalize vector avoiding NaN/inf issues."""
+    def _safe_normalize(self, vector: np.ndarray) -> np.ndarray:
+        """Safely normalize vector avoiding NaN/inf issues."""
 
-    # Remove NaN and inf values first
-    clean_vector = np.nan_to_num(
-        vector,
-        nan=0.0,
-        posinf=0.0,
-        neginf=0.0,
-    )
+        clean_vector = np.nan_to_num(
+            vector,
+            nan=0.0,
+            posinf=0.0,
+            neginf=0.0,
+        )
 
-    norm = np.linalg.norm(clean_vector)
+        norm = np.linalg.norm(clean_vector)
 
-    if norm == 0 or not np.isfinite(norm):
-        return np.zeros_like(clean_vector, dtype=np.float32)
+        if norm == 0 or not np.isfinite(norm):
+            return np.zeros_like(clean_vector, dtype=np.float32)
 
-    return (clean_vector / norm).astype(np.float32)
+        return (clean_vector / norm).astype(np.float32)
 
     def _vector_from_bytes(self, payload: bytes) -> np.ndarray:
         chunks = []
@@ -38,7 +37,11 @@ def _safe_normalize(self, vector: np.ndarray) -> np.ndarray:
         target_bytes = settings.EMBEDDING_DIM * 4
 
         while sum(len(chunk) for chunk in chunks) < target_bytes:
-            chunks.append(hashlib.sha256(payload + counter.to_bytes(4, "big")).digest())
+            chunks.append(
+                hashlib.sha256(
+                    payload + counter.to_bytes(4, "big")
+                ).digest()
+            )
             counter += 1
 
         raw = b"".join(chunks)[:target_bytes]
@@ -49,22 +52,26 @@ def _safe_normalize(self, vector: np.ndarray) -> np.ndarray:
 
     def _vector_from_text(self, text: str) -> np.ndarray:
         tokens = re.findall(r"[a-z0-9]+", text.lower())
+
         if not tokens:
             return self._vector_from_bytes(b"text:")
 
         vectors = [
-            self._vector_from_bytes(f"token:{token}".encode("utf-8"))
+            self._vector_from_bytes(
+                f"token:{token}".encode("utf-8")
+            )
             for token in tokens
         ]
 
         vector = np.mean(vectors, axis=0)
-        return self._safe_normalize(vector).astype(np.float32)
+        return self._safe_normalize(vector)
 
     def embed_image(self, image: Image.Image) -> np.ndarray:
         if image.mode != "RGB":
             image = image.convert("RGB")
 
         thumbnail = image.resize((16, 16))
+
         payload = (
             b"image:"
             + image.width.to_bytes(4, "big")
@@ -84,7 +91,9 @@ def _safe_normalize(self, vector: np.ndarray) -> np.ndarray:
         )
 
     def embed_metadata(
-        self, image: Image.Image, metadata: dict[str, Any]
+        self,
+        image: Image.Image,
+        metadata: dict[str, Any],
     ) -> list[float]:
         caption = str(metadata.get("caption", ""))
         objects = metadata.get("objects", [])
@@ -106,16 +115,21 @@ def _safe_normalize(self, vector: np.ndarray) -> np.ndarray:
             part.strip()
             for part in [caption, object_text, ocr_text]
             if part and part.strip()
-]
+        ]
 
         if text_parts:
             text_vector = self.embed_text(" ".join(text_parts))
+
             # Bias toward text in mock mode
-            hybrid_vector = (image_vector * 0.45) + (text_vector * 0.55)
+            hybrid_vector = (
+                image_vector * 0.45
+                + text_vector * 0.55
+            )
         else:
             hybrid_vector = image_vector
 
         hybrid_vector = self._safe_normalize(hybrid_vector)
+
         return hybrid_vector.tolist()
 
 
@@ -126,8 +140,10 @@ _mock_embedder_lock = threading.Lock()
 def get_mock_embedder() -> MockEmbedder:
     """Get or create the global mock embedder."""
     global _mock_embedder
+
     if _mock_embedder is None:
         with _mock_embedder_lock:
             if _mock_embedder is None:
                 _mock_embedder = MockEmbedder()
+
     return _mock_embedder

--- a/backend/src/find_api/ml/mock_embedder.py
+++ b/backend/src/find_api/ml/mock_embedder.py
@@ -14,14 +14,23 @@ from find_api.core.config import settings
 class MockEmbedder:
     """Generate stable vectors without loading external ML models."""
 
-    def _safe_normalize(self, vector: np.ndarray) -> np.ndarray:
-        """Safely normalize vector avoiding NaN/inf issues."""
-        norm = np.linalg.norm(vector)
+def _safe_normalize(self, vector: np.ndarray) -> np.ndarray:
+    """Safely normalize vector avoiding NaN/inf issues."""
 
-        if norm is None or norm == 0 or not np.isfinite(norm):
-            return vector  # safe fallback: keep original vector
+    # Remove NaN and inf values first
+    clean_vector = np.nan_to_num(
+        vector,
+        nan=0.0,
+        posinf=0.0,
+        neginf=0.0,
+    )
 
-        return vector / norm
+    norm = np.linalg.norm(clean_vector)
+
+    if norm == 0 or not np.isfinite(norm):
+        return np.zeros_like(clean_vector, dtype=np.float32)
+
+    return (clean_vector / norm).astype(np.float32)
 
     def _vector_from_bytes(self, payload: bytes) -> np.ndarray:
         chunks = []
@@ -96,8 +105,8 @@ class MockEmbedder:
         text_parts = [
             part.strip()
             for part in [caption, object_text, ocr_text]
-            if part
-        ]
+            if part and part.strip()
+]
 
         if text_parts:
             text_vector = self.embed_text(" ".join(text_parts))

--- a/backend/src/find_api/ml/mock_embedder.py
+++ b/backend/src/find_api/ml/mock_embedder.py
@@ -37,11 +37,7 @@ class MockEmbedder:
         target_bytes = settings.EMBEDDING_DIM * 4
 
         while sum(len(chunk) for chunk in chunks) < target_bytes:
-            chunks.append(
-                hashlib.sha256(
-                    payload + counter.to_bytes(4, "big")
-                ).digest()
-            )
+            chunks.append(hashlib.sha256(payload + counter.to_bytes(4, "big")).digest())
             counter += 1
 
         raw = b"".join(chunks)[:target_bytes]
@@ -57,9 +53,7 @@ class MockEmbedder:
             return self._vector_from_bytes(b"text:")
 
         vectors = [
-            self._vector_from_bytes(
-                f"token:{token}".encode("utf-8")
-            )
+            self._vector_from_bytes(f"token:{token}".encode("utf-8"))
             for token in tokens
         ]
 
@@ -121,10 +115,7 @@ class MockEmbedder:
             text_vector = self.embed_text(" ".join(text_parts))
 
             # Bias toward text in mock mode
-            hybrid_vector = (
-                image_vector * 0.45
-                + text_vector * 0.55
-            )
+            hybrid_vector = image_vector * 0.45 + text_vector * 0.55
         else:
             hybrid_vector = image_vector
 

--- a/backend/src/find_api/ml/mock_embedder.py
+++ b/backend/src/find_api/ml/mock_embedder.py
@@ -14,6 +14,15 @@ from find_api.core.config import settings
 class MockEmbedder:
     """Generate stable vectors without loading external ML models."""
 
+    def _safe_normalize(self, vector: np.ndarray) -> np.ndarray:
+        """Safely normalize vector avoiding NaN/inf issues."""
+        norm = np.linalg.norm(vector)
+
+        if norm is None or norm == 0 or not np.isfinite(norm):
+            return vector  # safe fallback: keep original vector
+
+        return vector / norm
+
     def _vector_from_bytes(self, payload: bytes) -> np.ndarray:
         chunks = []
         counter = 0
@@ -27,12 +36,7 @@ class MockEmbedder:
         vector = np.frombuffer(raw, dtype=np.uint32).astype(np.float32)
         vector = (vector / np.iinfo(np.uint32).max) - 0.5
 
-        norm = np.linalg.norm(vector)
-        if norm == 0:
-            vector[0] = 1.0
-            return vector
-
-        return vector / norm
+        return self._safe_normalize(vector)
 
     def _vector_from_text(self, text: str) -> np.ndarray:
         tokens = re.findall(r"[a-z0-9]+", text.lower())
@@ -43,11 +47,9 @@ class MockEmbedder:
             self._vector_from_bytes(f"token:{token}".encode("utf-8"))
             for token in tokens
         ]
+
         vector = np.mean(vectors, axis=0)
-        norm = np.linalg.norm(vector)
-        if norm > 0:
-            vector = vector / norm
-        return vector.astype(np.float32)
+        return self._safe_normalize(vector).astype(np.float32)
 
     def embed_image(self, image: Image.Image) -> np.ndarray:
         if image.mode != "RGB":
@@ -60,6 +62,7 @@ class MockEmbedder:
             + image.height.to_bytes(4, "big")
             + thumbnail.tobytes()
         )
+
         return self._vector_from_bytes(payload)
 
     def embed_text(self, text: str | list[str]) -> np.ndarray:
@@ -77,6 +80,7 @@ class MockEmbedder:
         caption = str(metadata.get("caption", ""))
         objects = metadata.get("objects", [])
         ocr_text = str(metadata.get("ocr_text", ""))
+
         object_text = ",".join(
             sorted(
                 {
@@ -86,19 +90,23 @@ class MockEmbedder:
                 }
             )
         )
+
         image_vector = self.embed_image(image)
 
-        text_parts = [part.strip() for part in [caption, object_text, ocr_text] if part]
+        text_parts = [
+            part.strip()
+            for part in [caption, object_text, ocr_text]
+            if part
+        ]
+
         if text_parts:
             text_vector = self.embed_text(" ".join(text_parts))
-            # Bias toward text in mock mode so lexical relevance is visible during development.
+            # Bias toward text in mock mode
             hybrid_vector = (image_vector * 0.45) + (text_vector * 0.55)
         else:
             hybrid_vector = image_vector
 
-        norm = np.linalg.norm(hybrid_vector)
-        if norm > 0:
-            hybrid_vector = hybrid_vector / norm
+        hybrid_vector = self._safe_normalize(hybrid_vector)
         return hybrid_vector.tolist()
 
 

--- a/backend/src/find_api/workers/processors.py
+++ b/backend/src/find_api/workers/processors.py
@@ -36,6 +36,29 @@ PERSON_OBJECT_LABELS = {
 }
 
 
+def _safe_normalize_embedding(
+    vector: np.ndarray,
+    *,
+    fallback: np.ndarray | None = None,
+) -> np.ndarray:
+    """Return a finite normalized embedding or a finite fallback vector."""
+    clean_vector = np.nan_to_num(
+        np.asarray(vector, dtype=np.float32),
+        nan=0.0,
+        posinf=0.0,
+        neginf=0.0,
+    )
+    norm = np.linalg.norm(clean_vector)
+
+    if np.isfinite(norm) and norm > 0:
+        return (clean_vector / norm).astype(np.float32)
+
+    if fallback is not None:
+        return _safe_normalize_embedding(fallback)
+
+    return np.zeros_like(clean_vector, dtype=np.float32)
+
+
 def _record_stage_error(metadata: Dict[str, Any], stage: str, error: Exception) -> None:
     """Store a safe, user-facing stage failure without stack traces."""
     if isinstance(error, ModelUnavailableError):
@@ -182,7 +205,7 @@ def generate_hybrid_embedding(
         embedder = get_clip_embedder()
 
         # --- 1. Image vector (always computed) ---
-        image_embedding = embedder.embed_image(image)
+        image_embedding = _safe_normalize_embedding(embedder.embed_image(image))
 
         # --- 2. Build text signals — only non-empty strings qualify ---
         caption = (metadata.get("caption") or "").strip()
@@ -225,13 +248,13 @@ def generate_hybrid_embedding(
 
         if text_inputs:
             if len(text_inputs) == 1:
-                signal_vectors[text_signal_names[0]] = embedder.embed_text(
-                    text_inputs[0]
+                signal_vectors[text_signal_names[0]] = _safe_normalize_embedding(
+                    embedder.embed_text(text_inputs[0])
                 )
             else:
                 text_embeddings = embedder.embed_text(text_inputs)
                 for name, vec in zip(text_signal_names, text_embeddings):
-                    signal_vectors[name] = vec
+                    signal_vectors[name] = _safe_normalize_embedding(vec)
 
         active_signals = list(signal_vectors.keys())
 
@@ -252,12 +275,10 @@ def generate_hybrid_embedding(
             n = len(signal_vectors)
             hybrid_vector = sum(signal_vectors.values()) / n
 
-        norm = np.linalg.norm(hybrid_vector)
-        if norm > 0:
-            hybrid_vector = hybrid_vector / norm
-        else:
-            # Degenerate fallback — return the image vector unchanged
-            hybrid_vector = image_embedding
+        hybrid_vector = _safe_normalize_embedding(
+            hybrid_vector,
+            fallback=image_embedding,
+        )
 
         logger.info(
             "Hybrid embedding generated (signals=%d: %s, ocr_weighting=%s)",

--- a/backend/tests/test_hybrid_embedding.py
+++ b/backend/tests/test_hybrid_embedding.py
@@ -275,6 +275,37 @@ class TestHybridEmbeddingEdgeCases:
         norm = float(np.linalg.norm(result))
         assert abs(norm - 1.0) < 1e-5, f"Expected unit norm, got {norm}"
 
+    def test_zero_vector_output_stays_finite(self):
+        """A degenerate all-zero embedding path must not produce NaN values."""
+        zero_vec = np.zeros(DIM, dtype=np.float32)
+        result, _ = _run(
+            image_vec=zero_vec,
+            caption="",
+            objects=[],
+            ocr_text="",
+            text_map={},
+        )
+
+        assert np.all(np.isfinite(result))
+        np.testing.assert_allclose(result, zero_vec, atol=1e-6)
+
+    def test_invalid_text_vector_falls_back_to_finite_embedding(self):
+        """NaN/inf text vectors must not poison the hybrid embedding."""
+        invalid_vec = np.array(
+            [np.nan, np.inf, -np.inf, 0, 0, 0, 0, 0],
+            dtype=np.float32,
+        )
+        result, _ = _run(
+            image_vec=IMG_VEC,
+            caption="bad text",
+            objects=[],
+            ocr_text="",
+            text_map={"bad text": invalid_vec},
+        )
+
+        assert np.all(np.isfinite(result))
+        np.testing.assert_allclose(result, IMG_VEC, atol=1e-6)
+
 
 class TestBiasRemoval:
     """


### PR DESCRIPTION
## Summary

Fixes unsafe vector normalization in MockEmbedder, preventing NaN/inf propagation when handling zero or invalid vectors during embedding generation.

This ensures deterministic and stable embeddings in mock mode and prevents failures in downstream similarity computations and smoke tests.

Fixes #293

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Documentation update
- [ ] Refactor
- [ ] CI / tooling

## What changed

* Added _safe_normalize() helper function to centralize vector normalization logic
* Updated _vector_from_bytes() to use safe normalization
* Updated _vector_from_text() to prevent invalid mean vectors from propagating NaN/inf
* Fixed embed_metadata() hybrid vector normalization using safe checks
* Ensured zero vectors, NaN, and inf values are handled safely


## How to test

Run the following:
python -m compileall .
pytest -q


## Checklist

- [x] I linked the related issue (#293)
- [x] I ran required checks from CONTRIBUTING.md
- [x] I updated docs/env notes if needed
- [x] My PR is scoped to a single issue
- [x] I followed commit message conventions
- [x] I am not committing secrets or local artifacts

## GSSoC'26 checklist

- [x] I requested issue assignment before starting
- [x] I have meaningful commits (no spam commits)
- [x] I am ready to explain my implementation in review comments


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved embedding normalization to defensively handle NaN/±inf and zero-norm vectors, ensuring hybrid embeddings stay finite and fall back to stable defaults when needed.
  * Refined metadata embedding by trimming and filtering whitespace-only text components before combining image/text signals for more consistent similarity results.
* **Tests**
  * Added regression tests covering zero-vector and invalid (NaN/±inf) text embeddings to prevent NaNs/infs in hybrid outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->