### PR TITLE
Add manual GHCR publish workflow

### DIFF
--- a/.github/workflows/manual-ghcr-publish.yml
+++ b/.github/workflows/manual-ghcr-publish.yml
@@ -1,0 +1,128 @@
+name: Manual GHCR Publish
+
+on:
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: "Image tag to publish"
+        required: true
+        default: "latest"
+      backend_flavor:
+        description: "Backend image flavor"
+        required: true
+        default: "light"
+        type: choice
+        options:
+          - light
+          - full-ml
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish:
+    name: Build and publish images from main
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out main
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          ref: main
+          persist-credentials: false
+
+      - name: Prepare image names
+        id: names
+        shell: bash
+        env:
+          IMAGE_TAG: ${{ inputs.image_tag }}
+          BACKEND_FLAVOR: ${{ inputs.backend_flavor }}
+        run: |
+          owner="$(echo "${GITHUB_REPOSITORY_OWNER}" | tr '[:upper:]' '[:lower:]')"
+          tag="${IMAGE_TAG}"
+          if [[ ! "${tag}" =~ ^[A-Za-z0-9._-]+$ ]]; then
+            echo "image_tag may only contain letters, numbers, dots, underscores, and dashes." >&2
+            exit 1
+          fi
+          sha_tag="main-$(git rev-parse --short=12 HEAD)"
+          if [ "${BACKEND_FLAVOR}" = "full-ml" ]; then
+            backend_tags="ghcr.io/${owner}/find-backend:${tag}-full-ml,ghcr.io/${owner}/find-backend:${sha_tag}-full-ml,ghcr.io/${owner}/find-backend:full-ml"
+          else
+            backend_tags="ghcr.io/${owner}/find-backend:${tag},ghcr.io/${owner}/find-backend:${sha_tag},ghcr.io/${owner}/find-backend:latest"
+          fi
+          {
+            echo "backend_image=ghcr.io/${owner}/find-backend"
+            echo "web_image=ghcr.io/${owner}/find-web"
+            echo "backend_tags=${backend_tags}"
+            echo "web_tags=ghcr.io/${owner}/find-web:${tag},ghcr.io/${owner}/find-web:${sha_tag},ghcr.io/${owner}/find-web:latest"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f
+
+      - name: Log in to GHCR
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push lightweight backend image
+        if: inputs.backend_flavor == 'light'
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8
+        with:
+          context: ./backend
+          file: ./backend/Dockerfile
+          push: true
+          platforms: linux/amd64,linux/arm64
+          build-args: |
+            BASE_IMAGE=python:3.12-slim
+            PYTHON_VERSION=3.12
+            UV_SYNC_EXTRAS=
+          tags: ${{ steps.names.outputs.backend_tags }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.description=Find FastAPI backend, lightweight mock-mode image
+
+      - name: Build and push full ML backend image
+        if: inputs.backend_flavor == 'full-ml'
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8
+        with:
+          context: ./backend
+          file: ./backend/Dockerfile
+          push: true
+          platforms: linux/amd64
+          build-args: |
+            BASE_IMAGE=nvidia/cuda:12.1.1-runtime-ubuntu22.04
+            PYTHON_VERSION=3.12
+            UV_SYNC_EXTRAS=--extra ml
+          tags: ${{ steps.names.outputs.backend_tags }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.description=Find FastAPI backend, full local ML image
+
+      - name: Build and push web image
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8
+        with:
+          context: ./frontend
+          file: ./frontend/Dockerfile
+          target: production
+          push: true
+          platforms: linux/amd64,linux/arm64
+          build-args: |
+            NEXT_PUBLIC_API_URL=http://localhost:8000
+            NEXT_PUBLIC_MINIO_URL=http://localhost:9200
+            NEXT_PUBLIC_MINIO_BUCKET=images
+          tags: ${{ steps.names.outputs.web_tags }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.description=Find Next.js web UI
+
+      - name: Publish summary
+        shell: bash
+        env:
+          BACKEND_TAGS: ${{ steps.names.outputs.backend_tags }}
+          WEB_TAGS: ${{ steps.names.outputs.web_tags }}
+        run: |
+          echo "Published backend tags: ${BACKEND_TAGS}" >> "$GITHUB_STEP_SUMMARY"
+          echo "Published web tags: ${WEB_TAGS}" >> "$GITHUB_STEP_SUMMARY"

--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,4 @@ minio_data/
 
 # Local reference copy of the AGPL-3.0 reference project — reference only, never committed
 reference-app/
+immich/

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,25 +1,34 @@
 # syntax=docker/dockerfile:1.7
 
-ARG BASE_IMAGE=nvidia/cuda:12.1.1-runtime-ubuntu22.04
+ARG BASE_IMAGE=python:3.12-slim
 ARG PYTHON_VERSION=3.12
-ARG UV_SYNC_EXTRAS="--extra ml"
+ARG UV_SYNC_EXTRAS=""
 FROM ${BASE_IMAGE}
-ARG UV_SYNC_EXTRAS="--extra ml"
+ARG PYTHON_VERSION=3.12
+ARG UV_SYNC_EXTRAS=""
 
-# Install system dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    python3 \
-    python3-dev \
-    build-essential \
-    libpq-dev \
-    libgl1 \
-    libglib2.0-0 \
-    libsm6 \
-    libxext6 \
-    libxrender-dev \
-    libgomp1 \
-    curl \
-    && rm -rf /var/lib/apt/lists/*
+# Install system dependencies.
+#
+# The set we need depends entirely on whether the ML extra is enabled:
+#   * ML build  (UV_SYNC_EXTRAS contains "ml") — needs a C toolchain to compile
+#     hdbscan and the OpenCV/X11 runtime libs for opencv + torch vision ops, plus
+#     a system python because the CUDA base image ships none.
+#   * Light build (UV_SYNC_EXTRAS empty) — runs on python:3.12-slim, which already
+#     has Python, and every base dependency installs from a prebuilt wheel. No
+#     compiler, no OpenCV libs. Installing them anyway pulled the whole gcc-14
+#     toolchain (~30 min apt) into an image that never uses it.
+#
+# So we branch: full set for ML, just curl (needed to fetch uv) for light.
+RUN set -eux; \
+    apt-get update; \
+    if echo "${UV_SYNC_EXTRAS}" | grep -q "ml"; then \
+      apt-get install -y --no-install-recommends \
+        python3 python3-dev build-essential libpq-dev \
+        libgl1 libglib2.0-0 libsm6 libxext6 libxrender-dev libgomp1 curl; \
+    else \
+      apt-get install -y --no-install-recommends curl; \
+    fi; \
+    rm -rf /var/lib/apt/lists/*
 
 # Ensure "python" command exists when base image only provides python3
 RUN if ! command -v python >/dev/null 2>&1; then \

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -20,11 +20,11 @@ FROM pnpm AS deps
 RUN apk add --no-cache libc6-compat
 WORKDIR /app
 
-COPY pnpm-lock.yaml* ./
+COPY pnpm-lock.yaml* pnpm-workspace.yaml ./
 RUN --mount=type=cache,id=find-pnpm-store,target=/pnpm/store \
     pnpm fetch
 
-COPY package.json ./
+COPY package.json pnpm-workspace.yaml ./
 RUN --mount=type=cache,id=find-pnpm-store,target=/pnpm/store \
     pnpm install --offline --frozen-lockfile
 
@@ -46,6 +46,21 @@ WORKDIR /app
 
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
+
+# NEXT_PUBLIC_* values are inlined into the client bundle at build time, so they
+# must be present here — setting them only at container runtime has no effect on
+# already-built JS. Defaults match the docker-compose port mapping (MinIO on
+# 9200, API on 8000). Override per-deployment with --build-arg.
+ARG NEXT_PUBLIC_API_URL=http://localhost:8000
+ARG NEXT_PUBLIC_MINIO_URL=http://localhost:9200
+ARG NEXT_PUBLIC_MINIO_BUCKET=images
+ARG NEXT_PUBLIC_MAX_BULK_FILES=200
+ARG NEXT_PUBLIC_MAX_UPLOAD_SIZE_MB=50
+ENV NEXT_PUBLIC_API_URL=$NEXT_PUBLIC_API_URL
+ENV NEXT_PUBLIC_MINIO_URL=$NEXT_PUBLIC_MINIO_URL
+ENV NEXT_PUBLIC_MINIO_BUCKET=$NEXT_PUBLIC_MINIO_BUCKET
+ENV NEXT_PUBLIC_MAX_BULK_FILES=$NEXT_PUBLIC_MAX_BULK_FILES
+ENV NEXT_PUBLIC_MAX_UPLOAD_SIZE_MB=$NEXT_PUBLIC_MAX_UPLOAD_SIZE_MB
 
 ENV NEXT_TELEMETRY_DISABLED 1
 ENV NEXT_OUTPUT standalone


### PR DESCRIPTION
## Summary

Adds a manually dispatchable GitHub Actions workflow that checks out `main`, builds Docker images, and publishes them to GitHub Container Registry:

- `ghcr.io/<owner>/find-backend` light multi-arch image by default
- optional full-ML backend image for amd64
- `ghcr.io/<owner>/find-web` multi-arch web image

Also updates the Dockerfiles so the light backend image does not pull the full CUDA/toolchain path by default, and so the web image honors `NEXT_PUBLIC_*` build args used by the workflow. `.gitignore` now explicitly keeps the local reference folder out of commits.

## Validation

- `git diff --check`
- `docker compose config --quiet`
- `gh --version` and `gh auth status`
- PR checks are passing on commit `6ff9cce` (CodeQL, CodeRabbit, GitGuardian, TestSprite, backend-check, frontend-check, compose-check, hardware matrix; Macroscope checks skipped)

## Notes

This workflow becomes visible under GitHub Actions only after this PR is merged to `main`, because workflow files must exist on the default branch for manual dispatch. After the first successful run, the GHCR packages may still need their visibility set to public in GitHub package settings before unauthenticated users can pull them.

Scope was requested and confirmed by the repository owner in the Codex thread for the Find overhaul/manual GHCR rollout.