### PR TITLE
perf(ocr): benchmark and default to PP-OCRv5 mobile for CPU deployments

### DIFF
--- a/backend/docs/ocr-mobile-benchmark.md
+++ b/backend/docs/ocr-mobile-benchmark.md
@@ -1,232 +1,115 @@
-\# PP-OCRv5 Mobile vs Server Benchmark (CPU Deployments)
-
-
+# PP-OCRv5 Mobile vs Server Benchmark (CPU Deployments)
 
 Resolves: benchmark PP-OCRv5 mobile models for CPU deployments
 
+## Summary
 
-
-\## Summary
-
-
-
-Benchmarked PaddleOCR's `PP-OCRv5\_mobile` (det+rec) against the previously
-
-implicit `PP-OCRv5\_server` (det+rec) default on CPU, across load time, RAM,
-
+Benchmarked PaddleOCR's `PP-OCRv5_mobile` (det+rec) against the previously
+implicit `PP-OCRv5_server` (det+rec) default on CPU, across load time, RAM,
 per-image latency, and OCR accuracy on five image categories: photos,
-
 screenshots, receipts, rotated text, and low-contrast text.
 
-
-
-\*\*Recommendation: use `mobile` as the CPU-pack default.\*\* It is faster,
-
+**Recommendation: use `mobile` as the CPU-pack default.** It is faster,
 uses less RAM, and was at least as accurate as `server` in 4 of 5 test
-
 categories on this benchmark set (see caveats below).
 
+## What changed
 
+- `OCRExtractor` now takes an explicit `variant: "mobile" | "server"`
+  (defaults to the new `settings.OCR_VARIANT`, default `"mobile"` based on
+  the recorded benchmark results below). Previously, PaddleOCR was
+  instantiated with no model names, which silently resolved to the
+  `PP-OCRv5_server_det`/`PP-OCRv5_server_rec` models -- the active variant
+  was invisible in code and in logs.
+- The ModelManager cache key is now variant-qualified
+  (`paddleocr:mobile` / `paddleocr:server`), so `get_status()` makes the
+  active variant visible directly via `loaded_models`, plus a dedicated
+  `runtime.ocr` status block (variant, lang, model names).
+- Response shapes (`extract_text`, `extract_text_with_boxes`,
+  `extract_text_and_boxes`) are unchanged.
 
-\## What changed
-
-
-
-\- `OCRExtractor` now takes an explicit `variant: "mobile" | "server"`
-
-&#x20; (defaults to the new `settings.OCR\_VARIANT`, default `"mobile"` based on
-
-&#x20; the recorded benchmark results below). Previously, PaddleOCR was
-
-&#x20; instantiated with no model names, which silently resolved to the
-
-&#x20; `PP-OCRv5\_server\_det`/`PP-OCRv5\_server\_rec` models -- the active variant
-
-&#x20; was invisible in code and in logs.
-
-\- The ModelManager cache key is now variant-qualified
-
-&#x20; (`paddleocr:mobile` / `paddleocr:server`), so `get\_status()` makes the
-
-&#x20; active variant visible directly via `loaded\_models`, plus a dedicated
-
-&#x20; `runtime.ocr` status block (variant, lang, model names).
-
-\- Response shapes (`extract\_text`, `extract\_text\_with\_boxes`,
-
-&#x20; `extract\_text\_and\_boxes`) are unchanged.
-
-
-
-\## Benchmark results (CPU, Windows, single run)
-
-
+## Benchmark results (CPU, Windows, single run)
 
 | Metric | Mobile | Server |
-
 |---|---|---|
-
 | Load time (cold) | 18.1s | 21.0s |
-
 | RAM after load | 689 MB | 1,145 MB |
-
 | Peak RAM (incl. inference) | 1,063 MB | 1,990 MB |
-
 | New model cache size | 21.1 MB | (already cached; PP-OCRv5 server det+rec combined is roughly 2-3x the mobile pair per PaddleOCR's own docs) |
 
-
-
-\### Latency by category (mean, ms; 1 warmup + 5 timed runs per image, 4 images/category)
-
-
+### Latency by category (mean, ms; 1 warmup + 5 timed runs per image, 4 images/category)
 
 | Category | Mobile | Server | Speedup |
-
 |---|---|---|---|
-
 | photos | 4,398 | 13,765 | 3.1x |
-
 | screenshots | 4,392 | 13,221 | 3.0x |
-
 | receipts | 4,543 | 17,699 | 3.9x |
-
 | rotated | 4,633 | 14,199 | 3.1x |
+| low_contrast | 4,410 | 14,039 | 3.2x |
 
-| low\_contrast | 4,410 | 14,039 | 3.2x |
-
-
-
-\### Accuracy by category (exact-match rate / avg character error rate)
-
-
+### Accuracy by category (exact-match rate / avg character error rate)
 
 | Category | Mobile | Server |
-
 |---|---|---|
-
 | photos | 75% / CER 0.014 | 0% / CER 0.087 |
-
 | screenshots | 100% / CER 0.0 | 75% / CER 0.031 |
-
 | receipts | 100% / CER 0.0 | 0% / CER 0.074 |
-
 | rotated | 0% / CER 0.917 | 25% / CER 0.735 |
-
-| low\_contrast | 100% / CER 0.0 | 0% / CER 0.09 |
-
-
+| low_contrast | 100% / CER 0.0 | 0% / CER 0.09 |
 
 Mobile matched or beat server in 4/5 categories. Server's exact-match
-
-misses on photos/screenshots/low\_contrast were consistently a missing
-
+misses on photos/screenshots/low_contrast were consistently a missing
 space between words (e.g. `"AMOXICILLIN250MG"` vs `"AMOXICILLIN 250MG"`),
-
 not garbled text -- low practical impact for fuzzy-matched downstream
-
 lookups, but worth noting since it explains most of server's CER.
 
-
-
-\*\*Rotated text (15-30 degrees) is a shared weak point for both variants\*\*
-
+**Rotated text (15-30 degrees) is a shared weak point for both variants**
 and should not be read as mobile-specific. This is likely because both
-
-configs run with `use\_doc\_orientation\_classify=False`, which is the
-
+configs run with `use_doc_orientation_classify=False`, which is the
 PaddleOCR module responsible for correcting whole-image rotation before
-
 detection runs -- worth a follow-up investigation, out of scope for this
-
 issue.
 
+## Caveats
 
+- Test images (`scripts/generate_test_images.py`) are **synthetic**
+  (rendered text + simulated noise/blur/lighting), not real device photos.
+  They're reproducible and useful for catching regressions, but real
+  photos of medicine strips/receipts should be substituted before treating
+  these accuracy numbers as final for production rollout.
+- Single benchmark run on one machine (Windows, CPU). Not averaged across
+  hardware or repeated runs beyond the 5 timed passes per image.
 
-\## Caveats
-
-
-
-\- Test images (`scripts/generate\_test\_images.py`) are \*\*synthetic\*\*
-
-&#x20; (rendered text + simulated noise/blur/lighting), not real device photos.
-
-&#x20; They're reproducible and useful for catching regressions, but real
-
-&#x20; photos of medicine strips/receipts should be substituted before treating
-
-&#x20; these accuracy numbers as final for production rollout.
-
-\- Single benchmark run on one machine (Windows, CPU). Not averaged across
-
-&#x20; hardware or repeated runs beyond the 5 timed passes per image.
-
-
-
-\## Supported languages
-
-
+## Supported languages
 
 Because `OCRExtractor` always passes explicit
-
-`text\_detection\_model\_name`/`text\_recognition\_model\_name` (required to pin
-
+`text_detection_model_name`/`text_recognition_model_name` (required to pin
 the mobile/server variant), PaddleOCR's `lang` parameter is not used --
-
 passing it alongside explicit model names is silently ignored by
-
-PaddleOCR itself. This means both variants use the \*\*default unified
-
-recognition model\*\*, which supports 5 major text types: Simplified
-
+PaddleOCR itself. This means both variants use the **default unified
+recognition model**, which supports 5 major text types: Simplified
 Chinese, Traditional Chinese, Pinyin, English, and Japanese.
 
-
-
-PP-OCRv5 separately offers dedicated recognition models for \~106 more
-
+PP-OCRv5 separately offers dedicated recognition models for ~106 more
 languages (Korean, Spanish, French, Russian, Thai, Greek, Arabic,
-
 Devanagari, and others), but those are only reachable by dropping the
-
 explicit model names and using `lang=<code>` instead -- which would mean
-
 giving up explicit mobile/server selection. If broader language support
-
 becomes a requirement, that's a separate tradeoff to evaluate (e.g.
-
 per-language explicit model names, since PaddleOCR does publish
+language-specific mobile/server pairs like `en_PP-OCRv5_mobile_rec`).
 
-language-specific mobile/server pairs like `en\_PP-OCRv5\_mobile\_rec`).
-
-
-
-\## How to reproduce
-
-
+## How to reproduce
 
 ```bash
+# Optional: regenerate synthetic test images
+uv run python scripts/generate_test_images.py
 
-\# Optional: regenerate synthetic test images
+# Speed/RAM/load-time benchmark -> scripts/ocr_benchmark_results.json
+uv run python scripts/benchmark_ocr_variants.py
 
-uv run python scripts/generate\_test\_images.py
+# Accuracy scoring against ground truth -> scripts/ocr_accuracy_results.json
+uv run python scripts/score_ocr_accuracy.py
 
-
-
-\# Speed/RAM/load-time benchmark -> scripts/ocr\_benchmark\_results.json
-
-uv run python scripts/benchmark\_ocr\_variants.py
-
-
-
-\# Accuracy scoring against ground truth -> scripts/ocr\_accuracy\_results.json
-
-uv run python scripts/score\_ocr\_accuracy.py
-
-
-
-\# Test suite
-
-uv run pytest tests/test\_ocr.py tests/test\_ocr\_variants.py -v
-
-```
-
+# Test suite
+uv run pytest tests/test_ocr.py tests/test_ocr_variants.py -v

--- a/backend/docs/ocr-mobile-benchmark.md
+++ b/backend/docs/ocr-mobile-benchmark.md
@@ -1,0 +1,232 @@
+\# PP-OCRv5 Mobile vs Server Benchmark (CPU Deployments)
+
+
+
+Resolves: benchmark PP-OCRv5 mobile models for CPU deployments
+
+
+
+\## Summary
+
+
+
+Benchmarked PaddleOCR's `PP-OCRv5\_mobile` (det+rec) against the previously
+
+implicit `PP-OCRv5\_server` (det+rec) default on CPU, across load time, RAM,
+
+per-image latency, and OCR accuracy on five image categories: photos,
+
+screenshots, receipts, rotated text, and low-contrast text.
+
+
+
+\*\*Recommendation: use `mobile` as the CPU-pack default.\*\* It is faster,
+
+uses less RAM, and was at least as accurate as `server` in 4 of 5 test
+
+categories on this benchmark set (see caveats below).
+
+
+
+\## What changed
+
+
+
+\- `OCRExtractor` now takes an explicit `variant: "mobile" | "server"`
+
+&#x20; (defaults to the new `settings.OCR\_VARIANT`, default `"mobile"` based on
+
+&#x20; the recorded benchmark results below). Previously, PaddleOCR was
+
+&#x20; instantiated with no model names, which silently resolved to the
+
+&#x20; `PP-OCRv5\_server\_det`/`PP-OCRv5\_server\_rec` models -- the active variant
+
+&#x20; was invisible in code and in logs.
+
+\- The ModelManager cache key is now variant-qualified
+
+&#x20; (`paddleocr:mobile` / `paddleocr:server`), so `get\_status()` makes the
+
+&#x20; active variant visible directly via `loaded\_models`, plus a dedicated
+
+&#x20; `runtime.ocr` status block (variant, lang, model names).
+
+\- Response shapes (`extract\_text`, `extract\_text\_with\_boxes`,
+
+&#x20; `extract\_text\_and\_boxes`) are unchanged.
+
+
+
+\## Benchmark results (CPU, Windows, single run)
+
+
+
+| Metric | Mobile | Server |
+
+|---|---|---|
+
+| Load time (cold) | 18.1s | 21.0s |
+
+| RAM after load | 689 MB | 1,145 MB |
+
+| Peak RAM (incl. inference) | 1,063 MB | 1,990 MB |
+
+| New model cache size | 21.1 MB | (already cached; PP-OCRv5 server det+rec combined is roughly 2-3x the mobile pair per PaddleOCR's own docs) |
+
+
+
+\### Latency by category (mean, ms; 1 warmup + 5 timed runs per image, 4 images/category)
+
+
+
+| Category | Mobile | Server | Speedup |
+
+|---|---|---|---|
+
+| photos | 4,398 | 13,765 | 3.1x |
+
+| screenshots | 4,392 | 13,221 | 3.0x |
+
+| receipts | 4,543 | 17,699 | 3.9x |
+
+| rotated | 4,633 | 14,199 | 3.1x |
+
+| low\_contrast | 4,410 | 14,039 | 3.2x |
+
+
+
+\### Accuracy by category (exact-match rate / avg character error rate)
+
+
+
+| Category | Mobile | Server |
+
+|---|---|---|
+
+| photos | 75% / CER 0.014 | 0% / CER 0.087 |
+
+| screenshots | 100% / CER 0.0 | 75% / CER 0.031 |
+
+| receipts | 100% / CER 0.0 | 0% / CER 0.074 |
+
+| rotated | 0% / CER 0.917 | 25% / CER 0.735 |
+
+| low\_contrast | 100% / CER 0.0 | 0% / CER 0.09 |
+
+
+
+Mobile matched or beat server in 4/5 categories. Server's exact-match
+
+misses on photos/screenshots/low\_contrast were consistently a missing
+
+space between words (e.g. `"AMOXICILLIN250MG"` vs `"AMOXICILLIN 250MG"`),
+
+not garbled text -- low practical impact for fuzzy-matched downstream
+
+lookups, but worth noting since it explains most of server's CER.
+
+
+
+\*\*Rotated text (15-30 degrees) is a shared weak point for both variants\*\*
+
+and should not be read as mobile-specific. This is likely because both
+
+configs run with `use\_doc\_orientation\_classify=False`, which is the
+
+PaddleOCR module responsible for correcting whole-image rotation before
+
+detection runs -- worth a follow-up investigation, out of scope for this
+
+issue.
+
+
+
+\## Caveats
+
+
+
+\- Test images (`scripts/generate\_test\_images.py`) are \*\*synthetic\*\*
+
+&#x20; (rendered text + simulated noise/blur/lighting), not real device photos.
+
+&#x20; They're reproducible and useful for catching regressions, but real
+
+&#x20; photos of medicine strips/receipts should be substituted before treating
+
+&#x20; these accuracy numbers as final for production rollout.
+
+\- Single benchmark run on one machine (Windows, CPU). Not averaged across
+
+&#x20; hardware or repeated runs beyond the 5 timed passes per image.
+
+
+
+\## Supported languages
+
+
+
+Because `OCRExtractor` always passes explicit
+
+`text\_detection\_model\_name`/`text\_recognition\_model\_name` (required to pin
+
+the mobile/server variant), PaddleOCR's `lang` parameter is not used --
+
+passing it alongside explicit model names is silently ignored by
+
+PaddleOCR itself. This means both variants use the \*\*default unified
+
+recognition model\*\*, which supports 5 major text types: Simplified
+
+Chinese, Traditional Chinese, Pinyin, English, and Japanese.
+
+
+
+PP-OCRv5 separately offers dedicated recognition models for \~106 more
+
+languages (Korean, Spanish, French, Russian, Thai, Greek, Arabic,
+
+Devanagari, and others), but those are only reachable by dropping the
+
+explicit model names and using `lang=<code>` instead -- which would mean
+
+giving up explicit mobile/server selection. If broader language support
+
+becomes a requirement, that's a separate tradeoff to evaluate (e.g.
+
+per-language explicit model names, since PaddleOCR does publish
+
+language-specific mobile/server pairs like `en\_PP-OCRv5\_mobile\_rec`).
+
+
+
+\## How to reproduce
+
+
+
+```bash
+
+\# Optional: regenerate synthetic test images
+
+uv run python scripts/generate\_test\_images.py
+
+
+
+\# Speed/RAM/load-time benchmark -> scripts/ocr\_benchmark\_results.json
+
+uv run python scripts/benchmark\_ocr\_variants.py
+
+
+
+\# Accuracy scoring against ground truth -> scripts/ocr\_accuracy\_results.json
+
+uv run python scripts/score\_ocr\_accuracy.py
+
+
+
+\# Test suite
+
+uv run pytest tests/test\_ocr.py tests/test\_ocr\_variants.py -v
+
+```
+

--- a/backend/docs/ocr-mobile-benchmark.md
+++ b/backend/docs/ocr-mobile-benchmark.md
@@ -24,7 +24,9 @@ categories on this benchmark set (see caveats below).
 - The ModelManager cache key is now variant-qualified
   (`paddleocr:mobile` / `paddleocr:server`), so `get_status()` makes the
   active variant visible directly via `loaded_models`, plus a dedicated
-  `runtime.ocr` status block (variant, lang, model names).
+  `runtime.ocr` status block (variant and the pinned model names), published
+  through `ModelManager.merge_runtime_status` so it cannot race with the
+  other ML components writing into the same dict.
 - Response shapes (`extract_text`, `extract_text_with_boxes`,
   `extract_text_and_boxes`) are unchanged.
 
@@ -79,25 +81,39 @@ issue.
   these accuracy numbers as final for production rollout.
 - Single benchmark run on one machine (Windows, CPU). Not averaged across
   hardware or repeated runs beyond the 5 timed passes per image.
+- The recorded "Peak RAM" figures were sampled *after* each inference call
+  returned, so they miss transients that are freed before the call ends --
+  most notably during the cold model load. `benchmark_ocr_variants.py` now
+  samples RSS continuously on a background thread across load and inference,
+  so a re-run will report peaks that are equal or higher for both variants.
+  The mobile-vs-server ordering is not in question (mobile's resident set
+  after load is ~40% smaller), but treat the absolute peak numbers above as
+  a floor rather than an exact measurement.
 
 ## Supported languages
 
 Because `OCRExtractor` always passes explicit
 `text_detection_model_name`/`text_recognition_model_name` (required to pin
-the mobile/server variant), PaddleOCR's `lang` parameter is not used --
-passing it alongside explicit model names is silently ignored by
-PaddleOCR itself. This means both variants use the **default unified
-recognition model**, which supports 5 major text types: Simplified
-Chinese, Traditional Chinese, Pinyin, English, and Japanese.
+the mobile/server variant), PaddleOCR's `lang` parameter has no effect.
+This is explicit in PaddleOCR 3.x's own constructor, which takes the
+model-names branch and warns:
+
+> `lang` and `ocr_version` will be ignored when model names or model
+> directories are not `None`.
+
+`OCRExtractor` therefore does **not** expose a `lang` argument at all --
+accepting one would read as configurable while being a no-op on the
+supported path. Both variants use the **default unified recognition
+model**, which supports 5 major text types: Simplified Chinese,
+Traditional Chinese, Pinyin, English, and Japanese.
 
 PP-OCRv5 separately offers dedicated recognition models for ~106 more
 languages (Korean, Spanish, French, Russian, Thai, Greek, Arabic,
-Devanagari, and others), but those are only reachable by dropping the
-explicit model names and using `lang=<code>` instead -- which would mean
-giving up explicit mobile/server selection. If broader language support
-becomes a requirement, that's a separate tradeoff to evaluate (e.g.
-per-language explicit model names, since PaddleOCR does publish
-language-specific mobile/server pairs like `en_PP-OCRv5_mobile_rec`).
+Devanagari, and others). Reaching those means selecting language-specific
+model *names* -- PaddleOCR publishes mobile/server pairs per language, e.g.
+`korean_PP-OCRv5_mobile_rec` -- which keeps variant pinning intact. That is
+the route to take if broader language support becomes a requirement; it is
+a separate tradeoff to evaluate, not a reason to reintroduce `lang`.
 
 ## How to reproduce
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -29,10 +29,6 @@ dependencies = [
   "slowapi>=0.1.9",
 ]
 
-[project.optional-dependencies]
-mock = [
-  "scikit-learn==1.5.0",
-]
 cpu = [
   "torch==2.9.1",
   "torchvision==0.24.1",
@@ -45,8 +41,6 @@ cpu = [
   "timm>=0.9.16",
   "einops>=0.8.0",
   "paddlepaddle>=3.2.2,<3.3",
-  "paddleocr>=3.5.0,<4",
-  "scikit-learn==1.5.0",
   "cython<3",
 ]
 nvidia = [
@@ -62,7 +56,6 @@ nvidia = [
   "einops>=0.8.0",
   "paddlepaddle>=3.2.2,<3.3",
   "paddleocr>=3.5.0,<4",
-  "scikit-learn==1.5.0",
   "cython<3",
 ]
 
@@ -78,9 +71,6 @@ dev = [
   "pytest==9.0.3",
   "pytest-asyncio==0.23.3",
   "black==26.3.1",
-  "ruff==0.1.14",
-  "pip-audit==2.9.0",
-  "scikit-learn==1.5.0",
   "psutil>=7.2.2",
   "python-levenshtein>=0.27.3",
 ]

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -81,6 +81,8 @@ dev = [
   "ruff==0.1.14",
   "pip-audit==2.9.0",
   "scikit-learn==1.5.0",
+  "psutil>=7.2.2",
+  "python-levenshtein>=0.27.3",
 ]
 
 [tool.pytest.ini_options]

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -29,6 +29,10 @@ dependencies = [
   "slowapi>=0.1.10",
 ]
 
+[project.optional-dependencies]
+mock = [
+  "scikit-learn==1.9.0",
+]
 cpu = [
   "torch==2.9.1",
   "torchvision==0.24.1",
@@ -40,8 +44,10 @@ cpu = [
   "onnxruntime==1.28.0",
   "timm>=1.0.28",
   "einops>=0.8.0",
-  "paddlepaddle>=3.2.2,<3.3",
-  "cython<3",
+  "paddlepaddle>=3.3.1,<3.4",
+  "paddleocr>=3.7.0,<4",
+  "scikit-learn==1.9.0",
+  "cython<4",
 ]
 nvidia = [
   "torch==2.9.1",
@@ -54,9 +60,10 @@ nvidia = [
   "onnxruntime-gpu==1.28.0",
   "timm>=1.0.28",
   "einops>=0.8.0",
-  "paddlepaddle>=3.2.2,<3.3",
-  "paddleocr>=3.5.0,<4",
-  "cython<3",
+  "paddlepaddle>=3.3.1,<3.4",
+  "paddleocr>=3.7.0,<4",
+  "scikit-learn==1.9.0",
+  "cython<4",
 ]
 
 [build-system]
@@ -71,6 +78,11 @@ dev = [
   "pytest==9.1.1",
   "pytest-asyncio==1.4.0",
   "black==26.3.1",
+  "ruff==0.1.14",
+  "pip-audit==2.10.1",
+  "scikit-learn==1.9.0",
+  # Used only by the standalone OCR benchmark scripts (scripts/benchmark_ocr_variants.py
+  # for RSS sampling, scripts/score_ocr_accuracy.py for edit distance).
   "psutil>=7.2.2",
   "python-levenshtein>=0.27.3",
 ]

--- a/backend/scripts/benchmark_ocr_variants.py
+++ b/backend/scripts/benchmark_ocr_variants.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""
+Benchmark PP-OCRv5 mobile vs server models for CPU deployments.
+
+Run with:  python scripts/benchmark_ocr_variants.py
+Or:        uv run python scripts/benchmark_ocr_variants.py
+
+Measures, for each variant ("mobile" and "server"):
+  - Model download/cache size on disk
+  - Cold load time (first inference, triggers model load)
+  - Peak RAM (resident set size) during load + inference
+  - Per-image inference latency (warm, averaged over several runs)
+
+This is a standalone diagnostic script, not a pytest test -- see
+tests/test_ocr.py for the automated test suite and
+tests/test_ocr_variants.py for the fallback/error-path tests.
+
+Results are written to backend/scripts/ocr_benchmark_results.json so they
+can be pasted into the issue/PR as the recorded evidence for recommending
+a CPU default (see issue: "benchmark PP-OCRv5 mobile models for CPU
+deployments").
+"""
+
+import gc
+import json
+import os
+import statistics
+import sys
+import time
+from pathlib import Path
+
+# Add src to path so this runs standalone like manual_ocr_check.py does
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+try:
+    import psutil
+except ImportError:
+    print("This script requires psutil. Install with: uv add --dev psutil")
+    sys.exit(1)
+
+from PIL import Image, ImageDraw, ImageFont
+import numpy as np
+
+
+VARIANTS = ["mobile", "server"]
+WARMUP_RUNS = 1
+TIMED_RUNS = 5
+
+# PaddleX/PaddleOCR caches downloaded model weights here by default.
+PADDLEX_CACHE_DIR = Path.home() / ".paddlex" / "official_models"
+
+
+def get_process_rss_mb() -> float:
+    """Current process resident set size in MB."""
+    return psutil.Process(os.getpid()).memory_info().rss / (1024 * 1024)
+
+
+def dir_size_mb(path: Path) -> float:
+    if not path.exists():
+        return 0.0
+    total = sum(f.stat().st_size for f in path.rglob("*") if f.is_file())
+    return total / (1024 * 1024)
+
+
+def make_test_image(text: str, size=(600, 200), rotate: int = 0) -> Image.Image:
+    """Synthetic fallback image generator, used only if no real test images
+    are found in scripts/ocr_test_images/. Prefer real photos/screenshots/
+    receipts for meaningful accuracy comparisons -- see acceptance criteria.
+    """
+    img = Image.new("RGB", size, color="white")
+    draw = ImageDraw.Draw(img)
+    try:
+        font = ImageFont.truetype("arial.ttf", 28)
+    except Exception:
+        font = ImageFont.load_default()
+    draw.text((20, size[1] // 2 - 20), text, fill="black", font=font)
+    if rotate:
+        img = img.rotate(rotate, expand=True, fillcolor="white")
+    return img
+
+
+def load_test_images() -> dict:
+    """Load benchmark/accuracy images.
+
+    Looks for real images under scripts/ocr_test_images/<category>/*, where
+    <category> is one of: photos, screenshots, receipts, rotated,
+    low_contrast -- matching the acceptance criteria's comparison
+    categories. Falls back to synthetic images for categories with nothing
+    on disk, purely so the script is runnable out of the box; synthetic
+    images are NOT a substitute for the real accuracy comparison and should
+    be replaced with real samples before recording final results.
+    """
+    categories = ["photos", "screenshots", "receipts", "rotated", "low_contrast"]
+    base_dir = Path(__file__).parent / "ocr_test_images"
+    images = {}
+
+    for category in categories:
+        cat_dir = base_dir / category
+        found = []
+        if cat_dir.exists():
+            for ext in ("*.png", "*.jpg", "*.jpeg"):
+                for f in cat_dir.glob(ext):
+                    try:
+                        found.append((f.name, Image.open(f).convert("RGB")))
+                    except Exception as exc:
+                        print(f"  ! Skipping unreadable image {f}: {exc}")
+        if found:
+            images[category] = found
+        else:
+            print(
+                f"  ! No real images found in scripts/ocr_test_images/{category}/, "
+                "using a synthetic placeholder. Add real samples for accurate results."
+            )
+            if category == "rotated":
+                placeholder = make_test_image("ROTATED SAMPLE TEXT", rotate=15)
+            else:
+                placeholder = make_test_image(f"{category.upper()} SAMPLE TEXT")
+            images[category] = [(f"synthetic_{category}.png", placeholder)]
+
+    return images
+
+
+def benchmark_variant(variant: str, test_images: dict) -> dict:
+    print(f"\n{'=' * 60}")
+    print(f"Benchmarking variant: {variant}")
+    print(f"{'=' * 60}")
+
+    from find_api.core.model_manager import get_model_manager
+    from find_api.ml.ocr import OCRExtractor
+
+    # Fresh state per variant so load time / RAM aren't skewed by a model
+    # already cached in the previous iteration.
+    get_model_manager().reset_for_tests()
+    gc.collect()
+
+    cache_size_before = dir_size_mb(PADDLEX_CACHE_DIR)
+    rss_before = get_process_rss_mb()
+
+    extractor = OCRExtractor(variant=variant)
+
+    # A tiny image is enough to force the model to load without spending
+    # time on real inference for this measurement.
+    warm_image = Image.new("RGB", (64, 64), color="white")
+
+    load_start = time.perf_counter()
+    extractor.extract_text(warm_image)
+    load_time_s = time.perf_counter() - load_start
+
+    rss_after_load = get_process_rss_mb()
+    cache_size_after = dir_size_mb(PADDLEX_CACHE_DIR)
+    downloaded_mb = max(0.0, cache_size_after - cache_size_before)
+
+    print(f"  Load time:        {load_time_s:.2f}s")
+    print(f"  RAM after load:   {rss_after_load:.1f} MB (+{rss_after_load - rss_before:.1f} MB)")
+    print(f"  New cache size:   {downloaded_mb:.1f} MB")
+
+    # Per-category latency + peak RAM during real inference
+    category_results = {}
+    peak_rss = rss_after_load
+
+    for category, images in test_images.items():
+        latencies = []
+        for name, img in images:
+            # Warmup run(s) not timed, to separate first-call JIT/graph
+            # overhead from steady-state per-image latency.
+            for _ in range(WARMUP_RUNS):
+                extractor.extract_text(img)
+
+            for _ in range(TIMED_RUNS):
+                start = time.perf_counter()
+                extractor.extract_text(img)
+                latencies.append(time.perf_counter() - start)
+                peak_rss = max(peak_rss, get_process_rss_mb())
+
+        category_results[category] = {
+            "images_tested": [name for name, _ in images],
+            "mean_latency_ms": round(statistics.mean(latencies) * 1000, 1),
+            "median_latency_ms": round(statistics.median(latencies) * 1000, 1),
+            "min_latency_ms": round(min(latencies) * 1000, 1),
+            "max_latency_ms": round(max(latencies) * 1000, 1),
+        }
+        print(
+            f"  [{category:>13}] mean={category_results[category]['mean_latency_ms']}ms "
+            f"median={category_results[category]['median_latency_ms']}ms"
+        )
+
+    return {
+        "variant": variant,
+        "load_time_seconds": round(load_time_s, 2),
+        "ram_after_load_mb": round(rss_after_load, 1),
+        "ram_delta_load_mb": round(rss_after_load - rss_before, 1),
+        "peak_ram_mb": round(peak_rss, 1),
+        "downloaded_cache_mb": round(downloaded_mb, 1),
+        "latency_by_category": category_results,
+    }
+
+
+def main():
+    print("PP-OCRv5 mobile vs server benchmark (CPU)")
+    print(f"PaddleX cache dir: {PADDLEX_CACHE_DIR}")
+
+    print("\nLoading test images...")
+    test_images = load_test_images()
+
+    results = {}
+    for variant in VARIANTS:
+        try:
+            results[variant] = benchmark_variant(variant, test_images)
+        except Exception as exc:
+            print(f"  ! Benchmark failed for variant={variant}: {exc}")
+            results[variant] = {"variant": variant, "error": str(exc)}
+
+    out_path = Path(__file__).parent / "ocr_benchmark_results.json"
+    with open(out_path, "w") as f:
+        json.dump(results, f, indent=2)
+
+    print(f"\n{'=' * 60}")
+    print(f"Results written to {out_path}")
+    print(f"{'=' * 60}")
+
+    if "mobile" in results and "server" in results:
+        m, s = results["mobile"], results["server"]
+        if "error" not in m and "error" not in s:
+            print("\nSummary (mobile vs server):")
+            print(f"  Load time:   {m['load_time_seconds']}s vs {s['load_time_seconds']}s")
+            print(f"  Peak RAM:    {m['peak_ram_mb']}MB vs {s['peak_ram_mb']}MB")
+            print(f"  Cache size:  {m['downloaded_cache_mb']}MB vs {s['downloaded_cache_mb']}MB")
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/scripts/benchmark_ocr_variants.py
+++ b/backend/scripts/benchmark_ocr_variants.py
@@ -55,6 +55,7 @@ def get_process_rss_mb() -> float:
 
 
 def dir_size_mb(path: Path) -> float:
+    """Calculate the total size of all files in a directory in MB."""
     if not path.exists():
         return 0.0
     total = sum(f.stat().st_size for f in path.rglob("*") if f.is_file())
@@ -71,7 +72,7 @@ def make_test_image(text: str, size=(600, 200), rotate: int = 0) -> Image.Image:
     try:
         font = ImageFont.truetype("arial.ttf", 28)
     except Exception:
-        font = ImageFont.load_default()
+        font = ImageFont.load_default(size=28)
     draw.text((20, size[1] // 2 - 20), text, fill="black", font=font)
     if rotate:
         img = img.rotate(rotate, expand=True, fillcolor="white")
@@ -120,6 +121,7 @@ def load_test_images() -> dict:
 
 
 def benchmark_variant(variant: str, test_images: dict) -> dict:
+    """Benchmark a specific OCR model variant for load time, RAM usage, and latency."""
     print(f"\n{'=' * 60}")
     print(f"Benchmarking variant: {variant}")
     print(f"{'=' * 60}")
@@ -195,6 +197,7 @@ def benchmark_variant(variant: str, test_images: dict) -> dict:
 
 
 def main():
+    """Run the complete OCR variant benchmark suite and output results to JSON."""
     print("PP-OCRv5 mobile vs server benchmark (CPU)")
     print(f"PaddleX cache dir: {PADDLEX_CACHE_DIR}")
 

--- a/backend/scripts/benchmark_ocr_variants.py
+++ b/backend/scripts/benchmark_ocr_variants.py
@@ -28,6 +28,8 @@ import statistics
 import sys
 import time
 from pathlib import Path
+from PIL import Image, ImageDraw, ImageFont
+import numpy as np
 
 # Add src to path so this runs standalone like manual_ocr_check.py does
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
@@ -37,9 +39,6 @@ try:
 except ImportError:
     print("This script requires psutil. Install with: uv add --dev psutil")
     sys.exit(1)
-
-from PIL import Image, ImageDraw, ImageFont
-import numpy as np
 
 
 VARIANTS = ["mobile", "server"]

--- a/backend/scripts/benchmark_ocr_variants.py
+++ b/backend/scripts/benchmark_ocr_variants.py
@@ -26,10 +26,10 @@ import json
 import os
 import statistics
 import sys
+import threading
 import time
 from pathlib import Path
 from PIL import Image, ImageDraw, ImageFont
-import numpy as np
 
 # Add src to path so this runs standalone like manual_ocr_check.py does
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
@@ -52,6 +52,39 @@ PADDLEX_CACHE_DIR = Path.home() / ".paddlex" / "official_models"
 def get_process_rss_mb() -> float:
     """Current process resident set size in MB."""
     return psutil.Process(os.getpid()).memory_info().rss / (1024 * 1024)
+
+
+class RssSampler:
+    """Continuously sample process RSS on a background thread.
+
+    Sampling only after each call returns misses transient allocations that
+    are freed before the call finishes -- most importantly the model download
+    and graph construction during the cold load, which is exactly the peak a
+    CPU-deployment reader cares about.
+    """
+
+    def __init__(self, interval_s: float = 0.05):
+        self.interval_s = interval_s
+        self.peak_mb = 0.0
+        self._stop = threading.Event()
+        self._thread = threading.Thread(target=self._run, daemon=True)
+
+    def _run(self):
+        while not self._stop.is_set():
+            self.peak_mb = max(self.peak_mb, get_process_rss_mb())
+            self._stop.wait(self.interval_s)
+
+    def __enter__(self):
+        self.peak_mb = get_process_rss_mb()
+        self._thread.start()
+        return self
+
+    def __exit__(self, *exc_info):
+        self._stop.set()
+        self._thread.join(timeout=2)
+        # Final sample so the peak covers anything since the last tick.
+        self.peak_mb = max(self.peak_mb, get_process_rss_mb())
+        return False
 
 
 def dir_size_mb(path: Path) -> float:
@@ -137,53 +170,59 @@ def benchmark_variant(variant: str, test_images: dict) -> dict:
     cache_size_before = dir_size_mb(PADDLEX_CACHE_DIR)
     rss_before = get_process_rss_mb()
 
-    extractor = OCRExtractor(variant=variant)
-
-    # A tiny image is enough to force the model to load without spending
-    # time on real inference for this measurement.
-    warm_image = Image.new("RGB", (64, 64), color="white")
-
-    load_start = time.perf_counter()
-    extractor.extract_text(warm_image)
-    load_time_s = time.perf_counter() - load_start
-
-    rss_after_load = get_process_rss_mb()
-    cache_size_after = dir_size_mb(PADDLEX_CACHE_DIR)
-    downloaded_mb = max(0.0, cache_size_after - cache_size_before)
-
-    print(f"  Load time:        {load_time_s:.2f}s")
-    print(f"  RAM after load:   {rss_after_load:.1f} MB (+{rss_after_load - rss_before:.1f} MB)")
-    print(f"  New cache size:   {downloaded_mb:.1f} MB")
-
-    # Per-category latency + peak RAM during real inference
     category_results = {}
-    peak_rss = rss_after_load
 
-    for category, images in test_images.items():
-        latencies = []
-        for name, img in images:
-            # Warmup run(s) not timed, to separate first-call JIT/graph
-            # overhead from steady-state per-image latency.
-            for _ in range(WARMUP_RUNS):
-                extractor.extract_text(img)
+    # Sample RSS continuously from before the load until after the last timed
+    # run, so the reported peak includes load-time and inference transients
+    # rather than only what is still resident once a call returns.
+    with RssSampler() as sampler:
+        extractor = OCRExtractor(variant=variant)
 
-            for _ in range(TIMED_RUNS):
-                start = time.perf_counter()
-                extractor.extract_text(img)
-                latencies.append(time.perf_counter() - start)
-                peak_rss = max(peak_rss, get_process_rss_mb())
+        # A tiny image is enough to force the model to load without spending
+        # time on real inference for this measurement.
+        warm_image = Image.new("RGB", (64, 64), color="white")
 
-        category_results[category] = {
-            "images_tested": [name for name, _ in images],
-            "mean_latency_ms": round(statistics.mean(latencies) * 1000, 1),
-            "median_latency_ms": round(statistics.median(latencies) * 1000, 1),
-            "min_latency_ms": round(min(latencies) * 1000, 1),
-            "max_latency_ms": round(max(latencies) * 1000, 1),
-        }
+        load_start = time.perf_counter()
+        extractor.extract_text(warm_image)
+        load_time_s = time.perf_counter() - load_start
+
+        rss_after_load = get_process_rss_mb()
+        cache_size_after = dir_size_mb(PADDLEX_CACHE_DIR)
+        downloaded_mb = max(0.0, cache_size_after - cache_size_before)
+
+        print(f"  Load time:        {load_time_s:.2f}s")
         print(
-            f"  [{category:>13}] mean={category_results[category]['mean_latency_ms']}ms "
-            f"median={category_results[category]['median_latency_ms']}ms"
+            f"  RAM after load:   {rss_after_load:.1f} MB "
+            f"(+{rss_after_load - rss_before:.1f} MB)"
         )
+        print(f"  New cache size:   {downloaded_mb:.1f} MB")
+
+        for category, images in test_images.items():
+            latencies = []
+            for name, img in images:
+                # Warmup run(s) not timed, to separate first-call JIT/graph
+                # overhead from steady-state per-image latency.
+                for _ in range(WARMUP_RUNS):
+                    extractor.extract_text(img)
+
+                for _ in range(TIMED_RUNS):
+                    start = time.perf_counter()
+                    extractor.extract_text(img)
+                    latencies.append(time.perf_counter() - start)
+
+            category_results[category] = {
+                "images_tested": [name for name, _ in images],
+                "mean_latency_ms": round(statistics.mean(latencies) * 1000, 1),
+                "median_latency_ms": round(statistics.median(latencies) * 1000, 1),
+                "min_latency_ms": round(min(latencies) * 1000, 1),
+                "max_latency_ms": round(max(latencies) * 1000, 1),
+            }
+            print(
+                f"  [{category:>13}] mean={category_results[category]['mean_latency_ms']}ms "
+                f"median={category_results[category]['median_latency_ms']}ms"
+            )
+
+    peak_rss = sampler.peak_mb
 
     return {
         "variant": variant,
@@ -224,9 +263,13 @@ def main():
         m, s = results["mobile"], results["server"]
         if "error" not in m and "error" not in s:
             print("\nSummary (mobile vs server):")
-            print(f"  Load time:   {m['load_time_seconds']}s vs {s['load_time_seconds']}s")
+            print(
+                f"  Load time:   {m['load_time_seconds']}s vs {s['load_time_seconds']}s"
+            )
             print(f"  Peak RAM:    {m['peak_ram_mb']}MB vs {s['peak_ram_mb']}MB")
-            print(f"  Cache size:  {m['downloaded_cache_mb']}MB vs {s['downloaded_cache_mb']}MB")
+            print(
+                f"  Cache size:  {m['downloaded_cache_mb']}MB vs {s['downloaded_cache_mb']}MB"
+            )
 
 
 if __name__ == "__main__":

--- a/backend/scripts/generate_test_images.py
+++ b/backend/scripts/generate_test_images.py
@@ -18,9 +18,15 @@ Run with: uv run python scripts/generate_test_images.py
 import random
 from pathlib import Path
 
+import numpy as np
 from PIL import Image, ImageDraw, ImageFilter, ImageFont
 
-random.seed(42)  # reproducible output
+# Reproducible output. Both generators need seeding: `random` drives line
+# sampling and rotation angles, numpy drives the per-pixel sensor noise in
+# add_noise(), so seeding only `random` would still give a different corpus
+# (and different accuracy numbers) on every regeneration.
+random.seed(42)
+_rng = np.random.default_rng(42)
 
 OUT_DIR = Path(__file__).parent / "ocr_test_images"
 
@@ -48,10 +54,8 @@ def _font(size):
 
 def add_noise(img: Image.Image, amount: float) -> Image.Image:
     """Add per-pixel random noise to simulate camera sensor grain."""
-    import numpy as np
-
     arr = np.array(img).astype(np.int16)
-    noise = np.random.randint(-int(255 * amount), int(255 * amount) + 1, arr.shape)
+    noise = _rng.integers(-int(255 * amount), int(255 * amount) + 1, arr.shape)
     arr = np.clip(arr + noise, 0, 255).astype(np.uint8)
     return Image.fromarray(arr)
 

--- a/backend/scripts/generate_test_images.py
+++ b/backend/scripts/generate_test_images.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""
+Generate synthetic OCR test images for scripts/ocr_test_images/.
+
+This is a stand-in for real photos/screenshots/receipts, meant to make
+benchmark_ocr_variants.py's accuracy comparison meaningful even without
+access to real device photos. It is NOT a substitute for real samples --
+replace these with real photos/screenshots/receipts before treating the
+benchmark's accuracy numbers as final, per the issue's acceptance criteria.
+
+Each generated image's ground-truth text is embedded in its filename
+(e.g. "gt_ASPIRIN_500MG.png") so a human (or a future accuracy script) can
+compare OCR output against a known-correct answer.
+
+Run with: uv run python scripts/generate_test_images.py
+"""
+
+import random
+from pathlib import Path
+
+from PIL import Image, ImageDraw, ImageFilter, ImageFont
+
+random.seed(42)  # reproducible output
+
+OUT_DIR = Path(__file__).parent / "ocr_test_images"
+
+SAMPLE_LINES = [
+    "PARACETAMOL 500MG",
+    "AMOXICILLIN 250MG",
+    "IBUPROFEN 400MG TABLETS",
+    "CETIRIZINE 10MG",
+    "METFORMIN 500MG SR",
+    "AZITHROMYCIN 500MG",
+    "OMEPRAZOLE 20MG CAPSULES",
+    "VITAMIN D3 60000 IU",
+]
+
+
+def _font(size):
+    for name in ("arial.ttf", "DejaVuSans.ttf", "calibri.ttf"):
+        try:
+            return ImageFont.truetype(name, size)
+        except Exception:
+            continue
+    return ImageFont.load_default()
+
+
+def add_noise(img: Image.Image, amount: float) -> Image.Image:
+    """Add per-pixel random noise to simulate camera sensor grain."""
+    import numpy as np
+
+    arr = np.array(img).astype(np.int16)
+    noise = np.random.randint(-int(255 * amount), int(255 * amount) + 1, arr.shape)
+    arr = np.clip(arr + noise, 0, 255).astype(np.uint8)
+    return Image.fromarray(arr)
+
+
+def make_photo(text: str) -> Image.Image:
+    """Simulate an angled phone photo: uneven lighting, blur, grain."""
+    img = Image.new("RGB", (700, 260), color=(235, 232, 225))
+    draw = ImageDraw.Draw(img)
+    draw.text((40, 100), text, fill=(20, 20, 25), font=_font(34))
+    # Uneven lighting: darken one corner
+    overlay = Image.new("L", img.size, 0)
+    odraw = ImageDraw.Draw(overlay)
+    odraw.ellipse((-200, -200, 300, 300), fill=60)
+    img = Image.composite(Image.new("RGB", img.size, (0, 0, 0)), img, overlay)
+    img = img.filter(ImageFilter.GaussianBlur(radius=1.1))
+    img = add_noise(img, 0.03)
+    return img
+
+
+def make_screenshot(text: str) -> Image.Image:
+    """Simulate a clean app/UI screenshot: crisp text, flat background."""
+    img = Image.new("RGB", (700, 220), color=(250, 250, 252))
+    draw = ImageDraw.Draw(img)
+    draw.rectangle((20, 20, 680, 200), outline=(210, 210, 215), width=2)
+    draw.text((40, 90), text, fill=(30, 30, 35), font=_font(30))
+    return img
+
+
+def make_receipt(text: str) -> Image.Image:
+    """Simulate a thermal-printer receipt: grainy, monospace, tall/narrow."""
+    lines = [text, "QTY: 1   MRP: 45.00", "BATCH: A1234  EXP: 12/27"]
+    img = Image.new("RGB", (420, 280), color=(245, 245, 240))
+    draw = ImageDraw.Draw(img)
+    y = 40
+    for line in lines:
+        draw.text((20, y), line, fill=(15, 15, 15), font=_font(22))
+        y += 45
+    img = img.filter(ImageFilter.GaussianBlur(radius=0.6))
+    img = add_noise(img, 0.05)
+    return img
+
+
+def make_rotated(text: str) -> Image.Image:
+    """Simulate a tilted photo (common when scanning strips by hand)."""
+    base = make_photo(text)
+    angle = random.choice([-25, -15, 12, 20, 30])
+    return base.rotate(angle, expand=True, fillcolor=(235, 232, 225))
+
+
+def make_low_contrast(text: str) -> Image.Image:
+    """Simulate faded/worn print or a bad-lighting photo: low text/bg contrast."""
+    img = Image.new("RGB", (700, 220), color=(210, 210, 205))
+    draw = ImageDraw.Draw(img)
+    draw.text((40, 90), text, fill=(175, 175, 170), font=_font(30))
+    img = img.filter(ImageFilter.GaussianBlur(radius=0.8))
+    return img
+
+
+GENERATORS = {
+    "photos": make_photo,
+    "screenshots": make_screenshot,
+    "receipts": make_receipt,
+    "rotated": make_rotated,
+    "low_contrast": make_low_contrast,
+}
+
+
+def safe_filename(text: str) -> str:
+    return "gt_" + text.replace(" ", "_").replace("/", "-")
+
+
+def main():
+    for category, generator in GENERATORS.items():
+        cat_dir = OUT_DIR / category
+        cat_dir.mkdir(parents=True, exist_ok=True)
+
+        # Clear any old generated samples so re-runs don't accumulate stale files
+        for old in cat_dir.glob("gt_*.png"):
+            old.unlink()
+
+        lines = random.sample(SAMPLE_LINES, k=4)
+        for text in lines:
+            img = generator(text)
+            out_path = cat_dir / f"{safe_filename(text)}.png"
+            img.save(out_path)
+            print(f"  Wrote {out_path.relative_to(OUT_DIR.parent)}")
+
+    print(f"\nDone. {len(GENERATORS) * 4} synthetic images written under {OUT_DIR}")
+    print(
+        "Ground truth is embedded in each filename (gt_<EXPECTED_TEXT>.png). "
+        "Replace with real photos before finalizing accuracy conclusions."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/scripts/generate_test_images.py
+++ b/backend/scripts/generate_test_images.py
@@ -37,12 +37,13 @@ SAMPLE_LINES = [
 
 
 def _font(size):
+    """Load a system TrueType font or fall back to default with the given size."""
     for name in ("arial.ttf", "DejaVuSans.ttf", "calibri.ttf"):
         try:
             return ImageFont.truetype(name, size)
         except Exception:
             continue
-    return ImageFont.load_default()
+    return ImageFont.load_default(size=size)
 
 
 def add_noise(img: Image.Image, amount: float) -> Image.Image:
@@ -81,7 +82,7 @@ def make_screenshot(text: str) -> Image.Image:
 
 def make_receipt(text: str) -> Image.Image:
     """Simulate a thermal-printer receipt: grainy, monospace, tall/narrow."""
-    lines = [text, "QTY: 1   MRP: 45.00", "BATCH: A1234  EXP: 12/27"]
+    lines = [text, "QTY: 1   MRP: 45.00", "BATCH: A1234   EXP: 12/27"]
     img = Image.new("RGB", (420, 280), color=(245, 245, 240))
     draw = ImageDraw.Draw(img)
     y = 40
@@ -119,10 +120,12 @@ GENERATORS = {
 
 
 def safe_filename(text: str) -> str:
+    """Format ground-truth text into a valid, safe filename string."""
     return "gt_" + text.replace(" ", "_").replace("/", "-")
 
 
 def main():
+    """Generate synthetic test image categories and write them to disk."""
     for category, generator in GENERATORS.items():
         cat_dir = OUT_DIR / category
         cat_dir.mkdir(parents=True, exist_ok=True)

--- a/backend/scripts/ocr_accuracy_results.json
+++ b/backend/scripts/ocr_accuracy_results.json
@@ -1,0 +1,356 @@
+{
+  "mobile": {
+    "photos": {
+      "images_scored": 4,
+      "exact_match_rate": 0.75,
+      "avg_char_error_rate": 0.014,
+      "details": [
+        {
+          "file": "gt_AMOXICILLIN_250MG.png",
+          "ground_truth": "AMOXICILLIN 250MG",
+          "predicted": "AMOXICILLIN 250MG",
+          "exact_match": true,
+          "char_error_rate": 0.0
+        },
+        {
+          "file": "gt_AZITHROMYCIN_500MG.png",
+          "ground_truth": "AZITHROMYCIN 500MG",
+          "predicted": "AZITHROMYCIN500MG",
+          "exact_match": false,
+          "char_error_rate": 0.056
+        },
+        {
+          "file": "gt_IBUPROFEN_400MG_TABLETS.png",
+          "ground_truth": "IBUPROFEN 400MG TABLETS",
+          "predicted": "IBUPROFEN 400MG TABLETS",
+          "exact_match": true,
+          "char_error_rate": 0.0
+        },
+        {
+          "file": "gt_PARACETAMOL_500MG.png",
+          "ground_truth": "PARACETAMOL 500MG",
+          "predicted": "PARACETAMOL 500MG",
+          "exact_match": true,
+          "char_error_rate": 0.0
+        }
+      ]
+    },
+    "screenshots": {
+      "images_scored": 4,
+      "exact_match_rate": 1.0,
+      "avg_char_error_rate": 0.0,
+      "details": [
+        {
+          "file": "gt_AMOXICILLIN_250MG.png",
+          "ground_truth": "AMOXICILLIN 250MG",
+          "predicted": "AMOXICILLIN 250MG",
+          "exact_match": true,
+          "char_error_rate": 0.0
+        },
+        {
+          "file": "gt_CETIRIZINE_10MG.png",
+          "ground_truth": "CETIRIZINE 10MG",
+          "predicted": "CETIRIZINE 10MG",
+          "exact_match": true,
+          "char_error_rate": 0.0
+        },
+        {
+          "file": "gt_OMEPRAZOLE_20MG_CAPSULES.png",
+          "ground_truth": "OMEPRAZOLE 20MG CAPSULES",
+          "predicted": "OMEPRAZOLE 20MG CAPSULES",
+          "exact_match": true,
+          "char_error_rate": 0.0
+        },
+        {
+          "file": "gt_PARACETAMOL_500MG.png",
+          "ground_truth": "PARACETAMOL 500MG",
+          "predicted": "PARACETAMOL 500MG",
+          "exact_match": true,
+          "char_error_rate": 0.0
+        }
+      ]
+    },
+    "receipts": {
+      "images_scored": 4,
+      "exact_match_rate": 1.0,
+      "avg_char_error_rate": 0.0,
+      "details": [
+        {
+          "file": "gt_AMOXICILLIN_250MG.png",
+          "ground_truth": "AMOXICILLIN 250MG",
+          "predicted": "AMOXICILLIN 250MG\nQTY:1 MRP:45.00\nBATCH:A1234EXP:12/27",
+          "exact_match": true,
+          "char_error_rate": 0.0
+        },
+        {
+          "file": "gt_CETIRIZINE_10MG.png",
+          "ground_truth": "CETIRIZINE 10MG",
+          "predicted": "CETIRIZINE 10MG\nQTY:1 MRP: 45.00\nBATCH:A1234 EXP:12/27",
+          "exact_match": true,
+          "char_error_rate": 0.0
+        },
+        {
+          "file": "gt_METFORMIN_500MG_SR.png",
+          "ground_truth": "METFORMIN 500MG SR",
+          "predicted": "METFORMIN 500MG SR\nQTY:1 MRP:45.00\nBATCH:A1234EXP:12/27",
+          "exact_match": true,
+          "char_error_rate": 0.0
+        },
+        {
+          "file": "gt_PARACETAMOL_500MG.png",
+          "ground_truth": "PARACETAMOL 500MG",
+          "predicted": "PARACETAMOL 500MG\nQTY:1 MRP:45.00\nBATCH:A1234 EXP:12/27",
+          "exact_match": true,
+          "char_error_rate": 0.0
+        }
+      ]
+    },
+    "rotated": {
+      "images_scored": 4,
+      "exact_match_rate": 0.0,
+      "avg_char_error_rate": 0.917,
+      "details": [
+        {
+          "file": "gt_AMOXICILLIN_250MG.png",
+          "ground_truth": "AMOXICILLIN 250MG",
+          "predicted": "\u798f",
+          "exact_match": false,
+          "char_error_rate": 1.0
+        },
+        {
+          "file": "gt_AZITHROMYCIN_500MG.png",
+          "ground_truth": "AZITHROMYCIN 500MG",
+          "predicted": "\"\nATRR50S\nA2m",
+          "exact_match": false,
+          "char_error_rate": 0.722
+        },
+        {
+          "file": "gt_PARACETAMOL_500MG.png",
+          "ground_truth": "PARACETAMOL 500MG",
+          "predicted": "\u4e32",
+          "exact_match": false,
+          "char_error_rate": 1.0
+        },
+        {
+          "file": "gt_VITAMIN_D3_60000_IU.png",
+          "ground_truth": "VITAMIN D3 60000 IU",
+          "predicted": "N",
+          "exact_match": false,
+          "char_error_rate": 0.947
+        }
+      ]
+    },
+    "low_contrast": {
+      "images_scored": 4,
+      "exact_match_rate": 1.0,
+      "avg_char_error_rate": 0.0,
+      "details": [
+        {
+          "file": "gt_AZITHROMYCIN_500MG.png",
+          "ground_truth": "AZITHROMYCIN 500MG",
+          "predicted": "AZITHROMYCIN 500MG",
+          "exact_match": true,
+          "char_error_rate": 0.0
+        },
+        {
+          "file": "gt_CETIRIZINE_10MG.png",
+          "ground_truth": "CETIRIZINE 10MG",
+          "predicted": "CETIRIZINE 10MG",
+          "exact_match": true,
+          "char_error_rate": 0.0
+        },
+        {
+          "file": "gt_METFORMIN_500MG_SR.png",
+          "ground_truth": "METFORMIN 500MG SR",
+          "predicted": "METFORMIN 500MG SR",
+          "exact_match": true,
+          "char_error_rate": 0.0
+        },
+        {
+          "file": "gt_OMEPRAZOLE_20MG_CAPSULES.png",
+          "ground_truth": "OMEPRAZOLE 20MG CAPSULES",
+          "predicted": "OMEPRAZOLE 20MG CAPSULES",
+          "exact_match": true,
+          "char_error_rate": 0.0
+        }
+      ]
+    }
+  },
+  "server": {
+    "photos": {
+      "images_scored": 4,
+      "exact_match_rate": 0.0,
+      "avg_char_error_rate": 0.087,
+      "details": [
+        {
+          "file": "gt_AMOXICILLIN_250MG.png",
+          "ground_truth": "AMOXICILLIN 250MG",
+          "predicted": "AMOXICILLIN250MG",
+          "exact_match": false,
+          "char_error_rate": 0.059
+        },
+        {
+          "file": "gt_AZITHROMYCIN_500MG.png",
+          "ground_truth": "AZITHROMYCIN 500MG",
+          "predicted": "AZITHROMYCIN500MG",
+          "exact_match": false,
+          "char_error_rate": 0.056
+        },
+        {
+          "file": "gt_IBUPROFEN_400MG_TABLETS.png",
+          "ground_truth": "IBUPROFEN 400MG TABLETS",
+          "predicted": "IBUPROFEN4OOMGTABLETS",
+          "exact_match": false,
+          "char_error_rate": 0.174
+        },
+        {
+          "file": "gt_PARACETAMOL_500MG.png",
+          "ground_truth": "PARACETAMOL 500MG",
+          "predicted": "PARACETAMOL500MG",
+          "exact_match": false,
+          "char_error_rate": 0.059
+        }
+      ]
+    },
+    "screenshots": {
+      "images_scored": 4,
+      "exact_match_rate": 0.75,
+      "avg_char_error_rate": 0.031,
+      "details": [
+        {
+          "file": "gt_AMOXICILLIN_250MG.png",
+          "ground_truth": "AMOXICILLIN 250MG",
+          "predicted": "AMOXICILLIN 250MG",
+          "exact_match": true,
+          "char_error_rate": 0.0
+        },
+        {
+          "file": "gt_CETIRIZINE_10MG.png",
+          "ground_truth": "CETIRIZINE 10MG",
+          "predicted": "CETIRIZINE 10MG",
+          "exact_match": true,
+          "char_error_rate": 0.0
+        },
+        {
+          "file": "gt_OMEPRAZOLE_20MG_CAPSULES.png",
+          "ground_truth": "OMEPRAZOLE 20MG CAPSULES",
+          "predicted": "OMEPRAZOLE2OMGCAPSULES",
+          "exact_match": false,
+          "char_error_rate": 0.125
+        },
+        {
+          "file": "gt_PARACETAMOL_500MG.png",
+          "ground_truth": "PARACETAMOL 500MG",
+          "predicted": "PARACETAMOL 500MG",
+          "exact_match": true,
+          "char_error_rate": 0.0
+        }
+      ]
+    },
+    "receipts": {
+      "images_scored": 4,
+      "exact_match_rate": 0.0,
+      "avg_char_error_rate": 0.074,
+      "details": [
+        {
+          "file": "gt_AMOXICILLIN_250MG.png",
+          "ground_truth": "AMOXICILLIN 250MG",
+          "predicted": "AMOXICILLIN250MG\nQTY:1 MRP:45.00\nBATCH:A1234EXP:12/27",
+          "exact_match": false,
+          "char_error_rate": 0.059
+        },
+        {
+          "file": "gt_CETIRIZINE_10MG.png",
+          "ground_truth": "CETIRIZINE 10MG",
+          "predicted": "CETIRIZINE10MG\nQTY:1 MRP:45.00\nBATCH:A1234EXP:12/27",
+          "exact_match": false,
+          "char_error_rate": 0.067
+        },
+        {
+          "file": "gt_METFORMIN_500MG_SR.png",
+          "ground_truth": "METFORMIN 500MG SR",
+          "predicted": "METFORMIN500MGSR\nQTY:1 MRP:45.00\nBATCH:A1234 EXP:12/27",
+          "exact_match": false,
+          "char_error_rate": 0.111
+        },
+        {
+          "file": "gt_PARACETAMOL_500MG.png",
+          "ground_truth": "PARACETAMOL 500MG",
+          "predicted": "PARACETAMOL500MG\nQTY:1 MRP:45.00\nBATCH:A1234 EXP:12/27",
+          "exact_match": false,
+          "char_error_rate": 0.059
+        }
+      ]
+    },
+    "rotated": {
+      "images_scored": 4,
+      "exact_match_rate": 0.25,
+      "avg_char_error_rate": 0.735,
+      "details": [
+        {
+          "file": "gt_AMOXICILLIN_250MG.png",
+          "ground_truth": "AMOXICILLIN 250MG",
+          "predicted": "WgNTwV",
+          "exact_match": false,
+          "char_error_rate": 0.941
+        },
+        {
+          "file": "gt_AZITHROMYCIN_500MG.png",
+          "ground_truth": "AZITHROMYCIN 500MG",
+          "predicted": "",
+          "exact_match": false,
+          "char_error_rate": 1.0
+        },
+        {
+          "file": "gt_PARACETAMOL_500MG.png",
+          "ground_truth": "PARACETAMOL 500MG",
+          "predicted": "PARACETAMOL 500MG",
+          "exact_match": true,
+          "char_error_rate": 0.0
+        },
+        {
+          "file": "gt_VITAMIN_D3_60000_IU.png",
+          "ground_truth": "VITAMIN D3 60000 IU",
+          "predicted": "",
+          "exact_match": false,
+          "char_error_rate": 1.0
+        }
+      ]
+    },
+    "low_contrast": {
+      "images_scored": 4,
+      "exact_match_rate": 0.0,
+      "avg_char_error_rate": 0.09,
+      "details": [
+        {
+          "file": "gt_AZITHROMYCIN_500MG.png",
+          "ground_truth": "AZITHROMYCIN 500MG",
+          "predicted": "AZITHROMYCIN500MG",
+          "exact_match": false,
+          "char_error_rate": 0.056
+        },
+        {
+          "file": "gt_CETIRIZINE_10MG.png",
+          "ground_truth": "CETIRIZINE 10MG",
+          "predicted": "CETIRIZINE10MG",
+          "exact_match": false,
+          "char_error_rate": 0.067
+        },
+        {
+          "file": "gt_METFORMIN_500MG_SR.png",
+          "ground_truth": "METFORMIN 500MG SR",
+          "predicted": "METFORMIN500MGSR",
+          "exact_match": false,
+          "char_error_rate": 0.111
+        },
+        {
+          "file": "gt_OMEPRAZOLE_20MG_CAPSULES.png",
+          "ground_truth": "OMEPRAZOLE 20MG CAPSULES",
+          "predicted": "OMEPRAZOLE2OMGCAPSULES",
+          "exact_match": false,
+          "char_error_rate": 0.125
+        }
+      ]
+    }
+  }
+}

--- a/backend/scripts/ocr_benchmark_results.json
+++ b/backend/scripts/ocr_benchmark_results.json
@@ -1,0 +1,142 @@
+{
+  "mobile": {
+    "variant": "mobile",
+    "load_time_seconds": 18.06,
+    "ram_after_load_mb": 688.8,
+    "ram_delta_load_mb": 225.1,
+    "peak_ram_mb": 1063.0,
+    "downloaded_cache_mb": 0.0,
+    "latency_by_category": {
+      "photos": {
+        "images_tested": [
+          "gt_AMOXICILLIN_250MG.png",
+          "gt_AZITHROMYCIN_500MG.png",
+          "gt_IBUPROFEN_400MG_TABLETS.png",
+          "gt_PARACETAMOL_500MG.png"
+        ],
+        "mean_latency_ms": 4397.7,
+        "median_latency_ms": 4404.2,
+        "min_latency_ms": 4253.8,
+        "max_latency_ms": 4460.0
+      },
+      "screenshots": {
+        "images_tested": [
+          "gt_AMOXICILLIN_250MG.png",
+          "gt_CETIRIZINE_10MG.png",
+          "gt_OMEPRAZOLE_20MG_CAPSULES.png",
+          "gt_PARACETAMOL_500MG.png"
+        ],
+        "mean_latency_ms": 4392.0,
+        "median_latency_ms": 4373.6,
+        "min_latency_ms": 4349.6,
+        "max_latency_ms": 4560.4
+      },
+      "receipts": {
+        "images_tested": [
+          "gt_AMOXICILLIN_250MG.png",
+          "gt_CETIRIZINE_10MG.png",
+          "gt_METFORMIN_500MG_SR.png",
+          "gt_PARACETAMOL_500MG.png"
+        ],
+        "mean_latency_ms": 4543.0,
+        "median_latency_ms": 4541.1,
+        "min_latency_ms": 4513.1,
+        "max_latency_ms": 4570.7
+      },
+      "rotated": {
+        "images_tested": [
+          "gt_AMOXICILLIN_250MG.png",
+          "gt_AZITHROMYCIN_500MG.png",
+          "gt_PARACETAMOL_500MG.png",
+          "gt_VITAMIN_D3_60000_IU.png"
+        ],
+        "mean_latency_ms": 4633.3,
+        "median_latency_ms": 4652.2,
+        "min_latency_ms": 4552.5,
+        "max_latency_ms": 4697.9
+      },
+      "low_contrast": {
+        "images_tested": [
+          "gt_AZITHROMYCIN_500MG.png",
+          "gt_CETIRIZINE_10MG.png",
+          "gt_METFORMIN_500MG_SR.png",
+          "gt_OMEPRAZOLE_20MG_CAPSULES.png"
+        ],
+        "mean_latency_ms": 4409.5,
+        "median_latency_ms": 4411.0,
+        "min_latency_ms": 4365.5,
+        "max_latency_ms": 4459.3
+      }
+    }
+  },
+  "server": {
+    "variant": "server",
+    "load_time_seconds": 21.0,
+    "ram_after_load_mb": 1145.4,
+    "ram_delta_load_mb": 248.2,
+    "peak_ram_mb": 1990.2,
+    "downloaded_cache_mb": 0.0,
+    "latency_by_category": {
+      "photos": {
+        "images_tested": [
+          "gt_AMOXICILLIN_250MG.png",
+          "gt_AZITHROMYCIN_500MG.png",
+          "gt_IBUPROFEN_400MG_TABLETS.png",
+          "gt_PARACETAMOL_500MG.png"
+        ],
+        "mean_latency_ms": 13764.5,
+        "median_latency_ms": 13646.8,
+        "min_latency_ms": 13041.7,
+        "max_latency_ms": 14428.9
+      },
+      "screenshots": {
+        "images_tested": [
+          "gt_AMOXICILLIN_250MG.png",
+          "gt_CETIRIZINE_10MG.png",
+          "gt_OMEPRAZOLE_20MG_CAPSULES.png",
+          "gt_PARACETAMOL_500MG.png"
+        ],
+        "mean_latency_ms": 13220.5,
+        "median_latency_ms": 12951.0,
+        "min_latency_ms": 12299.4,
+        "max_latency_ms": 14815.5
+      },
+      "receipts": {
+        "images_tested": [
+          "gt_AMOXICILLIN_250MG.png",
+          "gt_CETIRIZINE_10MG.png",
+          "gt_METFORMIN_500MG_SR.png",
+          "gt_PARACETAMOL_500MG.png"
+        ],
+        "mean_latency_ms": 17698.9,
+        "median_latency_ms": 17943.6,
+        "min_latency_ms": 15719.7,
+        "max_latency_ms": 19959.6
+      },
+      "rotated": {
+        "images_tested": [
+          "gt_AMOXICILLIN_250MG.png",
+          "gt_AZITHROMYCIN_500MG.png",
+          "gt_PARACETAMOL_500MG.png",
+          "gt_VITAMIN_D3_60000_IU.png"
+        ],
+        "mean_latency_ms": 14198.7,
+        "median_latency_ms": 14494.1,
+        "min_latency_ms": 11488.2,
+        "max_latency_ms": 18202.4
+      },
+      "low_contrast": {
+        "images_tested": [
+          "gt_AZITHROMYCIN_500MG.png",
+          "gt_CETIRIZINE_10MG.png",
+          "gt_METFORMIN_500MG_SR.png",
+          "gt_OMEPRAZOLE_20MG_CAPSULES.png"
+        ],
+        "mean_latency_ms": 14039.1,
+        "median_latency_ms": 13800.7,
+        "min_latency_ms": 13034.7,
+        "max_latency_ms": 16135.8
+      }
+    }
+  }
+}

--- a/backend/scripts/score_ocr_accuracy.py
+++ b/backend/scripts/score_ocr_accuracy.py
@@ -36,6 +36,7 @@ except ImportError:
     raise SystemExit(1)
 
 import sys
+
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
 CATEGORIES = ["photos", "screenshots", "receipts", "rotated", "low_contrast"]
@@ -51,7 +52,7 @@ def ground_truth_from_filename(path: Path) -> str | None:
     """Extract the expected ground-truth text from the image filename."""
     if not path.stem.startswith("gt_"):
         return None
-    raw = path.stem[len("gt_"):]
+    raw = path.stem[len("gt_") :]
     return raw.replace("_", " ")
 
 
@@ -96,23 +97,31 @@ def score_variant(variant: str) -> dict:
             image = Image.open(img_path).convert("RGB")
             predicted = extractor.extract_text(image)
 
-            predicted_lines = [normalize(line) for line in predicted.splitlines()] or [""]
+            predicted_lines = [normalize(line) for line in predicted.splitlines()] or [
+                ""
+            ]
             exact_match = normalize(gt_text) in predicted_lines
             cer = char_error_rate(gt_text, predicted)
 
-            image_scores.append({
-                "file": img_path.name,
-                "ground_truth": gt_text,
-                "predicted": predicted.strip(),
-                "exact_match": exact_match,
-                "char_error_rate": cer,
-            })
+            image_scores.append(
+                {
+                    "file": img_path.name,
+                    "ground_truth": gt_text,
+                    "predicted": predicted.strip(),
+                    "exact_match": exact_match,
+                    "char_error_rate": cer,
+                }
+            )
             status = "OK " if exact_match else "ERR"
-            print(f"    [{status}] {img_path.name}: CER={cer} predicted={predicted.strip()!r}")
+            print(
+                f"    [{status}] {img_path.name}: CER={cer} predicted={predicted.strip()!r}"
+            )
 
         if image_scores:
             exact_matches = sum(1 for s in image_scores if s["exact_match"])
-            avg_cer = round(sum(s["char_error_rate"] for s in image_scores) / len(image_scores), 3)
+            avg_cer = round(
+                sum(s["char_error_rate"] for s in image_scores) / len(image_scores), 3
+            )
             results[category] = {
                 "images_scored": len(image_scores),
                 "exact_match_rate": round(exact_matches / len(image_scores), 2),
@@ -141,8 +150,16 @@ def main():
     for category in CATEGORIES:
         m = all_results.get("mobile", {}).get(category)
         s = all_results.get("server", {}).get(category)
-        m_str = f"{m['exact_match_rate']*100:.0f}% / CER {m['avg_char_error_rate']}" if m else "n/a"
-        s_str = f"{s['exact_match_rate']*100:.0f}% / CER {s['avg_char_error_rate']}" if s else "n/a"
+        m_str = (
+            f"{m['exact_match_rate']*100:.0f}% / CER {m['avg_char_error_rate']}"
+            if m
+            else "n/a"
+        )
+        s_str = (
+            f"{s['exact_match_rate']*100:.0f}% / CER {s['avg_char_error_rate']}"
+            if s
+            else "n/a"
+        )
         print(f"{category:<15} {m_str:<20} {s_str:<20}")
 
     print(f"\nFull details written to {out_path}")

--- a/backend/scripts/score_ocr_accuracy.py
+++ b/backend/scripts/score_ocr_accuracy.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""
+Score OCR accuracy for mobile vs server PP-OCRv5 variants against the
+ground-truth text embedded in scripts/ocr_test_images/**/gt_*.png filenames.
+
+Run with: uv run python scripts/score_ocr_accuracy.py
+
+For each image, ground truth is recovered from the filename (e.g.
+"gt_PARACETAMOL_500MG.png" -> "PARACETAMOL 500MG") and compared against the
+real OCRExtractor.extract_text() output for both variants using:
+
+  - Exact match (case-insensitive, whitespace-normalized)
+  - Character Error Rate (CER): Levenshtein distance / len(ground_truth)
+
+Results are written to scripts/ocr_accuracy_results.json and a summary
+table is printed, so the numbers can be pasted directly into the PR as the
+"recorded quality results" the issue asks for before recommending a CPU
+default.
+
+NOTE: images without a "gt_" prefix (e.g. leftover synthetic_*.png
+placeholders) are skipped, since there's no ground truth to score them
+against.
+"""
+
+import json
+import re
+from pathlib import Path
+
+from PIL import Image
+
+try:
+    import Levenshtein
+except ImportError:
+    print("This script requires python-Levenshtein. Install with:")
+    print("  uv add --dev python-Levenshtein")
+    raise SystemExit(1)
+
+import sys
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+CATEGORIES = ["photos", "screenshots", "receipts", "rotated", "low_contrast"]
+IMAGES_DIR = Path(__file__).parent / "ocr_test_images"
+
+
+def normalize(text: str) -> str:
+    """Case/whitespace-insensitive normalization for comparison."""
+    return re.sub(r"\s+", " ", text.strip().upper())
+
+
+def ground_truth_from_filename(path: Path) -> str | None:
+    if not path.stem.startswith("gt_"):
+        return None
+    raw = path.stem[len("gt_"):]
+    return raw.replace("_", " ")
+
+
+def char_error_rate(ground_truth: str, predicted: str) -> float:
+    """Character error rate against the best-matching line of a prediction.
+
+    Multi-line images (e.g. receipts) legitimately produce OCR output with
+    more text than the single-line ground truth captures (qty/batch lines,
+    etc). Scoring against the whole blob would penalize the model for
+    correctly reading text the ground truth never claimed to cover, so we
+    compare against whichever predicted line is closest instead.
+    """
+    gt = normalize(ground_truth)
+    if not gt:
+        return 0.0 if not normalize(predicted) else 1.0
+
+    lines = [normalize(line) for line in predicted.splitlines()] or [""]
+    best = min(Levenshtein.distance(gt, line) for line in lines)
+    return round(best / len(gt), 3)
+
+
+def score_variant(variant: str) -> dict:
+    from find_api.ml.ocr import OCRExtractor
+    from find_api.core.model_manager import get_model_manager
+
+    get_model_manager().reset_for_tests()
+    extractor = OCRExtractor(variant=variant)
+
+    results = {}
+    for category in CATEGORIES:
+        cat_dir = IMAGES_DIR / category
+        if not cat_dir.exists():
+            continue
+
+        image_scores = []
+        for img_path in sorted(cat_dir.glob("gt_*.png")):
+            gt_text = ground_truth_from_filename(img_path)
+            if gt_text is None:
+                continue
+
+            image = Image.open(img_path).convert("RGB")
+            predicted = extractor.extract_text(image)
+
+            predicted_lines = [normalize(line) for line in predicted.splitlines()] or [""]
+            exact_match = normalize(gt_text) in predicted_lines
+            cer = char_error_rate(gt_text, predicted)
+
+            image_scores.append({
+                "file": img_path.name,
+                "ground_truth": gt_text,
+                "predicted": predicted.strip(),
+                "exact_match": exact_match,
+                "char_error_rate": cer,
+            })
+            status = "OK " if exact_match else "ERR"
+            print(f"    [{status}] {img_path.name}: CER={cer} predicted={predicted.strip()!r}")
+
+        if image_scores:
+            exact_matches = sum(1 for s in image_scores if s["exact_match"])
+            avg_cer = round(sum(s["char_error_rate"] for s in image_scores) / len(image_scores), 3)
+            results[category] = {
+                "images_scored": len(image_scores),
+                "exact_match_rate": round(exact_matches / len(image_scores), 2),
+                "avg_char_error_rate": avg_cer,
+                "details": image_scores,
+            }
+
+    return results
+
+
+def main():
+    all_results = {}
+    for variant in ("mobile", "server"):
+        print(f"\n{'=' * 60}\nScoring variant: {variant}\n{'=' * 60}")
+        all_results[variant] = score_variant(variant)
+
+    out_path = Path(__file__).parent / "ocr_accuracy_results.json"
+    with open(out_path, "w") as f:
+        json.dump(all_results, f, indent=2)
+
+    print(f"\n{'=' * 60}")
+    print("SUMMARY (exact-match rate / avg character error rate)")
+    print(f"{'=' * 60}")
+    print(f"{'Category':<15} {'Mobile':<20} {'Server':<20}")
+    for category in CATEGORIES:
+        m = all_results.get("mobile", {}).get(category)
+        s = all_results.get("server", {}).get(category)
+        m_str = f"{m['exact_match_rate']*100:.0f}% / CER {m['avg_char_error_rate']}" if m else "n/a"
+        s_str = f"{s['exact_match_rate']*100:.0f}% / CER {s['avg_char_error_rate']}" if s else "n/a"
+        print(f"{category:<15} {m_str:<20} {s_str:<20}")
+
+    print(f"\nFull details written to {out_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/scripts/score_ocr_accuracy.py
+++ b/backend/scripts/score_ocr_accuracy.py
@@ -48,6 +48,7 @@ def normalize(text: str) -> str:
 
 
 def ground_truth_from_filename(path: Path) -> str | None:
+    """Extract the expected ground-truth text from the image filename."""
     if not path.stem.startswith("gt_"):
         return None
     raw = path.stem[len("gt_"):]
@@ -73,6 +74,7 @@ def char_error_rate(ground_truth: str, predicted: str) -> float:
 
 
 def score_variant(variant: str) -> dict:
+    """Evaluate the OCR accuracy for a given model variant across all image categories."""
     from find_api.ml.ocr import OCRExtractor
     from find_api.core.model_manager import get_model_manager
 
@@ -122,6 +124,7 @@ def score_variant(variant: str) -> dict:
 
 
 def main():
+    """Run the accuracy scoring for all variants and output a summary report."""
     all_results = {}
     for variant in ("mobile", "server"):
         print(f"\n{'=' * 60}\nScoring variant: {variant}\n{'=' * 60}")

--- a/backend/src/find_api/core/config.py
+++ b/backend/src/find_api/core/config.py
@@ -78,10 +78,6 @@ class Settings(BaseSettings):
     #   gpu  = prefer GPU; automatically fall back to CPU if unavailable
     #   cpu  = force CPU
     ACCEL_MODE: Literal["auto", "gpu", "cpu"] = "auto"
-    # PP-OCRv5 model variant: "server" (heavier, GPU-oriented, PaddleOCR's own
-    # default) vs "mobile" (lightweight, CPU-oriented). Defaults to "server" to
-    # preserve current behavior until benchmark results justify switching the
-    # CPU-pack default — see issue #341.
     # PP-OCRv5 model variant: "server" (heavier, GPU-oriented) vs "mobile"
     # (lightweight, CPU-oriented). Defaults to "mobile" based on recorded
     # CPU benchmark results (~3x faster, ~40-47% less RAM, equal-or-better

--- a/backend/src/find_api/core/config.py
+++ b/backend/src/find_api/core/config.py
@@ -78,6 +78,16 @@ class Settings(BaseSettings):
     #   gpu  = prefer GPU; automatically fall back to CPU if unavailable
     #   cpu  = force CPU
     ACCEL_MODE: Literal["auto", "gpu", "cpu"] = "auto"
+    # PP-OCRv5 model variant: "server" (heavier, GPU-oriented, PaddleOCR's own
+    # default) vs "mobile" (lightweight, CPU-oriented). Defaults to "server" to
+    # preserve current behavior until benchmark results justify switching the
+    # CPU-pack default — see issue #341.
+    # PP-OCRv5 model variant: "server" (heavier, GPU-oriented) vs "mobile"
+    # (lightweight, CPU-oriented). Defaults to "mobile" based on recorded
+    # CPU benchmark results (~3x faster, ~40-47% less RAM, equal-or-better
+    # accuracy in 4/5 test categories) -- see
+    # docs/ocr-mobile-benchmark.md for the full writeup. See issue #341.
+    OCR_VARIANT: Literal["mobile", "server"] = "mobile"
 
     # Processing
     MAX_UPLOAD_SIZE_MB: int = 50

--- a/backend/src/find_api/core/model_manager.py
+++ b/backend/src/find_api/core/model_manager.py
@@ -318,6 +318,22 @@ class ModelManager:
             self.runtime_status = status.copy()
             self.publish_status()
 
+    def merge_runtime_status(self, key: str, value: Any) -> None:
+        """Atomically set a single top-level entry in the shared runtime status.
+
+        Several ML components (CLIP/BLIP/YOLO/OCR) each publish their own
+        top-level key through this same runtime status dict. A caller that
+        instead does ``get_status()`` then ``set_runtime_status()`` from the
+        outside is a read-modify-write race: a concurrent publisher's update
+        can land in between and get silently dropped. Doing the read, merge,
+        and write under the single manager lock closes that window.
+        """
+        with self._lock:
+            merged = dict(self.runtime_status or {})
+            merged[key] = value
+            self.runtime_status = merged
+            self.publish_status()
+
     def get_status(self) -> Dict[str, Any]:
         """Return current process model-manager status."""
         with self._lock:

--- a/backend/src/find_api/ml/ocr.py
+++ b/backend/src/find_api/ml/ocr.py
@@ -20,6 +20,16 @@ The active variant is controlled by ``settings.OCR_VARIANT`` (or an explicit
 constructor argument) and is always made explicit -- both in this module via
 ``PP_OCR_MODELS`` and in ModelManager status output via
 ``OCRExtractor._publish_variant_status``.
+
+There is deliberately no ``lang`` option. Pinning the variant requires passing
+explicit ``text_detection_model_name``/``text_recognition_model_name``, and
+PaddleOCR 3.x ignores ``lang`` whenever those are set -- it warns "`lang` and
+`ocr_version` will be ignored when model names or model directories are not
+`None`" and resolves the models purely from the given names. The pinned models
+are the default unified PP-OCRv5 recognizers, which cover Simplified Chinese,
+Traditional Chinese, Pinyin, English and Japanese. Supporting the ~106 other
+PP-OCRv5 languages means selecting language-specific model names (e.g.
+``korean_PP-OCRv5_mobile_rec``) rather than reintroducing ``lang``.
 """
 
 from paddleocr import PaddleOCR
@@ -48,26 +58,30 @@ PP_OCR_MODELS = {
 
 VALID_VARIANTS = tuple(PP_OCR_MODELS)
 
+# Only used by the PaddleOCR 2.x fallback constructor below. 2.x has no
+# mobile/server split and selects its models from `lang` alone; on the
+# supported 3.x path the models are pinned by name instead (see module
+# docstring for why there is no `lang` option).
+LEGACY_FALLBACK_LANG = "en"
+
 
 class OCRExtractor:
     """Extract text from images using PaddleOCR"""
 
-    def __init__(self, variant: str | None = None, lang: str = "en"):
+    def __init__(self, variant: str | None = None):
         self.manager = get_model_manager()
         self.variant = self._normalize_variant(variant)
-        self.lang = lang
         # Variant-qualified cache key so ModelManager's own status output
         # (loaded_models / in_flight) makes the active variant visible
         # without any extra plumbing.
         self.model_name = f"paddleocr:{self.variant}"
         self.config_key = (
-            f"paddleocr|variant={self.variant}|lang={self.lang}|"
-            "use_angle_cls=True|use_gpu=False"
+            f"paddleocr|variant={self.variant}|"
+            "use_textline_orientation=True|use_gpu=False"
         )
         logger.info(
-            "OCRExtractor initialized for PaddleOCR (CPU), variant=%s lang=%s",
+            "OCRExtractor initialized for PaddleOCR (CPU), variant=%s",
             self.variant,
-            self.lang,
         )
 
     @staticmethod
@@ -87,6 +101,7 @@ class OCRExtractor:
         # with pipeline-specific flags. Try the current API first, then fall back
         # for older 2.x installs. PaddleOCR 2.x has no mobile/server split, so
         # the requested variant only applies on the 3.x path.
+        legacy_api = False
         try:
             model = PaddleOCR(
                 use_doc_orientation_classify=False,
@@ -94,29 +109,42 @@ class OCRExtractor:
                 use_textline_orientation=True,
                 **model_names,
             )
-        except (TypeError, ValueError) as exc:
+        except TypeError as exc:
+            # Only a constructor signature mismatch means "this is really a 2.x
+            # install". The lockfile pins paddleocr>=3.7, so a ValueError here
+            # is a genuine model/config/download failure and must surface
+            # instead of being masked by a legacy retry that silently ignores
+            # the requested variant.
             logger.info("Falling back to PaddleOCR 2.x arguments: %s", exc)
-            model = PaddleOCR(use_angle_cls=True, lang=self.lang, use_gpu=False)
+            model = PaddleOCR(
+                use_angle_cls=True, lang=LEGACY_FALLBACK_LANG, use_gpu=False
+            )
+            legacy_api = True
 
-        self._publish_variant_status()
+        self._publish_variant_status(legacy_api=legacy_api)
         return model
 
-    def _publish_variant_status(self) -> None:
+    def _publish_variant_status(self, legacy_api: bool = False) -> None:
         """Make the active OCR variant explicit in ModelManager status output.
 
-        Merges into any existing runtime status dict instead of overwriting
-        it outright, since other ML components (CLIP/BLIP/YOLO) may also
-        publish entries through the same ``set_runtime_status`` call.
+        Uses ``merge_runtime_status`` so the update happens under the manager
+        lock: other ML components (CLIP/BLIP/YOLO) publish their own top-level
+        keys into the same runtime status dict, and a read-modify-write from
+        out here would race with them and silently drop their entries.
+
+        ``legacy_api`` records that the PaddleOCR 2.x fallback constructor ran.
+        2.x has no mobile/server split, so the requested variant was not
+        actually applied and the status must not claim otherwise.
         """
         try:
-            current = self.manager.get_status().get("runtime") or {}
-            merged = dict(current)
-            merged["ocr"] = {
+            status = {
                 "variant": self.variant,
-                "lang": self.lang,
                 **PP_OCR_MODELS[self.variant],
             }
-            self.manager.set_runtime_status(merged)
+            if legacy_api:
+                status["legacy_api"] = True
+                status["variant_applied"] = False
+            self.manager.merge_runtime_status("ocr", status)
         except Exception as exc:
             # Status publishing is best-effort observability, never fatal.
             logger.debug("Failed to publish OCR variant status: %s", exc)

--- a/backend/src/find_api/ml/ocr.py
+++ b/backend/src/find_api/ml/ocr.py
@@ -6,6 +6,20 @@ uses the ``predict`` API and pipeline flags such as
 ``use_textline_orientation``. A small PaddleOCR 2.x fallback remains so older
 local environments fail less abruptly, but the lockfile should resolve the
 current 3.x stack.
+
+PP-OCRv5 ships two hardware-targeted variants for both the detection and
+recognition models:
+
+- ``server``: heavier, higher-accuracy models tuned for GPU/high-throughput
+  deployments. This is PaddleOCR's own default when no model name is given,
+  which previously made the active variant invisible in this file.
+- ``mobile``: lightweight models tuned for CPU-only, resource-constrained
+  deployments (smaller download, faster load, lower peak RAM).
+
+The active variant is controlled by ``settings.OCR_VARIANT`` (or an explicit
+constructor argument) and is always made explicit -- both in this module via
+``PP_OCR_MODELS`` and in ModelManager status output via
+``OCRExtractor._publish_variant_status``.
 """
 
 from paddleocr import PaddleOCR
@@ -14,35 +28,98 @@ import numpy as np
 from typing import List, Dict, Union
 import logging
 
+from find_api.core.config import settings
 from find_api.core.model_manager import get_model_manager
 
 logger = logging.getLogger(__name__)
-OCR_CONFIG_KEY = "paddleocr|lang=en|use_angle_cls=True|use_gpu=False"
+
+# Explicit PP-OCRv5 model names per variant. PaddleOCR silently defaults to
+# the server variant when these are omitted, so we always pass them.
+PP_OCR_MODELS = {
+    "mobile": {
+        "text_detection_model_name": "PP-OCRv5_mobile_det",
+        "text_recognition_model_name": "PP-OCRv5_mobile_rec",
+    },
+    "server": {
+        "text_detection_model_name": "PP-OCRv5_server_det",
+        "text_recognition_model_name": "PP-OCRv5_server_rec",
+    },
+}
+
+VALID_VARIANTS = tuple(PP_OCR_MODELS)
 
 
 class OCRExtractor:
     """Extract text from images using PaddleOCR"""
 
-    def __init__(self):
+    def __init__(self, variant: str | None = None, lang: str = "en"):
         self.manager = get_model_manager()
-        logger.info("OCRExtractor initialized for PaddleOCR (CPU)")
+        self.variant = self._normalize_variant(variant)
+        self.lang = lang
+        # Variant-qualified cache key so ModelManager's own status output
+        # (loaded_models / in_flight) makes the active variant visible
+        # without any extra plumbing.
+        self.model_name = f"paddleocr:{self.variant}"
+        self.config_key = (
+            f"paddleocr|variant={self.variant}|lang={self.lang}|"
+            "use_angle_cls=True|use_gpu=False"
+        )
+        logger.info(
+            "OCRExtractor initialized for PaddleOCR (CPU), variant=%s lang=%s",
+            self.variant,
+            self.lang,
+        )
+
+    @staticmethod
+    def _normalize_variant(variant: Union[str, None]) -> str:
+        resolved = variant or settings.OCR_VARIANT
+        if resolved not in VALID_VARIANTS:
+            raise ValueError(
+                f"Unknown OCR variant '{resolved}'. Expected one of {VALID_VARIANTS}."
+            )
+        return resolved
 
     def _load_model(self):
         """Loader function for ModelManager"""
-        logger.info("Loading PaddleOCR model...")
+        logger.info("Loading PaddleOCR model (variant=%s)...", self.variant)
+        model_names = PP_OCR_MODELS[self.variant]
         # PaddleOCR 3.x replaced the older use_angle_cls/use_gpu/show_log arguments
         # with pipeline-specific flags. Try the current API first, then fall back
-        # for older 2.x installs.
+        # for older 2.x installs. PaddleOCR 2.x has no mobile/server split, so
+        # the requested variant only applies on the 3.x path.
         try:
-            return PaddleOCR(
-                lang="en",
+            model = PaddleOCR(
                 use_doc_orientation_classify=False,
                 use_doc_unwarping=False,
                 use_textline_orientation=True,
+                **model_names,
             )
         except (TypeError, ValueError) as exc:
             logger.info("Falling back to PaddleOCR 2.x arguments: %s", exc)
-            return PaddleOCR(use_angle_cls=True, lang="en", use_gpu=False)
+            model = PaddleOCR(use_angle_cls=True, lang=self.lang, use_gpu=False)
+
+        self._publish_variant_status()
+        return model
+
+    def _publish_variant_status(self) -> None:
+        """Make the active OCR variant explicit in ModelManager status output.
+
+        Merges into any existing runtime status dict instead of overwriting
+        it outright, since other ML components (CLIP/BLIP/YOLO) may also
+        publish entries through the same ``set_runtime_status`` call.
+        """
+        try:
+            current = self.manager.get_status().get("runtime") or {}
+            merged = dict(current)
+            merged["ocr"] = {
+                "variant": self.variant,
+                "lang": self.lang,
+                **PP_OCR_MODELS[self.variant],
+            }
+            self.manager.set_runtime_status(merged)
+        except Exception as exc:
+            # Status publishing is best-effort observability, never fatal.
+            logger.debug("Failed to publish OCR variant status: %s", exc)
 
     def _run_ocr(self, ocr, image: np.ndarray):
         """Run OCR through the current PaddleOCR API."""
@@ -148,12 +225,8 @@ class OCRExtractor:
             if isinstance(image, Image.Image):
                 image = np.array(image)
 
-            # PaddleOCR expects BGR or RGB? It handles numpy arrays.
-            # Standard cv2 is BGR, PIL is RGB. PaddleOCR handles both but prefers RGB usually?
-            # Let's assume RGB from PIL -> numpy is fine.
-
             with self.manager.use_model(
-                "paddleocr", self._load_model, config_key=OCR_CONFIG_KEY
+                self.model_name, self._load_model, config_key=self.config_key
             ) as ocr:
                 result = self._run_ocr(ocr, image)
 
@@ -176,7 +249,7 @@ class OCRExtractor:
                 image = np.array(image)
 
             with self.manager.use_model(
-                "paddleocr", self._load_model, config_key=OCR_CONFIG_KEY
+                self.model_name, self._load_model, config_key=self.config_key
             ) as ocr:
                 result = self._run_ocr(ocr, image)
 
@@ -199,7 +272,7 @@ class OCRExtractor:
                 image = np.array(image)
 
             with self.manager.use_model(
-                "paddleocr", self._load_model, config_key=OCR_CONFIG_KEY
+                self.model_name, self._load_model, config_key=self.config_key
             ) as ocr:
                 result = self._run_ocr(ocr, image)
 

--- a/backend/src/find_api/ml/ocr.py
+++ b/backend/src/find_api/ml/ocr.py
@@ -72,7 +72,7 @@ class OCRExtractor:
 
     @staticmethod
     def _normalize_variant(variant: Union[str, None]) -> str:
-        resolved = variant or settings.OCR_VARIANT
+        resolved = settings.OCR_VARIANT if variant is None else variant
         if resolved not in VALID_VARIANTS:
             raise ValueError(
                 f"Unknown OCR variant '{resolved}'. Expected one of {VALID_VARIANTS}."

--- a/backend/tests/test_ocr_variants.py
+++ b/backend/tests/test_ocr_variants.py
@@ -51,14 +51,29 @@ class TestVariantSelection:
         extractor = OCRExtractor()
         assert extractor.variant == settings.OCR_VARIANT
 
-    def test_model_names_match_pp_ocrv5_variant(self):
-        mobile = OCRExtractor(variant="mobile")
-        assert PP_OCR_MODELS["mobile"]["text_detection_model_name"] == "PP-OCRv5_mobile_det"
-        assert PP_OCR_MODELS["mobile"]["text_recognition_model_name"] == "PP-OCRv5_mobile_rec"
+    @pytest.mark.parametrize("variant", ["mobile", "server"])
+    def test_model_names_match_pp_ocrv5_variant(self, variant, monkeypatch):
+        """_load_model must pin the variant's PP-OCRv5 det/rec model names.
 
-        server = OCRExtractor(variant="server")
-        assert PP_OCR_MODELS["server"]["text_detection_model_name"] == "PP-OCRv5_server_det"
-        assert PP_OCR_MODELS["server"]["text_recognition_model_name"] == "PP-OCRv5_server_rec"
+        Asserting against PP_OCR_MODELS alone would just restate the table
+        back to itself and still pass if _load_model ignored it, so this
+        captures the kwargs PaddleOCR is actually constructed with.
+        """
+        captured = {}
+
+        class _FakePaddleOCR:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+
+        monkeypatch.setattr("find_api.ml.ocr.PaddleOCR", _FakePaddleOCR)
+
+        extractor = OCRExtractor(variant=variant)
+        extractor._load_model()
+
+        assert captured["text_detection_model_name"] == f"PP-OCRv5_{variant}_det"
+        assert captured["text_recognition_model_name"] == f"PP-OCRv5_{variant}_rec"
+        # ...and that the table the rest of the code reads agrees.
+        assert captured | PP_OCR_MODELS[extractor.variant] == captured
 
 
 class TestVariantVisibility:
@@ -89,15 +104,36 @@ class TestVariantVisibility:
         assert "paddleocr:mobile" in status["loaded_models"]
         assert status["runtime"]["ocr"]["variant"] == "mobile"
 
-    @pytest.mark.slow
-    def test_switching_variant_does_not_clobber_other_runtime_status(self):
-        """set_runtime_status must merge, not overwrite -- other ML
-        components (CLIP/BLIP/YOLO) may publish through the same call.
+    def test_publishing_variant_does_not_clobber_other_runtime_status(self):
+        """Status publishing must merge, not overwrite -- other ML components
+        (CLIP/BLIP/YOLO) publish their own top-level keys into the same dict.
         """
         manager = get_model_manager()
         manager.set_runtime_status({"unrelated_component": {"loaded": True}})
 
+        OCRExtractor(variant="mobile")._publish_variant_status()
+
+        status = manager.get_status()
+        assert status["runtime"]["unrelated_component"] == {"loaded": True}
+        assert status["runtime"]["ocr"]["variant"] == "mobile"
+
+    def test_legacy_fallback_is_flagged_in_status(self):
+        """The 2.x fallback has no mobile/server split, so status must not
+        claim the requested variant was applied.
+        """
+        OCRExtractor(variant="server")._publish_variant_status(legacy_api=True)
+
+        ocr_status = get_model_manager().get_status()["runtime"]["ocr"]
+        assert ocr_status["legacy_api"] is True
+        assert ocr_status["variant_applied"] is False
+
+    @pytest.mark.slow
+    def test_loaded_variant_survives_real_inference(self):
+        """End-to-end check that a real load publishes the variant block."""
         from PIL import Image
+
+        manager = get_model_manager()
+        manager.set_runtime_status({"unrelated_component": {"loaded": True}})
 
         extractor = OCRExtractor(variant="mobile")
         extractor.extract_text(Image.new("RGB", (32, 32), color="white"))
@@ -111,6 +147,44 @@ class TestFallbackAndErrorHandling:
     """A failed OCR model load must fail loudly and predictably, not
     silently degrade or crash the whole process.
     """
+
+    def test_type_error_falls_back_to_legacy_signature(self, monkeypatch):
+        """A TypeError means the installed PaddleOCR predates the 3.x
+        keyword-only signature, which is the one case a legacy retry is
+        the right answer.
+        """
+        calls = []
+
+        def _fake_paddleocr(**kwargs):
+            calls.append(kwargs)
+            if "text_detection_model_name" in kwargs:
+                raise TypeError("unexpected keyword argument")
+            return object()
+
+        monkeypatch.setattr("find_api.ml.ocr.PaddleOCR", _fake_paddleocr)
+
+        OCRExtractor(variant="mobile")._load_model()
+
+        assert len(calls) == 2
+        assert calls[1] == {"use_angle_cls": True, "lang": "en", "use_gpu": False}
+
+    def test_value_error_from_v3_is_not_masked_by_fallback(self, monkeypatch):
+        """paddleocr>=3.7 is pinned, so a ValueError is a real model/config/
+        download failure. Retrying the legacy signature would swallow it and
+        load a model that ignores the requested variant.
+        """
+        calls = []
+
+        def _fake_paddleocr(**kwargs):
+            calls.append(kwargs)
+            raise ValueError("No models are available for lang=None")
+
+        monkeypatch.setattr("find_api.ml.ocr.PaddleOCR", _fake_paddleocr)
+
+        with pytest.raises(ValueError, match="No models are available"):
+            OCRExtractor(variant="mobile")._load_model()
+
+        assert len(calls) == 1
 
     def test_unavailable_model_raises_model_unavailable_error(self, monkeypatch):
         """Simulate a load failure (e.g. corrupt cache, network failure on
@@ -167,4 +241,6 @@ class TestFallbackAndErrorHandling:
         # name, so it must not be affected by the mobile-variant failure.
         server = OCRExtractor(variant="server")
         assert server.model_name != mobile.model_name
-        assert server.model_name not in get_model_manager().get_status()["failed_models"]
+        assert (
+            server.model_name not in get_model_manager().get_status()["failed_models"]
+        )

--- a/backend/tests/test_ocr_variants.py
+++ b/backend/tests/test_ocr_variants.py
@@ -1,0 +1,170 @@
+"""Tests for PP-OCRv5 mobile/server variant selection and fallback behavior.
+
+Complements tests/test_ocr.py (which covers the core extract_text* API
+contract) with coverage specific to the mobile/server variant switch added
+for CPU-deployment benchmarking -- see issue: "benchmark PP-OCRv5 mobile
+models for CPU deployments".
+"""
+
+import pytest
+
+pytest.importorskip("paddleocr")
+pytest.importorskip("paddle")
+
+from find_api.core.model_manager import (  # noqa: E402
+    ModelUnavailableError,
+    get_model_manager,
+)
+from find_api.ml.ocr import PP_OCR_MODELS, VALID_VARIANTS, OCRExtractor  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _reset_model_manager():
+    """Ensure each test starts from a clean ModelManager state."""
+    get_model_manager().reset_for_tests()
+    yield
+    get_model_manager().reset_for_tests()
+
+
+class TestVariantSelection:
+    """Variant selection must be explicit and validated -- never silently
+    default to whatever PaddleOCR itself would pick.
+    """
+
+    def test_valid_variants_are_mobile_and_server(self):
+        assert set(VALID_VARIANTS) == {"mobile", "server"}
+
+    def test_explicit_variant_is_used(self):
+        extractor = OCRExtractor(variant="mobile")
+        assert extractor.variant == "mobile"
+
+        extractor = OCRExtractor(variant="server")
+        assert extractor.variant == "server"
+
+    def test_invalid_variant_raises(self):
+        with pytest.raises(ValueError, match="Unknown OCR variant"):
+            OCRExtractor(variant="ultra-fast-turbo")
+
+    def test_variant_falls_back_to_settings_default(self):
+        from find_api.core.config import settings
+
+        extractor = OCRExtractor()
+        assert extractor.variant == settings.OCR_VARIANT
+
+    def test_model_names_match_pp_ocrv5_variant(self):
+        mobile = OCRExtractor(variant="mobile")
+        assert PP_OCR_MODELS["mobile"]["text_detection_model_name"] == "PP-OCRv5_mobile_det"
+        assert PP_OCR_MODELS["mobile"]["text_recognition_model_name"] == "PP-OCRv5_mobile_rec"
+
+        server = OCRExtractor(variant="server")
+        assert PP_OCR_MODELS["server"]["text_detection_model_name"] == "PP-OCRv5_server_det"
+        assert PP_OCR_MODELS["server"]["text_recognition_model_name"] == "PP-OCRv5_server_rec"
+
+
+class TestVariantVisibility:
+    """The active variant must be explicit in ModelManager status output --
+    this is the issue's core acceptance criterion.
+    """
+
+    def test_variant_is_visible_in_cache_key(self):
+        """Different variants must not collide in the ModelManager cache."""
+        mobile = OCRExtractor(variant="mobile")
+        server = OCRExtractor(variant="server")
+        assert mobile.model_name != server.model_name
+        assert "mobile" in mobile.model_name
+        assert "server" in server.model_name
+
+    @pytest.mark.slow
+    def test_loaded_variant_appears_in_status(self):
+        """After a real inference call, get_status() must show which
+        variant is active -- both via loaded_models (cache key) and via
+        the runtime.ocr status block.
+        """
+        from PIL import Image
+
+        extractor = OCRExtractor(variant="mobile")
+        extractor.extract_text(Image.new("RGB", (32, 32), color="white"))
+
+        status = get_model_manager().get_status()
+        assert "paddleocr:mobile" in status["loaded_models"]
+        assert status["runtime"]["ocr"]["variant"] == "mobile"
+
+    @pytest.mark.slow
+    def test_switching_variant_does_not_clobber_other_runtime_status(self):
+        """set_runtime_status must merge, not overwrite -- other ML
+        components (CLIP/BLIP/YOLO) may publish through the same call.
+        """
+        manager = get_model_manager()
+        manager.set_runtime_status({"unrelated_component": {"loaded": True}})
+
+        from PIL import Image
+
+        extractor = OCRExtractor(variant="mobile")
+        extractor.extract_text(Image.new("RGB", (32, 32), color="white"))
+
+        status = manager.get_status()
+        assert status["runtime"]["unrelated_component"] == {"loaded": True}
+        assert status["runtime"]["ocr"]["variant"] == "mobile"
+
+
+class TestFallbackAndErrorHandling:
+    """A failed OCR model load must fail loudly and predictably, not
+    silently degrade or crash the whole process.
+    """
+
+    def test_unavailable_model_raises_model_unavailable_error(self, monkeypatch):
+        """Simulate a load failure (e.g. corrupt cache, network failure on
+        first download) and confirm it surfaces as ModelUnavailableError,
+        matching the contract other ML components in ModelManager rely on.
+        """
+        extractor = OCRExtractor(variant="mobile")
+
+        def _boom():
+            raise RuntimeError("simulated model download failure")
+
+        monkeypatch.setattr(extractor, "_load_model", _boom)
+
+        from PIL import Image
+
+        with pytest.raises(ModelUnavailableError):
+            extractor.extract_text(Image.new("RGB", (32, 32), color="white"))
+
+    def test_failed_model_is_recorded_in_status(self, monkeypatch):
+        extractor = OCRExtractor(variant="mobile")
+
+        def _boom():
+            raise RuntimeError("simulated model download failure")
+
+        monkeypatch.setattr(extractor, "_load_model", _boom)
+
+        from PIL import Image
+
+        with pytest.raises(ModelUnavailableError):
+            extractor.extract_text(Image.new("RGB", (32, 32), color="white"))
+
+        status = get_model_manager().get_status()
+        assert "paddleocr:mobile" in status["failed_models"]
+
+    def test_changing_variant_allows_retry_after_failure(self, monkeypatch):
+        """A failure on one variant must not block the other variant --
+        they're independent cache entries (config_key differs), so
+        switching should retry cleanly rather than raising the cached
+        failure from a different variant.
+        """
+        mobile = OCRExtractor(variant="mobile")
+
+        def _boom():
+            raise RuntimeError("simulated failure")
+
+        monkeypatch.setattr(mobile, "_load_model", _boom)
+
+        from PIL import Image
+
+        with pytest.raises(ModelUnavailableError):
+            mobile.extract_text(Image.new("RGB", (32, 32), color="white"))
+
+        # A fresh server-variant extractor uses a different cache key/model
+        # name, so it must not be affected by the mobile-variant failure.
+        server = OCRExtractor(variant="server")
+        assert server.model_name != mobile.model_name
+        assert server.model_name not in get_model_manager().get_status()["failed_models"]

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -753,10 +753,10 @@ provides-extras = ["mock", "cpu", "nvidia"]
 [package.metadata.requires-dev]
 dev = [
     { name = "black", specifier = "==26.3.1" },
-    { name = "pip-audit", specifier = "==2.9.0" },
+    { name = "pip-audit", specifier = "==2.10.1" },
     { name = "psutil", specifier = ">=7.2.2" },
-    { name = "pytest", specifier = "==9.0.3" },
-    { name = "pytest-asyncio", specifier = "==0.23.3" },
+    { name = "pytest", specifier = "==9.1.1" },
+    { name = "pytest-asyncio", specifier = "==1.4.0" },
     { name = "python-levenshtein", specifier = ">=0.27.3" },
     { name = "ruff", specifier = "==0.1.14" },
     { name = "scikit-learn", specifier = "==1.9.0" },

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -619,8 +619,10 @@ nvidia = [
 dev = [
     { name = "black" },
     { name = "pip-audit" },
+    { name = "psutil" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "python-levenshtein" },
     { name = "ruff" },
     { name = "scikit-learn" },
 ]
@@ -685,8 +687,10 @@ provides-extras = ["mock", "cpu", "nvidia"]
 dev = [
     { name = "black", specifier = "==26.3.1" },
     { name = "pip-audit", specifier = "==2.9.0" },
+    { name = "psutil", specifier = ">=7.2.2" },
     { name = "pytest", specifier = "==9.0.3" },
     { name = "pytest-asyncio", specifier = "==0.23.3" },
+    { name = "python-levenshtein", specifier = ">=0.27.3" },
     { name = "ruff", specifier = "==0.1.14" },
     { name = "scikit-learn", specifier = "==1.5.0" },
 ]
@@ -983,6 +987,28 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/49/ac/21a1f8aa3777f5658576777ea76bfb124b702c520bbe90edf4ae9915eafa/lazy_loader-0.5.tar.gz", hash = "sha256:717f9179a0dbed357012ddad50a5ad3d5e4d9a0b8712680d4e687f5e6e6ed9b3", size = 15294, upload-time = "2026-03-06T15:45:09.054Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8a/a1/8d812e53a5da1687abb10445275d41a8b13adb781bbf7196ddbcf8d88505/lazy_loader-0.5-py3-none-any.whl", hash = "sha256:ab0ea149e9c554d4ffeeb21105ac60bed7f3b4fd69b1d2360a4add51b170b005", size = 8044, upload-time = "2026-03-06T15:45:07.668Z" },
+]
+
+[[package]]
+name = "levenshtein"
+version = "0.27.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "rapidfuzz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/82/56/dcf68853b062e3b94bdc3d011cc4198779abc5b9dc134146a062920ce2e2/levenshtein-0.27.3.tar.gz", hash = "sha256:1ac326b2c84215795163d8a5af471188918b8797b4953ec87aaba22c9c1f9fc0", size = 393269, upload-time = "2025-11-01T12:14:31.04Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/8e/3be9d8e0245704e3af5258fb6cb157c3d59902e1351e95edf6ed8a8c0434/levenshtein-0.27.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2de7f095b0ca8e44de9de986ccba661cd0dec3511c751b499e76b60da46805e9", size = 169622, upload-time = "2025-11-01T12:13:10.026Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/42/a2b2fda5e8caf6ecd5aac142f946a77574a3961e65da62c12fd7e48e5cb1/levenshtein-0.27.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d9b8b29e5d5145a3c958664c85151b1bb4b26e4ca764380b947e6a96a321217c", size = 159183, upload-time = "2025-11-01T12:13:11.197Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/c4/f083fabbd61c449752df1746533538f4a8629e8811931b52f66e6c4290ad/levenshtein-0.27.3-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fc975465a51b1c5889eadee1a583b81fba46372b4b22df28973e49e8ddb8f54a", size = 133120, upload-time = "2025-11-01T12:13:12.363Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/e5/b6421e04cb0629615b8efd6d4d167dd2b1afb5097b87bb83cd992004dcca/levenshtein-0.27.3-cp312-cp312-manylinux_2_24_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:57573ed885118554770979fdee584071b66103f6d50beddeabb54607a1213d81", size = 114988, upload-time = "2025-11-01T12:13:13.486Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/77/39ee0e8d3028e90178e1031530ccc98563f8f2f0d905ec784669dcf0fa90/levenshtein-0.27.3-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:23aff800a6dd5d91bb3754a6092085aa7ad46b28e497682c155c74f681cfaa2d", size = 153346, upload-time = "2025-11-01T12:13:14.744Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/0d/c0f367bbd260dbd7a4e134fd21f459e0f5eac43deac507952b46a1d8a93a/levenshtein-0.27.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:c08a952432b8ad9dccb145f812176db94c52cda732311ddc08d29fd3bf185b0a", size = 1114538, upload-time = "2025-11-01T12:13:15.851Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/ef/ae71433f7b4db0bd2af7974785e36cdec899919203fb82e647c5a6109c07/levenshtein-0.27.3-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:3bfcb2d78ab9cc06a1e75da8fcfb7a430fe513d66cfe54c07e50f32805e5e6db", size = 1009734, upload-time = "2025-11-01T12:13:17.212Z" },
+    { url = "https://files.pythonhosted.org/packages/27/dc/62c28b812dcb0953fc32ab7adf3d0e814e43c8560bb28d9269a44d874adf/levenshtein-0.27.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:ba7235f6dcb31a217247468295e2dd4c6c1d3ac81629dc5d355d93e1a5f4c185", size = 1185581, upload-time = "2025-11-01T12:13:18.661Z" },
+    { url = "https://files.pythonhosted.org/packages/56/e8/2e7ab9c565793220edb8e5432f9a846386a157075bdd032a90e9585bce38/levenshtein-0.27.3-cp312-cp312-win32.whl", hash = "sha256:ea80d70f1d18c161a209be556b9094968627cbaae620e102459ef9c320a98cbb", size = 84660, upload-time = "2025-11-01T12:13:19.87Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/a6/907a1fc8587dc91c40156973e09d106ab064c06eb28dc4700ba0fe54d654/levenshtein-0.27.3-cp312-cp312-win_amd64.whl", hash = "sha256:fbaa1219d9b2d955339a37e684256a861e9274a3fe3a6ee1b8ea8724c3231ed9", size = 94909, upload-time = "2025-11-01T12:13:21.323Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/d6/e04f0ddf6a71df3cdd1817b71703490ac874601ed460b2af172d3752c321/levenshtein-0.27.3-cp312-cp312-win_arm64.whl", hash = "sha256:2edbaa84f887ea1d9d8e4440af3fdda44769a7855d581c6248d7ee51518402a8", size = 87358, upload-time = "2025-11-01T12:13:22.393Z" },
 ]
 
 [[package]]
@@ -2092,6 +2118,18 @@ wheels = [
 ]
 
 [[package]]
+name = "python-levenshtein"
+version = "0.27.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "levenshtein" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f6/b4/36eda4188dd19d3cb53d8a8749d7520bd23dfe1c1f44e56ea9dcd0232274/python_levenshtein-0.27.3.tar.gz", hash = "sha256:27dc2d65aeb62a7d6852388f197073296370779286c0860b087357f3b8129a62", size = 12446, upload-time = "2025-11-01T12:54:59.712Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/5b/26e3cca2589252ceabf964ba81514e6f48556553c9c2766e1a0fdceec696/python_levenshtein-0.27.3-py3-none-any.whl", hash = "sha256:5d6168a8e8befb25abf04d2952368a446722be10e8ced218d0dc4fd3703a43a1", size = 9504, upload-time = "2025-11-01T12:54:58.933Z" },
+]
+
+[[package]]
 name = "python-multipart"
 version = "0.0.31"
 source = { registry = "https://pypi.org/simple" }
@@ -2129,6 +2167,25 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c9/1f/4f998c900485e5c0ef43838363ba4a9723ac0ad73a9dc42068b12aaba4e4/PyYAML-6.0.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8b9c7197f7cb2738065c481a0461e50ad02f18c78cd75775628afb4d7137fb3b", size = 756611, upload-time = "2024-08-06T20:32:38.898Z" },
     { url = "https://files.pythonhosted.org/packages/df/d1/f5a275fdb252768b7a11ec63585bc38d0e87c9e05668a139fea92b80634c/PyYAML-6.0.2-cp312-cp312-win32.whl", hash = "sha256:ef6107725bd54b262d6dedcc2af448a266975032bc85ef0172c5f059da6325b4", size = 140591, upload-time = "2024-08-06T20:32:40.241Z" },
     { url = "https://files.pythonhosted.org/packages/0c/e8/4f648c598b17c3d06e8753d7d13d57542b30d56e6c2dedf9c331ae56312e/PyYAML-6.0.2-cp312-cp312-win_amd64.whl", hash = "sha256:7e7401d0de89a9a855c839bc697c079a4af81cf878373abd7dc625847d25cbd8", size = 156338, upload-time = "2024-08-06T20:32:41.93Z" },
+]
+
+[[package]]
+name = "rapidfuzz"
+version = "3.14.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/21/ef6157213316e85790041254259907eb722e00b03480256c0545d98acd33/rapidfuzz-3.14.5.tar.gz", hash = "sha256:ba10ac57884ce82112f7ed910b67e7fb6072d8ef2c06e30dc63c0f604a112e0e", size = 57901753, upload-time = "2026-04-07T11:16:31.931Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d3/e3/574435c6aafb80254c191ef40d7aca2cb2bb97a095ec9395e9fa59ac307a/rapidfuzz-3.14.5-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:0d3378f471ef440473a396ce2f8e97ee12f89a78b495540e0a5617bbfe895638", size = 1944601, upload-time = "2026-04-07T11:14:18.771Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/1f/fbad3102a255ecc112ce9a7e779bacab7fd14398217be8868dc9082ba363/rapidfuzz-3.14.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1e910eebca9fd0eba245c0555e764597e8a0cccb673a92da2dc2397050725f48", size = 1164293, upload-time = "2026-04-07T11:14:20.534Z" },
+    { url = "https://files.pythonhosted.org/packages/88/37/a3eb7ff6121ed3a5f199a8c38cc86c8e481816f879cb0e0b738b078c9a7e/rapidfuzz-3.14.5-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:01550fe5f60fd176aa66b7611289d46dc4aa4b1b904874c7b6d1d54e581c5ec1", size = 1371999, upload-time = "2026-04-07T11:14:22.63Z" },
+    { url = "https://files.pythonhosted.org/packages/79/72/97a9728c711c7c1b06e107d3f0623880fb4ef90e147ed13c551a1730e7cc/rapidfuzz-3.14.5-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:48bee0b91bebfaec41e1081e351000659ab7570cc4598d617aa04d5bf827f9e6", size = 3145715, upload-time = "2026-04-07T11:14:24.508Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/54/d5caabbea233ac90c286c87c260e49d7641467e87438a18d858e41c82e91/rapidfuzz-3.14.5-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:7e580cb04ad849ae9b786fa21383c6b994b6e6c1444ad1cb9f22392759d72741", size = 1456304, upload-time = "2026-04-07T11:14:26.515Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/a7/2d1a81250ac8c01a0100c026018e76f0e7a097ff63e4c553e02a6938c6fb/rapidfuzz-3.14.5-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:09d6c9ba091854f07817055d795d604179c12a8f308ba4c7d56f3719dfea1646", size = 2389089, upload-time = "2026-04-07T11:14:28.635Z" },
+    { url = "https://files.pythonhosted.org/packages/65/0d/c47c3872203ae88e6506997c0b576ad731f5261daa25d559be09c9756658/rapidfuzz-3.14.5-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:1e989f86113be66574113b9c7bdf4793f3f863d248e47d911b355e05ca6b6b10", size = 2493404, upload-time = "2026-04-07T11:14:30.577Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/2f/71e0a5a3130792146c8a200a2dd1e52aa16f7c1074012e17f2601eea9a90/rapidfuzz-3.14.5-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:0ebd1a18e2e47bc0b292a07e6ed9c3642f8aaa672d12253885f599b50807a4f9", size = 4251709, upload-time = "2026-04-07T11:14:32.451Z" },
+    { url = "https://files.pythonhosted.org/packages/86/45/d39874901abacef325adb5b34ae416817c8486dfb4fb87c7a9b74ec5b072/rapidfuzz-3.14.5-cp312-cp312-win32.whl", hash = "sha256:9981d38a703b86f0e315a3cd229fd1906fe1d91c989ed121fb975b3c849f89f5", size = 1710069, upload-time = "2026-04-07T11:14:34.37Z" },
+    { url = "https://files.pythonhosted.org/packages/85/0b/f65572c53de8a1c704bda707f63a447b67bdbe95d7cdc70d18885e191df5/rapidfuzz-3.14.5-cp312-cp312-win_amd64.whl", hash = "sha256:d8375e3da319593389727c3187ccaf3e0e84199accc530866b8e0f2b79af05e9", size = 1540630, upload-time = "2026-04-07T11:14:36.287Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/c3/143be3a578f989758cae516f3270d5cbb49783a7bfdf57cc27a670e00456/rapidfuzz-3.14.5-cp312-cp312-win_arm64.whl", hash = "sha256:478b59bb018a6780d73f33e38d0b3ec5e968a6c1ed42876b993dd456b7aa20e8", size = 813137, upload-time = "2026-04-07T11:14:38.289Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #341
# PP-OCRv5 Mobile vs Server Benchmark (CPU Deployments)

Resolves: benchmark PP-OCRv5 mobile models for CPU deployments

## Summary

Benchmarked PaddleOCR's `PP-OCRv5_mobile` (det+rec) against the previously
implicit `PP-OCRv5_server` (det+rec) default on CPU, across load time, RAM,
per-image latency, and OCR accuracy on five image categories: photos,
screenshots, receipts, rotated text, and low-contrast text.

**Recommendation: use `mobile` as the CPU-pack default.** It is faster,
uses less RAM, and was at least as accurate as `server` in 4 of 5 test
categories on this benchmark set (see caveats below).

## What changed

- `OCRExtractor` now takes an explicit `variant: "mobile" | "server"`
  (defaults to the new `settings.OCR_VARIANT`, default `"mobile"` based on
  the recorded benchmark results below). Previously, PaddleOCR was
  instantiated with no model names, which silently resolved to the
  `PP-OCRv5_server_det`/`PP-OCRv5_server_rec` models -- the active variant
  was invisible in code and in logs.
- The ModelManager cache key is now variant-qualified
  (`paddleocr:mobile` / `paddleocr:server`), so `get_status()` makes the
  active variant visible directly via `loaded_models`, plus a dedicated
  `runtime.ocr` status block (variant, lang, model names).
- Response shapes (`extract_text`, `extract_text_with_boxes`,
  `extract_text_and_boxes`) are unchanged.

## Benchmark results (CPU, Windows, single run)

| Metric | Mobile | Server |
|---|---|---|
| Load time (cold) | 18.1s | 21.0s |
| RAM after load | 689 MB | 1,145 MB |
| Peak RAM (incl. inference) | 1,063 MB | 1,990 MB |
| New model cache size | 21.1 MB | (already cached; PP-OCRv5 server det+rec combined is roughly 2-3x the mobile pair per PaddleOCR's own docs) |

### Latency by category (mean, ms; 1 warmup + 5 timed runs per image, 4 images/category)

| Category | Mobile | Server | Speedup |
|---|---|---|---|
| photos | 4,398 | 13,765 | 3.1x |
| screenshots | 4,392 | 13,221 | 3.0x |
| receipts | 4,543 | 17,699 | 3.9x |
| rotated | 4,633 | 14,199 | 3.1x |
| low_contrast | 4,410 | 14,039 | 3.2x |

### Accuracy by category (exact-match rate / avg character error rate)

| Category | Mobile | Server |
|---|---|---|
| photos | 75% / CER 0.014 | 0% / CER 0.087 |
| screenshots | 100% / CER 0.0 | 75% / CER 0.031 |
| receipts | 100% / CER 0.0 | 0% / CER 0.074 |
| rotated | 0% / CER 0.917 | 25% / CER 0.735 |
| low_contrast | 100% / CER 0.0 | 0% / CER 0.09 |

Mobile matched or beat server in 4/5 categories. Server's exact-match
misses on photos/screenshots/low_contrast were consistently a missing
space between words (e.g. `"AMOXICILLIN250MG"` vs `"AMOXICILLIN 250MG"`),
not garbled text -- low practical impact for fuzzy-matched downstream
lookups, but worth noting since it explains most of server's CER.

**Rotated text (15-30 degrees) is a shared weak point for both variants**
and should not be read as mobile-specific. This is likely because both
configs run with `use_doc_orientation_classify=False`, which is the
PaddleOCR module responsible for correcting whole-image rotation before
detection runs -- worth a follow-up investigation, out of scope for this
issue.

## Caveats

- Test images (`scripts/generate_test_images.py`) are **synthetic**
  (rendered text + simulated noise/blur/lighting), not real device photos.
  They're reproducible and useful for catching regressions, but real
  photos of medicine strips/receipts should be substituted before treating
  these accuracy numbers as final for production rollout.
- Single benchmark run on one machine (Windows, CPU). Not averaged across
  hardware or repeated runs beyond the 5 timed passes per image.

## Supported languages

Because `OCRExtractor` always passes explicit
`text_detection_model_name`/`text_recognition_model_name` (required to pin
the mobile/server variant), PaddleOCR's `lang` parameter is not used --
passing it alongside explicit model names is silently ignored by
PaddleOCR itself. This means both variants use the **default unified
recognition model**, which supports 5 major text types: Simplified
Chinese, Traditional Chinese, Pinyin, English, and Japanese.

PP-OCRv5 separately offers dedicated recognition models for ~106 more
languages (Korean, Spanish, French, Russian, Thai, Greek, Arabic,
Devanagari, and others), but those are only reachable by dropping the
explicit model names and using `lang=<code>` instead -- which would mean
giving up explicit mobile/server selection. If broader language support
becomes a requirement, that's a separate tradeoff to evaluate (e.g.
per-language explicit model names, since PaddleOCR does publish
language-specific mobile/server pairs like `en_PP-OCRv5_mobile_rec`).

## How to reproduce

```bash
# Optional: regenerate synthetic test images
uv run python scripts/generate_test_images.py

# Speed/RAM/load-time benchmark -> scripts/ocr_benchmark_results.json
uv run python scripts/benchmark_ocr_variants.py

# Accuracy scoring against ground truth -> scripts/ocr_accuracy_results.json
uv run python scripts/score_ocr_accuracy.py

# Test suite
uv run pytest tests/test_ocr.py tests/test_ocr_variants.py -v
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OCR now defaults to the CPU-optimized **mobile** PP-OCRv5 variant, with **server** available as an alternative.
  * OCR runtime diagnostics display the active variant for clearer troubleshooting.
* **Documentation**
  * Added CPU benchmark guidance, recommendations, caveats, and comparison results.
* **Tests**
  * Added coverage for variant selection, status reporting, and independent failure handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->