### PR TITLE
chore(ci): split Dependabot majors from minors and pin torch to manual bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,20 @@
 version: 2
+
+# Each ecosystem is split into two groups: one for minor/patch updates and one
+# for majors.
+#
+# A single all-in-one group repeatedly produced PRs that could not merge,
+# because one breaking major took the whole batch down with it and blocked the
+# routine security patches riding along:
+#
+#   - #369 bundled a torch major that does not exist on the pinned
+#     pytorch-cu128 index, so `uv sync --locked` failed on every runner and the
+#     other 20 python updates were stuck behind it.
+#   - #375 / #380 bundled tailwindcss 3 -> 4 and typescript 5 -> 7, which fail
+#     `frontend-check`, blocking the axios and react patches in the same PR.
+#
+# Keeping majors separate means the safe half stays mergeable on its own, and
+# each breaking upgrade gets reviewed on its own terms.
 updates:
   - package-ecosystem: github-actions
     directory: /
@@ -11,6 +27,10 @@ updates:
     groups:
       actions:
         patterns: ["*"]
+        update-types: ["minor", "patch"]
+      actions-major:
+        patterns: ["*"]
+        update-types: ["major"]
 
   - package-ecosystem: pip
     directory: /backend
@@ -23,6 +43,28 @@ updates:
     groups:
       python-runtime:
         patterns: ["*"]
+        update-types: ["minor", "patch"]
+      python-runtime-major:
+        patterns: ["*"]
+        update-types: ["major"]
+    # torch/torchvision resolve from the pinned pytorch-cpu and pytorch-cu128
+    # indexes (see [tool.uv.sources] in backend/pyproject.toml), and cu128 lags
+    # PyPI. Dependabot reads PyPI, so it proposes versions the nvidia extra
+    # cannot resolve at all -- #369 proposed torch 2.13.0, which cu128 does not
+    # publish, and `uv sync --locked` failed on every runner. That was a minor
+    # bump, so the major/minor split above would not have caught it.
+    #
+    # TRADEOFF, read before removing: `ignore` suppresses Dependabot *security*
+    # update PRs for these packages as well as version updates. A future torch
+    # CVE will therefore still raise an alert in the Security tab, but will NOT
+    # open a PR on its own -- someone has to act on the alert by hand. That is
+    # accepted here only because a torch bump has to be hand-verified against
+    # the real ML stack regardless (transformers, open-clip-torch, timm,
+    # ultralytics, insightface). #382 tracks the current open torch advisories
+    # and the 2.11.0 evaluation; keep that issue alive while this ignore exists.
+    ignore:
+      - dependency-name: torch
+      - dependency-name: torchvision
 
   - package-ecosystem: npm
     directory: /frontend
@@ -35,6 +77,10 @@ updates:
     groups:
       frontend-runtime:
         patterns: ["*"]
+        update-types: ["minor", "patch"]
+      frontend-runtime-major:
+        patterns: ["*"]
+        update-types: ["major"]
 
   - package-ecosystem: cargo
     directory: /frontend/src-tauri
@@ -44,6 +90,10 @@ updates:
     groups:
       desktop-runtime:
         patterns: ["*"]
+        update-types: ["minor", "patch"]
+      desktop-runtime-major:
+        patterns: ["*"]
+        update-types: ["major"]
 
   - package-ecosystem: docker
     directory: /backend


### PR DESCRIPTION
## Summary

Stops Dependabot from producing PRs that structurally cannot merge.

Every ecosystem was grouped `patterns: ["*"]` with no update-type split, so a single breaking major took the whole batch down with it — and dragged the routine security patches riding along into the same dead end:

- **#375 / #380** bundle `tailwindcss` 3→4 and `typescript` 5→7. Both fail `frontend-check`, which blocks the `axios` 1.18.1 and `react` 19.2.8 patches sitting in the same PR.
- **#369** bundled a torch bump that cannot resolve at all, stalling 20 other python updates behind it.

## What changed

**1. Majors split from minors/patches**, per ecosystem:

| Ecosystem | Minor/patch group | Major group |
| --- | --- | --- |
| github-actions | `actions` | `actions-major` |
| pip | `python-runtime` | `python-runtime-major` |
| npm | `frontend-runtime` | `frontend-runtime-major` |
| cargo | `desktop-runtime` | `desktop-runtime-major` |

The safe half now stays mergeable on its own, and each breaking upgrade arrives as its own reviewable PR.

**2. `torch` and `torchvision` moved to manual bumps.** They resolve from the pinned `pytorch-cpu` and `pytorch-cu128` indexes (`[tool.uv.sources]`), and cu128 lags PyPI. Dependabot reads PyPI, so in #369 it proposed torch **2.13.0** — a version cu128 does not publish — making `find-backend[nvidia]` unsatisfiable and failing `uv sync --locked` on all three runners.

Worth being explicit: that was a **minor** bump, so the major/minor split above would *not* have caught it. The ignore is doing real work here, not duplicating the split.

## Tradeoff you should know about

`ignore` suppresses Dependabot **security** update PRs for those two packages, not just version updates.

A future torch CVE will still raise an alert in the Security tab, but will **not** open a PR on its own — someone has to act on the alert by hand. I've accepted that here because a torch bump has to be hand-verified against the real ML stack regardless (`transformers`, `open-clip-torch`, `timm`, `ultralytics`, `insightface`), which is never something to merge unattended.

This is documented inline in the config so it isn't rediscovered the hard way. **#382 tracks the open torch advisories and the 2.11.0 evaluation — keep that issue alive as long as this ignore exists.** If you'd rather not take that tradeoff, say so and I'll drop the ignore; the cost is that torch PRs will keep failing `hardware-accel-matrix` until cu128 catches up to PyPI.

## Type of change

- [x] CI / tooling

## Release impact

- [x] No user-visible release note needed

## How to test

Config-only; nothing to run locally. Validated as parseable YAML with the expected group and ignore structure. Real verification is the next Monday run producing separate minor and major PRs per ecosystem, and no new torch PRs.

## Follow-ups

- #380 should be closed once this lands and Dependabot re-raises the frontend group split.
- #378 tracks the Tailwind v4 migration that #380's major half was trying to force.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated dependency update grouping by separating major updates from minor and patch updates.
  * Added guidance explaining dependency update batching.
  * Excluded selected machine-learning dependencies from automated updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->