### PR TITLE
chore(ci): split linters out of the Dependabot runtime groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -48,11 +48,22 @@ updates:
       time: "05:00"
       timezone: Asia/Kolkata
     groups:
+      # Linters and formatters get their own group, ahead of the runtime ones
+      # so they win the pattern match. They are pinned exactly and they rewrite
+      # the tree, so a bump is never a routine dependency update: ruff 0.1.14 ->
+      # 0.16 in #401 produced 801 `ruff check` errors and took 20 unrelated
+      # patches down with it. Being 0.x, that is a *minor* bump as far as
+      # Dependabot is concerned, so the major/minor split alone cannot separate
+      # them. Reviewing a formatter upgrade on its own is the point.
+      python-tooling:
+        patterns: ["ruff", "black"]
       python-runtime:
         patterns: ["*"]
+        exclude-patterns: ["ruff", "black"]
         update-types: ["minor", "patch"]
       python-runtime-major:
         patterns: ["*"]
+        exclude-patterns: ["ruff", "black"]
         update-types: ["major"]
     # torch/torchvision resolve from the pinned pytorch-cpu and pytorch-cu128
     # indexes (see [tool.uv.sources] in backend/pyproject.toml), and cu128 lags
@@ -69,9 +80,19 @@ updates:
     # the real ML stack regardless (transformers, open-clip-torch, timm,
     # ultralytics, insightface). #382 tracks the current open torch advisories
     # and the 2.11.0 evaluation; keep that issue alive while this ignore exists.
+    #
+    # insightface is ignored for the same shape of reason, not a resolution
+    # one. It is only installed by the cpu/nvidia extras, so `uv sync --group
+    # dev` never pulls it and no CI job imports it -- a bump is green on a
+    # checkmark that never executed a line of it. On top of that, ml/
+    # face_detector.py already carries an AssertionError retry for antelopev2's
+    # nested model layout, so the thing most likely to break across a major is
+    # exactly the thing nothing here can see. #404 tracks evaluating 1.0.1 by
+    # hand against real model weights.
     ignore:
       - dependency-name: torch
       - dependency-name: torchvision
+      - dependency-name: insightface
 
   - package-ecosystem: npm
     directory: /frontend
@@ -82,11 +103,20 @@ updates:
       time: "05:30"
       timezone: Asia/Kolkata
     groups:
+      # Same reasoning as python-tooling above. Biome is the formatter and the
+      # linter behind `pnpm check`, so its rules moving is a tree-wide rewrite,
+      # not a dependency update: 2.4.15 -> 2.5.5 in #399 failed frontend-check
+      # with 5 errors on files nobody touched, and took an axios patch down
+      # with it.
+      frontend-tooling:
+        patterns: ["@biomejs/biome"]
       frontend-runtime:
         patterns: ["*"]
+        exclude-patterns: ["@biomejs/biome"]
         update-types: ["minor", "patch"]
       frontend-runtime-major:
         patterns: ["*"]
+        exclude-patterns: ["@biomejs/biome"]
         update-types: ["major"]
 
   - package-ecosystem: cargo

--- a/backend/src/find_api/core/model_manager.py
+++ b/backend/src/find_api/core/model_manager.py
@@ -342,7 +342,10 @@ class ModelManager:
 
             redis_conn = Redis.from_url(settings.REDIS_URL)
             key = f"find:model_status:{self.process_name}"
-            redis_conn.setex(key, 600, json.dumps(self.get_status()))
+            # set(ex=) rather than setex(): redis-py deprecated setex in 2.6.12
+            # and started emitting the warning on every call from 8.x, which is
+            # once per publish. Identical semantics, 600s TTL.
+            redis_conn.set(key, json.dumps(self.get_status()), ex=600)
         except Exception as exc:
             logger.debug("Failed to publish model manager status: %s", exc)
 


### PR DESCRIPTION
Follow-on from #395, from reviewing the first batch Dependabot opened against the `uv` ecosystem.

## Linters don't belong in the runtime groups

They're pinned exactly and they rewrite the tree, so a bump is never a routine dependency update. Grouped with everything else, one takes the whole batch down:

| PR | Bump | Result |
| --- | --- | --- |
| #401 | ruff 0.1.14 → 0.16 | **801** `ruff check` errors; blocked 20 unrelated patches |
| #399 | @biomejs/biome 2.4.15 → 2.5.5 | `pnpm check` fails with 5 errors on untouched files; blocked an axios patch |

The collateral matters: #401 was carrying `pgvector` 0.2.4 → 0.5.0 and `minio` 7.2.3 → 7.2.20, both stuck for months behind the pip/uv problem #395 just fixed — and now stuck again behind a formatter.

**The major/minor split from #384 can't catch this.** ruff is 0.x, so 0.1.14 → 0.16.0 is a *minor* bump as far as Dependabot is concerned, even though it's by far the most disruptive change in the batch. Matching on package name is the only thing that separates them.

After this, a formatter upgrade arrives as its own PR — which is what you want, because it's a real piece of work (801 findings is a day, not a merge button), and it stops holding security patches hostage in the meantime.

## insightface ignored

Same shape as the `torch` ignore, different mechanism. `insightface` is only installed by the `cpu`/`nvidia` extras; `backend-check` runs `uv sync --group dev` and no job imports it. #402 proposed 0.7.3 → **1.0.1** and went green on a checkmark that never executed a line of the package.

`ml/face_detector.py` already carries this:

```python
try:
    app = FaceAnalysis(name="antelopev2", providers=providers)
except AssertionError:
    app = FaceAnalysis(name="antelopev2/antelopev2", providers=providers)
```

Model packaging is exactly what a 1.0 release cleans up, so the most likely breakage is the one thing CI can't observe. #404 tracks the manual evaluation — including whether the embedding dimensionality moved, which decides whether that's a bump or a migration of every stored face vector.

**Same tradeoff as torch, stated plainly:** `ignore` also suppresses security PRs. Advisories still raise alerts; nobody gets a PR for free. Accepted because a bump needs hand-verification against real weights either way.

## setex → set(ex=)

redis-py deprecated `setex` in 2.6.12 and 8.x emits the warning on every call. Measured under the redis 5 → 8 bump in #402: **55 of the suite's 56 warnings** came from this single line in `publish_status()`. Identical semantics, same 600s TTL. Doing it now so the redis 8 bump lands clean rather than noisy.

## Verification

- `dependabot.yml` parses; group and ignore lists confirmed per ecosystem.
- `ruff check` + `ruff format --check` clean.
- Model-manager tests pass (13).
- The redis-8 warning count was measured by running the full suite on #402's lockfile, not inferred.

## Follow-up on the open batch

- #403 (uvicorn) — verified and merged.
- #402 — needs a rebase regardless; it currently reverts #403's uvicorn bump. Will re-open without insightface once this lands.
- #401 / #399 — will regenerate without the formatter, and should then be mergeable.
- #400, #398 — closing; see comments there.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of model processing status updates while preserving automatic expiration of stale statuses.

- **Chores**
  - Refined dependency update management to separate runtime and development-tooling updates.
  - Added clearer handling for selected machine-learning and frontend tooling packages, helping keep routine updates more focused and predictable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->