### PR TITLE
fix: harden Docker builds and local runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
 
       - uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d
         with:
-          version: 10.16.0
+          version: 11.3.0
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ See the documentation index in [`docs/index.md`](./docs/index.md), the mobile di
 - Inspect full-resolution images with zoom, keyboard navigation, and slideshow
 - Share albums with scoped links and optional passwords/download controls
 - Organize media with favorites, archive, recoverable trash, and near-duplicate review
-- Protect hidden images in an encrypted, passphrase-locked local vault
+- Protect hidden images in an encrypted local vault; full design alignment remains in progress
 - Record local feedback for search, captions, objects, and people grouping
 
 ## Tech stack

--- a/README.md
+++ b/README.md
@@ -28,13 +28,31 @@ See the documentation index in [`docs/index.md`](./docs/index.md), the mobile di
 - Extract captions, detected objects, OCR text, EXIF metadata, and dimensions
 - Generate hybrid embeddings for semantic search
 - Automatically cluster related images after indexing completes
-- Browse gallery, inspect details, like/delete media, and review cluster members
+- Browse a virtualized timeline, gallery, albums, people, and clusters
+- Inspect full-resolution images with zoom, keyboard navigation, and slideshow
+- Share albums with scoped links and optional passwords/download controls
+- Organize media with favorites, archive, recoverable trash, and near-duplicate review
+- Protect hidden images in an encrypted, passphrase-locked local vault
+- Record local feedback for search, captions, objects, and people grouping
 
 ## Tech stack
 
 - **Frontend:** Next.js 16, React 19, React Query, Tailwind CSS, Biome
 - **Backend:** FastAPI, SQLAlchemy, PostgreSQL + pgvector, Redis, RQ, MinIO
-- **ML pipeline:** YOLOv10, Florence-2, PaddleOCR, SigLIP (`open-clip`), HDBSCAN
+- **ML pipeline:** YOLO26 nano, Florence-2 base, PaddleOCR, SigLIP (`open-clip`), InsightFace, HDBSCAN
+
+## Runtime profiles
+
+| Profile | Command | Intended use | ML behavior |
+| --- | --- | --- | --- |
+| Light | `docker compose -f docker-compose.light.yml up --build` | UI, API, docs, contributor work, and low-resource smoke tests | Deterministic mock inference; no model downloads or GPU required |
+| Full | `docker compose up --build` | Real caption, OCR, detection, embedding, face, and search-quality validation | Downloads the configured local models and currently expects NVIDIA GPU support |
+
+The full profile is intentionally much larger because it includes CUDA PyTorch,
+PaddleOCR/PaddlePaddle, ONNX Runtime, Florence-2, SigLIP, YOLO26 nano, and
+InsightFace. Use the light profile unless the change specifically needs real ML
+quality or hardware measurements. Model-size and CPU-only packaging improvements
+are tracked in GitHub issues rather than silently changing model behavior.
 
 ## Architecture
 
@@ -80,7 +98,7 @@ This project is open for **GSSoC'26** contributions.
 
 ## Install and run
 
-### Option A: one-command demo stack (recommended)
+### Option A: full real-ML stack
 
 From repository root:
 
@@ -100,7 +118,7 @@ Notes:
 - Current Docker setup is GPU-oriented and expects NVIDIA GPU access.
 - If no root `.env` is present, compose defaults support local demo startup.
 
-### Option B: fast contributor mode
+### Option B: fast contributor mode (recommended for most work)
 
 For UI, API, upload, gallery, search, clustering, docs, and workflow changes, use the light stack:
 

--- a/backend/src/find_api/core/database.py
+++ b/backend/src/find_api/core/database.py
@@ -3,8 +3,7 @@ Database configuration and session management
 """
 
 from sqlalchemy import create_engine, text
-from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm import declarative_base, sessionmaker
 from find_api.core.config import settings
 import logging
 

--- a/backend/src/find_api/core/storage.py
+++ b/backend/src/find_api/core/storage.py
@@ -10,7 +10,10 @@ import asyncio
 import logging
 import threading
 
-from find_api.core.storage_factory import get_storage_instance
+from find_api.core.storage_factory import (
+    StorageNotInitializedError,
+    get_storage_instance,
+)
 from find_api.core.storage_thumbnails import (
     THUMBNAIL_CONTENT_TYPE,
     generate_thumbnail,
@@ -81,16 +84,13 @@ def _get_or_init_storage():
     """
     try:
         return get_storage_instance()
-    except RuntimeError as exc:
-        if "Storage backend not initialized" not in str(exc):
-            raise
+    except StorageNotInitializedError:
+        pass
 
     with _storage_init_lock:
         try:
             return get_storage_instance()
-        except RuntimeError as exc:
-            if "Storage backend not initialized" not in str(exc):
-                raise
+        except StorageNotInitializedError:
             init_storage()
             return get_storage_instance()
 

--- a/backend/src/find_api/core/storage.py
+++ b/backend/src/find_api/core/storage.py
@@ -18,6 +18,7 @@ from find_api.core.storage_thumbnails import (
 )
 
 logger = logging.getLogger(__name__)
+_storage_init_lock = threading.Lock()
 
 __all__ = [
     "THUMBNAIL_CONTENT_TYPE",
@@ -70,47 +71,71 @@ def init_storage():
         raise
 
 
+def _get_or_init_storage():
+    """Return the process-local backend, initializing it for worker processes.
+
+    FastAPI initializes storage during lifespan startup, but RQ workers are
+    separate processes and never execute that lifespan. Lazy initialization
+    keeps the route behavior unchanged while ensuring the first worker storage
+    operation creates its own process-local backend exactly once.
+    """
+    try:
+        return get_storage_instance()
+    except RuntimeError as exc:
+        if "Storage backend not initialized" not in str(exc):
+            raise
+
+    with _storage_init_lock:
+        try:
+            return get_storage_instance()
+        except RuntimeError as exc:
+            if "Storage backend not initialized" not in str(exc):
+                raise
+            init_storage()
+            return get_storage_instance()
+
+
 def upload_file(
     file_data: bytes, object_name: str, content_type: str = "image/jpeg"
 ) -> str:
     """Upload file to storage backend"""
-    backend = get_storage_instance()
+    backend = _get_or_init_storage()
     return _run_backend_call(backend.upload_file(file_data, object_name, content_type))
 
 
 def get_file(object_name: str) -> bytes:
     """Download file from storage backend"""
-    backend = get_storage_instance()
+    backend = _get_or_init_storage()
     return _run_backend_call(backend.get_file(object_name))
 
 
 def download_file_to_path(object_name: str, destination_path: str) -> None:
     """Stream a storage object to a local path without loading into memory"""
-    backend = get_storage_instance()
+    backend = _get_or_init_storage()
     _run_backend_call(backend.download_file_to_path(object_name, destination_path))
 
 
 def get_file_url(object_name: str, expires: int = 3600) -> str:
     """Get presigned URL for file"""
-    backend = get_storage_instance()
+    backend = _get_or_init_storage()
     return _run_backend_call(backend.get_file_url(object_name, expires))
 
 
 def delete_file(object_name: str) -> None:
     """Delete file from storage backend"""
-    backend = get_storage_instance()
+    backend = _get_or_init_storage()
     _run_backend_call(backend.delete_file(object_name))
 
 
 def file_exists(object_name: str) -> bool:
     """Check if file exists in storage backend"""
-    backend = get_storage_instance()
+    backend = _get_or_init_storage()
     return _run_backend_call(backend.file_exists(object_name))
 
 
 def upload_thumbnail(file_data: bytes, file_hash: str) -> dict | None:
     """Generate and upload a thumbnail with the configured storage backend."""
-    backend = get_storage_instance()
+    backend = _get_or_init_storage()
     return _run_backend_call(upload_thumbnail_to_backend(backend, file_data, file_hash))
 
 
@@ -118,7 +143,7 @@ def upload_file_with_thumbnail(
     file_data: bytes, object_name: str, file_hash: str, content_type: str = "image/jpeg"
 ) -> tuple[str, dict | None]:
     """Upload file and generate thumbnail"""
-    backend = get_storage_instance()
+    backend = _get_or_init_storage()
     result = _run_backend_call(
         backend.upload_file(file_data, object_name, content_type)
     )

--- a/backend/src/find_api/core/storage_factory.py
+++ b/backend/src/find_api/core/storage_factory.py
@@ -11,6 +11,10 @@ from find_api.core.storage_abstract import StorageBackend
 logger = logging.getLogger(__name__)
 
 
+class StorageNotInitializedError(RuntimeError):
+    """Raised when process-local storage has not been initialized yet."""
+
+
 def create_storage_backend() -> StorageBackend:
     """Factory function to create the appropriate storage backend"""
     backend_type = getattr(settings, "STORAGE_BACKEND", "minio").lower()
@@ -59,7 +63,7 @@ async def initialize_storage() -> None:
 def get_storage_instance() -> StorageBackend:
     """Get the global storage instance"""
     if _storage_instance is None:
-        raise RuntimeError(
+        raise StorageNotInitializedError(
             "Storage backend not initialized. Call initialize_storage() first."
         )
     return _storage_instance

--- a/backend/src/find_api/core/storage_minio.py
+++ b/backend/src/find_api/core/storage_minio.py
@@ -203,11 +203,19 @@ class MinIOStorageBackend(StorageBackend):
                 base_path = parsed.path.rstrip("/")
                 if base_path:
                     signed_parsed = urlparse(base_url)
+                    signed_path = signed_parsed.path
+                    # A common endpoint value already includes the bucket
+                    # (for example /images). The SDK also includes the bucket
+                    # in signed paths, so only add a distinct proxy prefix.
+                    if signed_path == base_path or signed_path.startswith(
+                        f"{base_path}/"
+                    ):
+                        return base_url
                     base_url = urlunparse(
                         (
                             signed_parsed.scheme,
                             signed_parsed.netloc,
-                            base_path + signed_parsed.path,
+                            base_path + signed_path,
                             signed_parsed.params,
                             signed_parsed.query,
                             signed_parsed.fragment,

--- a/backend/src/find_api/services/duplicate_service.py
+++ b/backend/src/find_api/services/duplicate_service.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import json
 from typing import Any
 
 from sqlalchemy import text
@@ -33,7 +34,9 @@ def find_near_duplicate(
         """
         ),
         {
-            "embedding": str(embedding),
+            # pgvector accepts JSON-style vectors. SQLAlchemy may return a NumPy
+            # array here, whose string form uses whitespace instead of commas.
+            "embedding": json.dumps([float(value) for value in embedding]),
             "media_id": media_id,
         },
     ).fetchone()

--- a/backend/src/find_api/services/duplicate_service.py
+++ b/backend/src/find_api/services/duplicate_service.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
-import logging
 import json
+import logging
+from collections.abc import Iterable
 from typing import Any
 
 from sqlalchemy import text
@@ -18,7 +19,7 @@ SIMILARITY_THRESHOLD = 0.97
 def find_near_duplicate(
     db: Session,
     media_id: int,
-    embedding: list[float],
+    embedding: Iterable[float],
 ) -> int | None:
     """Query pgvector for a near-duplicate of a newly indexed image."""
     result = db.execute(

--- a/backend/src/find_api/workers/jobs.py
+++ b/backend/src/find_api/workers/jobs.py
@@ -5,7 +5,7 @@ Background worker jobs for image processing
 from PIL import Image
 import io
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 import numpy as np
 from rq import get_current_job
 
@@ -178,7 +178,7 @@ def analyze_image(media_id: int, clear_model_failures: bool = False):
 
         media.metadata_json = metadata
         media.status = "indexed"
-        media.processed_at = datetime.utcnow()
+        media.processed_at = datetime.now(timezone.utc)
 
         db.commit()
         invalidate_query_cache()

--- a/backend/tests/test_duplicate_service.py
+++ b/backend/tests/test_duplicate_service.py
@@ -51,9 +51,11 @@ class _FakeDb:
     def __init__(self, row: tuple[int, float] | None):
         self.row = row
         self.statements: list[str] = []
+        self.params: list[dict[str, Any]] = []
 
     def execute(self, statement: Any, params: dict[str, Any] | None = None):
         self.statements.append(str(statement))
+        self.params.append(params or {})
         return _FakeResult(self.row)
 
 
@@ -76,6 +78,22 @@ def test_find_near_duplicate_returns_match_above_threshold():
     assert result == 42
     assert "user_id" not in db.statements[0]
     assert "id != :media_id" in db.statements[0]
+    assert db.params[0]["embedding"] == "[0.1, 0.2, 0.3]"
+
+
+def test_find_near_duplicate_serializes_numpy_vectors_for_pgvector():
+    np = pytest.importorskip("numpy")
+    db = _FakeDb(None)
+
+    find_near_duplicate(
+        db,
+        media_id=7,
+        embedding=np.asarray([0.1, 0.2, 0.3], dtype=np.float32),
+    )
+
+    serialized = db.params[0]["embedding"]
+    assert serialized.startswith("[")
+    assert "," in serialized
 
 
 def test_find_near_duplicate_ignores_match_below_threshold():

--- a/backend/tests/test_reprocess.py
+++ b/backend/tests/test_reprocess.py
@@ -100,14 +100,14 @@ def _fresh_db():
 
 _ORIGINAL_GALLERY_MEDIA = gallery_module.Media
 
-test_app = FastAPI()
-test_app.include_router(gallery_module.router, prefix="/api")
-test_app.dependency_overrides[get_db] = get_test_db
+app_under_test = FastAPI()
+app_under_test.include_router(gallery_module.router, prefix="/api")
+app_under_test.dependency_overrides[get_db] = get_test_db
 # Gallery endpoints now depend on get_required_user; this minimal test app
 # has no users table, so force local (single-user) mode by returning None.
 from find_api.core.dependencies import get_required_user  # noqa: E402
 
-test_app.dependency_overrides[get_required_user] = lambda: None
+app_under_test.dependency_overrides[get_required_user] = lambda: None
 
 
 @pytest.fixture(autouse=True, scope="module")
@@ -140,7 +140,7 @@ def reset_db():
 
 @pytest.fixture()
 def client():
-    with TestClient(test_app) as c:
+    with TestClient(app_under_test) as c:
         yield c
 
 

--- a/backend/tests/test_storage_facade.py
+++ b/backend/tests/test_storage_facade.py
@@ -50,6 +50,29 @@ def fake_backend(monkeypatch):
     return backend
 
 
+def test_storage_facade_initializes_backend_inside_worker_process(monkeypatch):
+    """The first worker call initializes storage when app lifespan never ran."""
+    backend = FakeAsyncStorageBackend()
+    initialized = False
+
+    def get_instance():
+        if not initialized:
+            raise RuntimeError(
+                "Storage backend not initialized. Call initialize_storage() first."
+            )
+        return backend
+
+    def initialize():
+        nonlocal initialized
+        initialized = True
+
+    monkeypatch.setattr(storage, "get_storage_instance", get_instance)
+    monkeypatch.setattr(storage, "init_storage", initialize)
+
+    assert storage.get_file("worker-image.jpg") == b"data:worker-image.jpg"
+    assert initialized is True
+
+
 @pytest.mark.asyncio
 async def test_sync_storage_facade_returns_values_inside_running_event_loop(
     fake_backend,

--- a/backend/tests/test_storage_facade.py
+++ b/backend/tests/test_storage_facade.py
@@ -57,7 +57,7 @@ def test_storage_facade_initializes_backend_inside_worker_process(monkeypatch):
 
     def get_instance():
         if not initialized:
-            raise RuntimeError(
+            raise storage.StorageNotInitializedError(
                 "Storage backend not initialized. Call initialize_storage() first."
             )
         return backend

--- a/backend/tests/test_storage_minio_urls.py
+++ b/backend/tests/test_storage_minio_urls.py
@@ -1,0 +1,27 @@
+"""Regression tests for public MinIO URL rewriting."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import patch
+
+from find_api.core.config import settings
+from find_api.core.storage_minio import MinIOStorageBackend
+
+
+def test_presigned_url_does_not_duplicate_bucket_path(monkeypatch):
+    monkeypatch.setattr(
+        settings, "MINIO_PUBLIC_ENDPOINT", "http://localhost:9200/images"
+    )
+    monkeypatch.setattr(settings, "MINIO_PUBLIC_READ", False)
+
+    with patch("find_api.core.storage_minio.Minio") as minio_cls:
+        minio_cls.return_value.presigned_get_object.return_value = (
+            "http://localhost:9200/images/images/example.webp?signature=test"
+        )
+        backend = MinIOStorageBackend()
+        backend._public_client = minio_cls.return_value
+
+        url = asyncio.run(backend.get_file_url("images/example.webp"))
+
+    assert url == "http://localhost:9200/images/images/example.webp?signature=test"

--- a/backend/tests/test_storage_minio_urls.py
+++ b/backend/tests/test_storage_minio_urls.py
@@ -9,7 +9,7 @@ from find_api.core.config import settings
 from find_api.core.storage_minio import MinIOStorageBackend
 
 
-def test_presigned_url_does_not_duplicate_bucket_path(monkeypatch):
+def test_presigned_url_does_not_repeat_public_endpoint_prefix(monkeypatch):
     monkeypatch.setattr(
         settings, "MINIO_PUBLIC_ENDPOINT", "http://localhost:9200/images"
     )

--- a/docker-compose.light.yml
+++ b/docker-compose.light.yml
@@ -1,6 +1,17 @@
+x-light-backend: &light-backend
+  image: find-light-backend
+  pull_policy: never
+  build:
+    context: ./backend
+    dockerfile: Dockerfile
+    args:
+      BASE_IMAGE: python:3.12-slim
+      PYTHON_VERSION: "3.12"
+      UV_SYNC_EXTRAS: ""
+
 services:
   db:
-    image: ankane/pgvector:latest
+    image: pgvector/pgvector:0.8.4-pg16-bookworm
     container_name: find-light-db
     # Local-only defaults for contributor setup. Override via .env for anything else.
     environment:
@@ -19,7 +30,7 @@ services:
       retries: 5
 
   redis:
-    image: redis:7-alpine
+    image: redis:7.4.9-alpine3.21
     command: redis-server --loglevel warning
     container_name: find-light-redis
     ports:
@@ -33,7 +44,7 @@ services:
       retries: 5
 
   minio:
-    image: minio/minio:latest
+    image: minio/minio:RELEASE.2025-09-07T16-13-09Z
     container_name: find-light-minio
     command: server /data --console-address ":9001"
     # Local-only defaults for contributor setup. Never reuse these credentials in production.
@@ -52,14 +63,7 @@ services:
       retries: 3
 
   api:
-    image: find-light-backend
-    build:
-      context: ./backend
-      dockerfile: Dockerfile
-      args:
-        BASE_IMAGE: python:3.12-slim
-        PYTHON_VERSION: "3.12"
-        UV_SYNC_EXTRAS: ""
+    <<: *light-backend
     container_name: find-light-api
     command: uvicorn find_api.main:app --host 0.0.0.0 --port 8000 --log-level warning
     ports:
@@ -92,7 +96,7 @@ services:
     restart: unless-stopped
 
   worker:
-    image: find-light-backend
+    <<: *light-backend
     container_name: find-light-worker
     command: rq worker --worker-class ${RQ_WORKER_CLASS:-rq.worker.worker_classes.SimpleWorker} --url redis://redis:6379 high default low
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,17 @@
+x-full-backend: &full-backend
+  image: find-backend
+  pull_policy: never
+  build:
+    context: ./backend
+    dockerfile: Dockerfile
+    args:
+      BASE_IMAGE: ${BACKEND_BASE_IMAGE:-nvidia/cuda:12.1.1-runtime-ubuntu22.04}
+      PYTHON_VERSION: ${BACKEND_PYTHON_VERSION:-3.12}
+
 services:
   # PostgreSQL Database with pgvector
   db:
-    image: ankane/pgvector:latest
+    image: pgvector/pgvector:0.8.4-pg16-bookworm
     container_name: find-db
     environment:
       POSTGRES_DB: find
@@ -22,7 +32,7 @@ services:
 
   # Redis for job queue
   redis:
-    image: redis:7-alpine
+    image: redis:7.4.9-alpine3.21
     command: redis-server --loglevel warning --requirepass ${REDIS_PASSWORD:-find-redis-dev}
     container_name: find-redis
     hostname: redis
@@ -39,7 +49,7 @@ services:
 
   # MinIO for object storage
   minio:
-    image: minio/minio:latest
+    image: minio/minio:RELEASE.2025-09-07T16-13-09Z
     container_name: find-minio
     command: server /data --console-address ":9001"
     environment:
@@ -60,13 +70,7 @@ services:
 
   # FastAPI Backend
   api:
-    image: find-backend
-    build:
-      context: ./backend
-      dockerfile: Dockerfile
-      args:
-        BASE_IMAGE: ${BACKEND_BASE_IMAGE:-nvidia/cuda:12.1.1-runtime-ubuntu22.04}
-        PYTHON_VERSION: ${BACKEND_PYTHON_VERSION:-3.12}
+    <<: *full-backend
     container_name: find-api
     command: uvicorn find_api.main:app --host 0.0.0.0 --port 8000 --log-level warning
     ports:
@@ -108,7 +112,7 @@ services:
 
   # RQ Worker for background ML processing
   worker:
-    image: find-backend
+    <<: *full-backend
     container_name: find-worker
     command: rq worker --worker-class ${RQ_WORKER_CLASS:-rq.worker.worker_classes.SimpleWorker} --url ${REDIS_URL:-redis://:find-redis-dev@redis:6379} high default low
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ x-full-backend: &full-backend
     args:
       BASE_IMAGE: ${BACKEND_BASE_IMAGE:-nvidia/cuda:12.1.1-runtime-ubuntu22.04}
       PYTHON_VERSION: ${BACKEND_PYTHON_VERSION:-3.12}
+      UV_SYNC_EXTRAS: "--extra ml"
 
 services:
   # PostgreSQL Database with pgvector

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,6 +21,7 @@ This directory is organized by document purpose and implementation status.
 - [Desktop Framework Evaluation](plans/partial/desktop-tauri-vs-electron-adr.md) - Tauri spike exists, but release-grade packaging and updater decisions remain open.
 - [Personalization Research](plans/partial/personalization-research.md) - feedback collection exists; adaptive personalization is still planned.
 - [Vault Encryption Design](plans/partial/vault-encryption-design.md) - vault feature exists, but implementation still needs alignment with the full design note.
+- [Small-Team Authentication](plans/partial/small-team-authentication.md) - authentication foundations exist; the Instance management UI remains planned.
 
 ### Not Started
 
@@ -31,7 +32,6 @@ This directory is organized by document purpose and implementation status.
 - [Desktop Runtime Quick Reference](plans/not-started/desktop-runtime-quick-reference.md)
 - [Mobile Strategy ADR](plans/not-started/mobile-strategy.md)
 - [Optional Self-Hosted Remote Acceleration](plans/not-started/remote-acceleration.md)
-- [Small-Team Authentication](plans/not-started/small-team-authentication.md)
 
 ## Guides
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,7 +21,7 @@ This directory is organized by document purpose and implementation status.
 - [Desktop Framework Evaluation](plans/partial/desktop-tauri-vs-electron-adr.md) - Tauri spike exists, but release-grade packaging and updater decisions remain open.
 - [Personalization Research](plans/partial/personalization-research.md) - feedback collection exists; adaptive personalization is still planned.
 - [Vault Encryption Design](plans/partial/vault-encryption-design.md) - vault feature exists, but implementation still needs alignment with the full design note.
-- [Small-Team Authentication](plans/partial/small-team-authentication.md) - authentication foundations exist; the Instance management UI remains planned.
+- [Small-Team Authentication](plans/partial/small-team-authentication.md) - backend authentication foundations exist; frontend UI, deletion-request workflow, audit log, and Instance management UI remain planned.
 
 ### Not Started
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.7
 
-FROM node:20-alpine AS base
-ARG PNPM_VERSION=10.17.1
+FROM node:22-alpine AS base
+ARG PNPM_VERSION=11.3.0
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,7 @@
 {
   "name": "find-frontend",
   "version": "1.0.0",
+  "packageManager": "pnpm@11.3.0",
   "private": true,
   "license": "AGPL-3.0-only",
   "scripts": {
@@ -50,20 +51,5 @@
     "tailwindcss-animate": "^1.0.7",
     "typescript": "^5.9.3",
     "vitest": "^4.1.6"
-  },
-  "pnpm": {
-    "overrides": {
-      "postcss": "^8.5.14"
-    },
-    "onlyBuiltDependencies": [
-      "sharp"
-    ],
-    "allowedDeprecatedVersions": {},
-    "allowBuild": [
-      "sharp"
-    ],
-    "allowBuilds": {
-      "sharp": true
-    }
   }
 }

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -5,7 +5,10 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  form-data: 4.0.6
   postcss: ^8.5.14
+  undici: 7.28.0
+  vite: 8.0.16
 
 importers:
 
@@ -77,7 +80,7 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
         specifier: ^6.0.2
-        version: 6.0.2(vite@8.0.12(@types/node@22.19.1)(jiti@1.21.7))
+        version: 6.0.2(vite@8.0.16(@types/node@22.19.1)(jiti@1.21.7))
       autoprefixer:
         specifier: ^10.5.0
         version: 10.5.0(postcss@8.5.14)
@@ -101,7 +104,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.6
-        version: 4.1.6(@types/node@22.19.1)(jsdom@29.1.1)(vite@8.0.12(@types/node@22.19.1)(jiti@1.21.7))
+        version: 4.1.6(@types/node@22.19.1)(jsdom@29.1.1)(vite@8.0.16(@types/node@22.19.1)(jiti@1.21.7))
 
 packages:
 
@@ -500,105 +503,105 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@oxc-project/types@0.129.0':
-    resolution: {integrity: sha512-3oz8m3FGdr2nDXVqmFUw7jolKliC4MoyXYIG2c7gpjBnzUWQpUGIYcXYKxTdTi+N2jusvt610ckTMkxdwHkYEg==}
+  '@oxc-project/types@0.133.0':
+    resolution: {integrity: sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==}
 
   '@playwright/test@1.61.0':
     resolution: {integrity: sha512-cKA5B6lpFEMyMGjxF54QihfYpB4FkEGH+qZhtArDEG+wezQAJY8Pq6C7T1SjWz+FFzt3TbyoXBQYk/0292TdJA==}
     engines: {node: '>=18'}
     hasBin: true
 
-  '@rolldown/binding-android-arm64@1.0.0':
-    resolution: {integrity: sha512-TWMZnRLMe63C2Lhyicviu7ZHaU4kxa6PS3rofvc9GmcvptzNN11BcfQ4Sl7MwTOsisQoa2keB/EBdNCAnUo8vA==}
+  '@rolldown/binding-android-arm64@1.0.3':
+    resolution: {integrity: sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@rolldown/binding-darwin-arm64@1.0.0':
-    resolution: {integrity: sha512-6XcD+8k0gPVItNagEw78/qqcBDwKcwDYS8V2hRmVsfUSIrd8cWe/CBvRDI5toqFyPfj+FJr6t8U6Xj2P2prEew==}
+  '@rolldown/binding-darwin-arm64@1.0.3':
+    resolution: {integrity: sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@rolldown/binding-darwin-x64@1.0.0':
-    resolution: {integrity: sha512-iN/tWVXRQDWvmZlKdceP1Dwug9GDpEymhb9p4xnEe6zvCg5lFmzVljl+1qR1NVx3yfGpr2Na+CuLmv5IU8uzfQ==}
+  '@rolldown/binding-darwin-x64@1.0.3':
+    resolution: {integrity: sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@rolldown/binding-freebsd-x64@1.0.0':
-    resolution: {integrity: sha512-jjQMDvvwSOuhOwMszD/klSOjyWMM3zI64hWTj9KT5x4MxRbZAf+7vLQ6qouRhtsLVFHr3f0ILaJAfgENPiQdAQ==}
+  '@rolldown/binding-freebsd-x64@1.0.3':
+    resolution: {integrity: sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0':
-    resolution: {integrity: sha512-d//Dtg2x6/m3mbV64yUGNnDGNZaDGRpDLLNGerHQUVObuNaIQaaDp25yUiqGXtHEXX+NP2d0wAlmKgpYgIAJ2A==}
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.3':
+    resolution: {integrity: sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.0':
-    resolution: {integrity: sha512-n7Ofp0mx+aB2cC+Sdy5YtMnXtY9lchnHbY+3Yt0uq9JsWQExf4f5Whu0tK0R8Jdc9S6RchTHjIFY7uc92puOVQ==}
+  '@rolldown/binding-linux-arm64-gnu@1.0.3':
+    resolution: {integrity: sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-arm64-musl@1.0.0':
-    resolution: {integrity: sha512-EIVjy2cgd7uuMMo94FVkBp7F6DhcZAUwNURkSG3RwUmvAXR6s0ISxM81U+IydcZByPG0pZIHsf1b6kTxoFDgJA==}
+  '@rolldown/binding-linux-arm64-musl@1.0.3':
+    resolution: {integrity: sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-linux-ppc64-gnu@1.0.0':
-    resolution: {integrity: sha512-JEwwOPcwTLAcpDQlqSmjEmfs63xJnSiUNIGvLcDLUHCWK4XowpS/7c7tUsUH6uT/ct6bMUTdXKfI8967FYj6mg==}
+  '@rolldown/binding-linux-ppc64-gnu@1.0.3':
+    resolution: {integrity: sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-s390x-gnu@1.0.0':
-    resolution: {integrity: sha512-0wjCFhLrihtAubnT9iA0N++0pSV0z5Hg7tNGdNJ4RFaINceHadoF+kiFGyY1qSSNVIAZtLotG8Ju1bgDPkjnFA==}
+  '@rolldown/binding-linux-s390x-gnu@1.0.3':
+    resolution: {integrity: sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-x64-gnu@1.0.0':
-    resolution: {integrity: sha512-Dfn7iak9BcMMePxcoJfpSbWqnEyrp/dRF63/8qW/eHBdOZov6x5aShLLEYGYdIeSJ6vMLK/XCVB+lGIxm41bQA==}
+  '@rolldown/binding-linux-x64-gnu@1.0.3':
+    resolution: {integrity: sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-x64-musl@1.0.0':
-    resolution: {integrity: sha512-5/utzzDmD/pD/bmuaUcbTf/sZYy0aztwIVlfpoW1fTjCZ0BaPOMVWGZL1zvgxyi7ZIVYWlxKONHmSbHuiOh8Jw==}
+  '@rolldown/binding-linux-x64-musl@1.0.3':
+    resolution: {integrity: sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-openharmony-arm64@1.0.0':
-    resolution: {integrity: sha512-ouJs8VcUomfLfpbUECqFMRqdV4x6aeAK3MA4m6vTrJJjKyWTV5KnxZx7Jd9G+GlDaQQxubcba00x16OyJ1meig==}
+  '@rolldown/binding-openharmony-arm64@1.0.3':
+    resolution: {integrity: sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rolldown/binding-wasm32-wasi@1.0.0':
-    resolution: {integrity: sha512-E+oHKGiDA+lsKMmFtffDDw91EryDT7uJocrIuCHqhm6bCTM6xFK+3gaCkYOHfPwQr0cCNarSM2xaELoQDz9jJg==}
+  '@rolldown/binding-wasm32-wasi@1.0.3':
+    resolution: {integrity: sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [wasm32]
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.0':
-    resolution: {integrity: sha512-yYK02n8Rngo+gbm1y6G0+7jk1sJ/2Wt7K0me0Y7k/ErBpyf+LJ2gFpqWVTcRV1rUepBlQRmpgWkTQCiiwrK0Ow==}
+  '@rolldown/binding-win32-arm64-msvc@1.0.3':
+    resolution: {integrity: sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@rolldown/binding-win32-x64-msvc@1.0.0':
-    resolution: {integrity: sha512-14bpChMahXRRXiTwahSl+zzHPW6qQTXtkMuJBFlbo+pqSAews2d4BdCSHfrJ/MBsCZtpmTafsY+1QhBzitcmdg==}
+  '@rolldown/binding-win32-x64-msvc@1.0.3':
+    resolution: {integrity: sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
@@ -751,7 +754,7 @@ packages:
     peerDependencies:
       '@rolldown/plugin-babel': ^0.1.7 || ^0.2.0
       babel-plugin-react-compiler: ^1.0.0
-      vite: ^8.0.0
+      vite: 8.0.16
     peerDependenciesMeta:
       '@rolldown/plugin-babel':
         optional: true
@@ -765,7 +768,7 @@ packages:
     resolution: {integrity: sha512-MCFc63czMjEInOlcY2cpQCvCN+KgbAn+60xu9cMgP4sKaLC5JNAKw7JH8QdAnoAC88hW1IiSNZ+GgVXlN1UcMQ==}
     peerDependencies:
       msw: ^2.4.9
-      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+      vite: 8.0.16
     peerDependenciesMeta:
       msw:
         optional: true
@@ -1029,8 +1032,8 @@ packages:
       debug:
         optional: true
 
-  form-data@4.0.5:
-    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+  form-data@4.0.6:
+    resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
     engines: {node: '>= 6'}
 
   fraction.js@5.3.4:
@@ -1462,8 +1465,8 @@ packages:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
-  rolldown@1.0.0:
-    resolution: {integrity: sha512-yD986aXDESFGS95spT1LAv0jssywP4npMEjmMHyN2/5+eE8qQJUype2AaKkRiLgBgyD0LFlubwAht7VmY8rGoA==}
+  rolldown@1.0.3:
+    resolution: {integrity: sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
@@ -1573,8 +1576,8 @@ packages:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
 
-  tinyglobby@0.2.16:
-    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
 
   tinyrainbow@3.1.0:
@@ -1614,8 +1617,8 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
-  undici@7.26.0:
-    resolution: {integrity: sha512-3O9Tf67pGhgOv9jM35AbhkXAKi13f3oy3aE4CSgr+TckGeY+/iu97ZXN+J7DpHPzLbVApFd1IFhcnBjREYXYcg==}
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
 
   update-browserslist-db@1.2.3:
@@ -1627,8 +1630,8 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
-  vite@8.0.12:
-    resolution: {integrity: sha512-w2dDofOWv2QB09ZITZBsvKTVAlYvPR4IAmrY/v0ir9KvLs0xybR7i48wxhM1/oyBWO34wPns+bPGw5ZrZqDpZg==}
+  vite@8.0.16:
+    resolution: {integrity: sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -1686,7 +1689,7 @@ packages:
       '@vitest/ui': 4.1.6
       happy-dom: '*'
       jsdom: '*'
-      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+      vite: 8.0.16
     peerDependenciesMeta:
       '@edge-runtime/vm':
         optional: true
@@ -2039,59 +2042,59 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
 
-  '@oxc-project/types@0.129.0': {}
+  '@oxc-project/types@0.133.0': {}
 
   '@playwright/test@1.61.0':
     dependencies:
       playwright: 1.61.0
 
-  '@rolldown/binding-android-arm64@1.0.0':
+  '@rolldown/binding-android-arm64@1.0.3':
     optional: true
 
-  '@rolldown/binding-darwin-arm64@1.0.0':
+  '@rolldown/binding-darwin-arm64@1.0.3':
     optional: true
 
-  '@rolldown/binding-darwin-x64@1.0.0':
+  '@rolldown/binding-darwin-x64@1.0.3':
     optional: true
 
-  '@rolldown/binding-freebsd-x64@1.0.0':
+  '@rolldown/binding-freebsd-x64@1.0.3':
     optional: true
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0':
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.3':
     optional: true
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.0':
+  '@rolldown/binding-linux-arm64-gnu@1.0.3':
     optional: true
 
-  '@rolldown/binding-linux-arm64-musl@1.0.0':
+  '@rolldown/binding-linux-arm64-musl@1.0.3':
     optional: true
 
-  '@rolldown/binding-linux-ppc64-gnu@1.0.0':
+  '@rolldown/binding-linux-ppc64-gnu@1.0.3':
     optional: true
 
-  '@rolldown/binding-linux-s390x-gnu@1.0.0':
+  '@rolldown/binding-linux-s390x-gnu@1.0.3':
     optional: true
 
-  '@rolldown/binding-linux-x64-gnu@1.0.0':
+  '@rolldown/binding-linux-x64-gnu@1.0.3':
     optional: true
 
-  '@rolldown/binding-linux-x64-musl@1.0.0':
+  '@rolldown/binding-linux-x64-musl@1.0.3':
     optional: true
 
-  '@rolldown/binding-openharmony-arm64@1.0.0':
+  '@rolldown/binding-openharmony-arm64@1.0.3':
     optional: true
 
-  '@rolldown/binding-wasm32-wasi@1.0.0':
+  '@rolldown/binding-wasm32-wasi@1.0.3':
     dependencies:
       '@emnapi/core': 1.10.0
       '@emnapi/runtime': 1.10.0
       '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.0':
+  '@rolldown/binding-win32-arm64-msvc@1.0.3':
     optional: true
 
-  '@rolldown/binding-win32-x64-msvc@1.0.0':
+  '@rolldown/binding-win32-x64-msvc@1.0.3':
     optional: true
 
   '@rolldown/pluginutils@1.0.0': {}
@@ -2214,10 +2217,10 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
-  '@vitejs/plugin-react@6.0.2(vite@8.0.12(@types/node@22.19.1)(jiti@1.21.7))':
+  '@vitejs/plugin-react@6.0.2(vite@8.0.16(@types/node@22.19.1)(jiti@1.21.7))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0
-      vite: 8.0.12(@types/node@22.19.1)(jiti@1.21.7)
+      vite: 8.0.16(@types/node@22.19.1)(jiti@1.21.7)
 
   '@vitest/expect@4.1.6':
     dependencies:
@@ -2228,13 +2231,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.6(vite@8.0.12(@types/node@22.19.1)(jiti@1.21.7))':
+  '@vitest/mocker@4.1.6(vite@8.0.16(@types/node@22.19.1)(jiti@1.21.7))':
     dependencies:
       '@vitest/spy': 4.1.6
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.12(@types/node@22.19.1)(jiti@1.21.7)
+      vite: 8.0.16(@types/node@22.19.1)(jiti@1.21.7)
 
   '@vitest/pretty-format@4.1.6':
     dependencies:
@@ -2297,7 +2300,7 @@ snapshots:
   axios@1.16.0:
     dependencies:
       follow-redirects: 1.16.0
-      form-data: 4.0.5
+      form-data: 4.0.6
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
       - debug
@@ -2471,7 +2474,7 @@ snapshots:
 
   follow-redirects@1.16.0: {}
 
-  form-data@4.0.5:
+  form-data@4.0.6:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8
@@ -2576,7 +2579,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.1
-      undici: 7.26.0
+      undici: 7.28.0
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -2846,26 +2849,26 @@ snapshots:
 
   reusify@1.1.0: {}
 
-  rolldown@1.0.0:
+  rolldown@1.0.3:
     dependencies:
-      '@oxc-project/types': 0.129.0
+      '@oxc-project/types': 0.133.0
       '@rolldown/pluginutils': 1.0.0
     optionalDependencies:
-      '@rolldown/binding-android-arm64': 1.0.0
-      '@rolldown/binding-darwin-arm64': 1.0.0
-      '@rolldown/binding-darwin-x64': 1.0.0
-      '@rolldown/binding-freebsd-x64': 1.0.0
-      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0
-      '@rolldown/binding-linux-arm64-gnu': 1.0.0
-      '@rolldown/binding-linux-arm64-musl': 1.0.0
-      '@rolldown/binding-linux-ppc64-gnu': 1.0.0
-      '@rolldown/binding-linux-s390x-gnu': 1.0.0
-      '@rolldown/binding-linux-x64-gnu': 1.0.0
-      '@rolldown/binding-linux-x64-musl': 1.0.0
-      '@rolldown/binding-openharmony-arm64': 1.0.0
-      '@rolldown/binding-wasm32-wasi': 1.0.0
-      '@rolldown/binding-win32-arm64-msvc': 1.0.0
-      '@rolldown/binding-win32-x64-msvc': 1.0.0
+      '@rolldown/binding-android-arm64': 1.0.3
+      '@rolldown/binding-darwin-arm64': 1.0.3
+      '@rolldown/binding-darwin-x64': 1.0.3
+      '@rolldown/binding-freebsd-x64': 1.0.3
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.3
+      '@rolldown/binding-linux-arm64-gnu': 1.0.3
+      '@rolldown/binding-linux-arm64-musl': 1.0.3
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.3
+      '@rolldown/binding-linux-s390x-gnu': 1.0.3
+      '@rolldown/binding-linux-x64-gnu': 1.0.3
+      '@rolldown/binding-linux-x64-musl': 1.0.3
+      '@rolldown/binding-openharmony-arm64': 1.0.3
+      '@rolldown/binding-wasm32-wasi': 1.0.3
+      '@rolldown/binding-win32-arm64-msvc': 1.0.3
+      '@rolldown/binding-win32-x64-msvc': 1.0.3
 
   run-parallel@1.2.0:
     dependencies:
@@ -3005,7 +3008,7 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
 
-  tinyglobby@0.2.16:
+  tinyglobby@0.2.17:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
@@ -3038,7 +3041,7 @@ snapshots:
 
   undici-types@6.21.0: {}
 
-  undici@7.26.0: {}
+  undici@7.28.0: {}
 
   update-browserslist-db@1.2.3(browserslist@4.28.2):
     dependencies:
@@ -3048,22 +3051,22 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  vite@8.0.12(@types/node@22.19.1)(jiti@1.21.7):
+  vite@8.0.16(@types/node@22.19.1)(jiti@1.21.7):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
       postcss: 8.5.15
-      rolldown: 1.0.0
-      tinyglobby: 0.2.16
+      rolldown: 1.0.3
+      tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 22.19.1
       fsevents: 2.3.3
       jiti: 1.21.7
 
-  vitest@4.1.6(@types/node@22.19.1)(jsdom@29.1.1)(vite@8.0.12(@types/node@22.19.1)(jiti@1.21.7)):
+  vitest@4.1.6(@types/node@22.19.1)(jsdom@29.1.1)(vite@8.0.16(@types/node@22.19.1)(jiti@1.21.7)):
     dependencies:
       '@vitest/expect': 4.1.6
-      '@vitest/mocker': 4.1.6(vite@8.0.12(@types/node@22.19.1)(jiti@1.21.7))
+      '@vitest/mocker': 4.1.6(vite@8.0.16(@types/node@22.19.1)(jiti@1.21.7))
       '@vitest/pretty-format': 4.1.6
       '@vitest/runner': 4.1.6
       '@vitest/snapshot': 4.1.6
@@ -3080,7 +3083,7 @@ snapshots:
       tinyexec: 1.1.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vite: 8.0.12(@types/node@22.19.1)(jiti@1.21.7)
+      vite: 8.0.16(@types/node@22.19.1)(jiti@1.21.7)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.19.1

--- a/frontend/pnpm-workspace.yaml
+++ b/frontend/pnpm-workspace.yaml
@@ -1,5 +1,14 @@
 minimumReleaseAge: 10080
 minimumReleaseAgeExclude:
   - baseline-browser-mapping
+  # Security patches must not wait for the normal seven-day release-age gate.
+  - form-data
+  - undici
+  - vite
 allowBuilds:
   sharp: true
+overrides:
+  form-data: 4.0.6
+  postcss: ^8.5.14
+  undici: 7.28.0
+  vite: 8.0.16


### PR DESCRIPTION
## Summary

Harden local and CI builds, repair worker-only runtime failures discovered through a real Docker upload, update dependency tooling, and align the documentation with the current application.

Closes #332
Closes #333
Closes #334
Closes #337

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] Documentation update
- [x] Refactor
- [x] CI / tooling

## What changed

- Align Node 22 and pnpm 11 across Docker, CI, and package metadata; patch audited frontend dependencies and allow the Sharp install script.
- Build one deterministic backend image per Compose profile and pin PostgreSQL/pgvector, Redis, and MinIO images.
- Lazily initialize storage in RQ worker processes, serialize NumPy embeddings safely for pgvector, and prevent duplicated MinIO endpoint paths.
- Remove the scoped SQLAlchemy, naive UTC, and pytest collection warnings.
- Update the README and documentation index for the current UI, vault, sharing, models, and light/full runtime profiles.
- Add focused regressions for worker storage initialization, MinIO URLs, duplicate detection, and reprocessing.

## Root cause and impact

The API initialized storage during FastAPI lifespan startup, but RQ workers run in separate processes and never execute that lifespan. In addition, NumPy's string representation is not a valid pgvector literal, and the configured MinIO bucket path could be prepended twice during presigned URL rewriting. These defects allowed healthy containers to fail during real image processing.

After this change, a first-run light-stack build is reproducible and a fresh upload completes indexing with working original and thumbnail URLs.

## Screenshots / recordings

No visual behavior changed. The production UI routes were smoke-tested from the rebuilt Docker image.

## How to test

```bash
docker compose -f docker-compose.light.yml config --quiet
docker compose config --quiet
docker compose -f docker-compose.light.yml up -d --build

cd backend
uv run ruff check .
uv run ruff format --check .
uv run pytest tests/ -q

cd ../frontend
pnpm install --frozen-lockfile
pnpm check
pnpm test
pnpm build
pnpm audit --audit-level=high
```

Verified locally:

- Backend: 460 passed, 6 skipped.
- Frontend: 215 passed.
- Frontend production Docker build passed.
- Frontend audit reports no known vulnerabilities.
- Fresh Docker upload reached `indexed`; original and thumbnail returned HTTP 200.
- Home, gallery, upload, vault, and settings returned HTTP 200.
- API and worker runtime error scan was clean.

## Checklist

- [x] I linked the related issues
- [x] I ran required checks from CONTRIBUTING.md
- [x] I updated docs/env notes if needed
- [x] The combined maintainer bundle is limited to the four linked, assigned hardening issues
- [x] I followed commit message conventions
- [x] I am not committing secrets or local artifacts

## GSSoC'26 checklist

- [x] I requested issue assignment before starting
- [x] I have meaningful commits (no spam commits)
- [x] I am ready to explain my implementation in review comments


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved storage reliability when processing occurs outside normal application startup.
  - Fixed public image URLs that could contain duplicated bucket paths.
  - Improved near-duplicate image matching for vector data.
  - Standardized processing timestamps for more consistent results.

- **Documentation**
  - Expanded feature descriptions and clarified light versus full runtime profiles.
  - Updated authentication progress documentation.

- **Maintenance**
  - Improved consistency across local and full deployment configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->