### PR TITLE
chore(ci): move backend Dependabot to the uv ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,7 +32,14 @@ updates:
         patterns: ["*"]
         update-types: ["major"]
 
-  - package-ecosystem: pip
+  # `uv`, not `pip`. The pip ecosystem edits pyproject.toml and stops there --
+  # it has no idea uv.lock exists. backend-check runs `uv sync --locked`, so
+  # every pip-authored PR failed with "The lockfile at `uv.lock` needs to be
+  # updated" the moment it opened. #387 through #391 all died that way, and the
+  # backend pins have been frozen for months as a result (pgvector was still on
+  # 0.2.4, minio on 7.2.3). The uv ecosystem updates the manifest and the
+  # lockfile together, which is the only thing that can pass this repo's CI.
+  - package-ecosystem: uv
     directory: /backend
     target-branch: canary
     schedule:

--- a/.github/scripts/pr-context-triage.js
+++ b/.github/scripts/pr-context-triage.js
@@ -63,6 +63,20 @@ function parseClosingIssueRefs(text) {
   );
 }
 
+// Deliberate non-closing links. A PR that implements half of a tracking issue
+// has to say "Part of #N" rather than "Closes #N", or merging it auto-closes an
+// issue that is still open work -- so treating only closing keywords as "linked"
+// punished contributors for splitting their work correctly. Keyword-anchored
+// rather than reusing parseIssueRefs, which matches any bare #N and would let a
+// passing mention of an unrelated PR count as a link.
+function parseRelatedIssueRefs(text) {
+  return uniqueNumbers(
+    [...(text || "").matchAll(/\b(?:part of|related to|relates to|refs?|references|towards|toward|see)\b\s*:?\s*#(\d+)\b/gi)].map(
+      (match) => Number(match[1]),
+    ),
+  );
+}
+
 function tokenize(text) {
   return new Set(
     (text || "")
@@ -214,10 +228,15 @@ module.exports = async function run({ github, context, core }) {
   const comments = await listAllComments(github, repo, issueNumber);
 
   const closingIssueNumbers = parseClosingIssueRefs(pr.body || "");
+  const relatedIssueNumbers = parseRelatedIssueRefs(pr.body || "");
   const referencedIssueNumbers = parseIssueRefs([pr.title, pr.body].filter(Boolean).join("\n"));
   const nonClosingRefs = referencedIssueNumbers.filter(
     (number) => !closingIssueNumbers.includes(number),
   );
+  // Either kind of explicit link counts as linked. Only the closing set is used
+  // for assignee sync further down, since that acts on the issue the PR owns.
+  const hasLinkedIssue =
+    closingIssueNumbers.length > 0 || relatedIssueNumbers.length > 0;
 
   if (isDependabot) {
     await removeLabelIfPresent(
@@ -227,7 +246,7 @@ module.exports = async function run({ github, context, core }) {
       labelSet,
       "needs linked issue",
     );
-  } else if (closingIssueNumbers.length === 0) {
+  } else if (!hasLinkedIssue) {
     await addLabelIfMissing(
       github,
       repo,
@@ -292,9 +311,16 @@ module.exports = async function run({ github, context, core }) {
     triggerMacroscope && !hasHardBlockLabel && hasReviewLabel && (!hasTriggerComment || forceReview);
 
   if (shouldTriggerReview) {
+    // Hand the reviewer both kinds of link. A "Part of #N" PR is still meant to
+    // be judged against #N, so reporting "none linked yet" sent the review off
+    // without the one issue that defines the acceptance criteria.
+    const allLinkedIssues = uniqueNumbers([
+      ...closingIssueNumbers,
+      ...relatedIssueNumbers,
+    ]);
     const linkedIssuesText =
-      closingIssueNumbers.length > 0
-        ? closingIssueNumbers.map((number) => `#${number}`).join(", ")
+      allLinkedIssues.length > 0
+        ? allLinkedIssues.map((number) => `#${number}`).join(", ")
         : "none linked yet";
     const sourceLabelText = [...ELIGIBLE_REVIEW_LABELS].filter((label) => labelSet.has(label)).join(", ");
     const triggerBody = [


### PR DESCRIPTION
Part of the maintenance sweep on the current Dependabot batch.

## Why

Every pip-authored PR against `/backend` has been dead on arrival. The `pip` ecosystem edits `pyproject.toml` and stops there — it has no idea `uv.lock` exists. `backend-check` runs `uv sync --locked`, so each one failed with:

```
error: The lockfile at `uv.lock` needs to be updated, but `--locked` was provided.
```

That took out #387, #388, #389, #390 and #391 in a single batch, and it isn't new. The backend pins have been frozen behind it long enough that `pgvector` is still on **0.2.4** (current 0.5.0) and `minio` on **7.2.3** (current 7.2.20). The major/minor split from #384 couldn't help here — the failure has nothing to do with *which* versions were proposed.

The `uv` ecosystem updates the manifest and the lockfile in the same commit, which is the only shape that passes this repo's CI. The `torch`/`torchvision` ignore and the group split carry over unchanged.

## Also in here

The linked-issue check in `pr-context-triage.js` only counted closing keywords. A PR implementing half of a tracking issue has to write `Part of #N` instead of `Closes #N`, or merging it auto-closes work that's still open — so the rule was punishing contributors for splitting their work correctly. It mislabelled #367 as `needs linked issue` when that PR linked #354 deliberately.

Non-closing links now count, matched off explicit keywords (`Part of`, `Related to`, `Refs`, `Towards`, `See`) rather than any bare `#N` — so a passing mention of an unrelated PR still doesn't qualify. The Macroscope trigger comment reports both kinds now too, since a `Part of` issue holds the acceptance criteria the review is judged against.

## Verification

- `.github/dependabot.yml` parses.
- `node --check` on the triage script.
- Parser exercised against 10 cases including #367's verbatim body — `Part of #354` now resolves to `related=[354]`, and "I rebased on top of #377" still resolves to nothing.

## Follow-up

The five open pip PRs get closed once this lands; Dependabot will reopen them against the `uv` ecosystem with the lockfile included.