### PR TITLE
fix: constrain transitive setuptools to the patched release

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -101,6 +101,10 @@ torchvision = [
 ]
 
 [tool.uv]
+# setuptools arrives transitively (torch, pip-audit) and resolved to 82.0.1,
+# which is GHSA-affected (<83.0.0). The build-system pin above only governs
+# building this package, not the resolved environment, so constrain it here.
+constraint-dependencies = ["setuptools>=83.0.0"]
 conflicts = [
   [
     { extra = "cpu" },

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -17,6 +17,9 @@ conflicts = [[
     { package = "find-backend", extra = "nvidia" },
 ]]
 
+[manifest]
+constraints = [{ name = "setuptools", specifier = ">=83.0.0" }]
+
 [[package]]
 name = "aiofiles"
 version = "25.1.0"
@@ -2327,11 +2330,11 @@ wheels = [
 
 [[package]]
 name = "setuptools"
-version = "82.0.1"
+version = "83.0.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4f/db/cfac1baf10650ab4d1c111714410d2fbb77ac5a616db26775db562c8fab2/setuptools-82.0.1.tar.gz", hash = "sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9", size = 1152316, upload-time = "2026-03-09T12:47:17.221Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/26/f5d29e25ffdb535afef2d35cdb55b325298f96debd670da4c325e08d70f4/setuptools-83.0.0.tar.gz", hash = "sha256:025bccbbf0fa05b6192bc64ae1e7b16e001fd6d6d4d5de03c97b1c1ade523bef", size = 1154254, upload-time = "2026-07-04T15:31:22.699Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9d/76/f789f7a86709c6b087c5a2f52f911838cad707cc613162401badc665acfe/setuptools-82.0.1-py3-none-any.whl", hash = "sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb", size = 1006223, upload-time = "2026-03-09T12:47:15.026Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/40/e1e72872c6354b306daef1703549e8e83b4d43cfea356311bf722a043752/setuptools-83.0.0-py3-none-any.whl", hash = "sha256:29b23c360f22f414dc7336bb39178cc7bcbf6021ed2733cde173f09dba19abb3", size = 1008090, upload-time = "2026-07-04T15:31:20.885Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Closes the last actionable backend advisory: `setuptools <83.0.0` (medium) against `backend/uv.lock`.

#373 bumped the build-system pin to `setuptools>=83.0.0`, but `[build-system].requires` only governs **building** this package — it does not constrain the resolved environment. setuptools also arrives transitively via `torch` and `pip-audit` with no lower bound, so `uv.lock` stayed on **82.0.1** and the alert stayed open.

Adding `constraint-dependencies` under `[tool.uv]` pins the transitive resolution forward without making setuptools a direct runtime dependency:

```toml
[tool.uv]
constraint-dependencies = ["setuptools>=83.0.0"]
```

`uv lock` then moves it: `Updated setuptools v82.0.1 -> v83.0.0`.

## Type of change

- [x] Bug fix

## Release impact

- [x] Critical/security fix (keep sensitive details private)

## How to test

```bash
cd backend
uv sync --group dev --locked
uv run ruff check . && uv run ruff format --check .
uv run pytest tests/
uv run pip-audit
grep -A1 '^name = "setuptools"$' uv.lock   # 83.0.0
```

All green locally: 527 tests passing (5 skipped), `pip-audit` reports no known vulnerabilities.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency resolution to require a secure version of the package build tooling.
  * Prevented installation of a vulnerable transitive dependency version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->