### PR TITLE
fix(ml): serialize embed_text output as native floats

### DIFF
--- a/backend/src/find_api/routers/ml.py
+++ b/backend/src/find_api/routers/ml.py
@@ -206,6 +206,11 @@ def embed_text(body: Dict[str, Any]) -> Dict[str, Any]:
             detail="Text embedding failed on the remote server.",
         ) from exc
 
+    # embed_text() returns an np.ndarray. list() on that yields np.float32
+    # elements, which the JSON encoder cannot serialize -- a 500 on every
+    # remote search. tolist() converts to native floats.
+    if hasattr(embedding, "tolist"):
+        embedding = embedding.tolist()
     return {"embedding": list(embedding)}
 
 

--- a/backend/tests/test_remote_ml_router.py
+++ b/backend/tests/test_remote_ml_router.py
@@ -8,6 +8,7 @@ import types
 from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
+import numpy as np
 import pytest
 from fastapi.testclient import TestClient
 from PIL import Image
@@ -31,6 +32,11 @@ def client_with_key(monkeypatch):
     mock_settings.MIN_SAMPLES = 1
     # The cluster fixtures below use 2-d toy vectors, not real 768-d ones.
     mock_settings.EMBEDDING_DIM = 2
+    # Clustering goes through ImageClusterer, which reads these. A bare
+    # MagicMock reaches HDBSCAN as an invalid n_jobs and 500s.
+    mock_settings.CLUSTERING_N_JOBS = 1
+    mock_settings.CLUSTERING_BACKEND = "sklearn"
+    mock_settings.USE_GPU = False
     monkeypatch.setattr(cfg_module, "settings", mock_settings)
 
     import find_api.routers.ml as ml_mod
@@ -56,6 +62,11 @@ def client_no_key(monkeypatch):
     mock_settings.MIN_SAMPLES = 1
     # The cluster fixtures below use 2-d toy vectors, not real 768-d ones.
     mock_settings.EMBEDDING_DIM = 2
+    # Clustering goes through ImageClusterer, which reads these. A bare
+    # MagicMock reaches HDBSCAN as an invalid n_jobs and 500s.
+    mock_settings.CLUSTERING_N_JOBS = 1
+    mock_settings.CLUSTERING_BACKEND = "sklearn"
+    mock_settings.USE_GPU = False
     monkeypatch.setattr(cfg_module, "settings", mock_settings)
 
     import find_api.routers.ml as ml_mod
@@ -195,7 +206,10 @@ class TestEmbedTextEndpoint:
 
     def test_embed_text_returns_embedding(self, client_with_key):
         fake = MagicMock()
-        fake.embed_text.return_value = [0.5] * 768
+        # An ndarray, matching CLIPEmbedder.embed_text. Returning a plain list
+        # here hid a real bug: list(ndarray) yields np.float32 elements that
+        # the JSON encoder rejects, so every remote search 500'd.
+        fake.embed_text.return_value = np.zeros(768, dtype=np.float32)
 
         # clip_embedder pulls in torch, which the mock test env does not ship,
         # so stub the whole module rather than patching an attribute on it.


### PR DESCRIPTION
Follow-up to #365.

`CLIPEmbedder.embed_text` returns an `np.ndarray`. `list()` on that yields `np.float32` elements, which the JSON encoder rejects — so `/api/ml/embed_text` raised on serialization and **every search from a remote-mode instance returned 500**.

```python
>>> list(np.zeros(4, dtype=np.float32))[0]
np.float32(0.0)
>>> json.dumps({"embedding": list(np.zeros(4, dtype=np.float32))})
TypeError: Object of type float32 is not JSON serializable
```

`/api/ml/embed` was already fine — `generate_hybrid_embedding` ends in `.tolist()`. Only the new text path was affected.

This was raised in review on #365, but the fix landed after that PR was squash-merged, so it goes in separately.

## Why the original test missed it

The fake returned a plain Python list, which is not what the real embedder returns. It now returns an `ndarray`, so the assertion actually exercises serialization. Verified by reverting the fix and confirming the test fails.

## Also here

`/api/ml/cluster` now routes through `ImageClusterer`, which reads `CLUSTERING_N_JOBS` / `CLUSTERING_BACKEND` / `USE_GPU`. The router fixtures are `MagicMock`, so `n_jobs` reached HDBSCAN as a mock and raised `InvalidParameterError`. It only surfaced when `clusterer` imported *after* the fixture patch, making the test order-dependent rather than reliably failing — pinned in the fixtures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NqgDVkzDhi97MGsVQhAjyB