### PR TITLE
feat(settings): add an About card, and finish the open a11y gaps

### DIFF
--- a/backend/src/find_api/routers/config.py
+++ b/backend/src/find_api/routers/config.py
@@ -8,6 +8,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
+from find_api import __version__
 from find_api.core.config import settings
 from find_api.core.database import get_db
 from find_api.core.dependencies import get_admin_user, get_required_user
@@ -69,6 +70,7 @@ def get_app_config(db: Session = Depends(get_db)):
 
     runtime = _runtime_resolution(db)
     return {
+        "app_version": __version__,
         "ml_mode": runtime.applied_mode,
         "configured_ml_mode": runtime.configured_mode,
         "accel_mode": runtime.configured_accel_mode,

--- a/backend/tests/test_settings.py
+++ b/backend/tests/test_settings.py
@@ -13,8 +13,10 @@ from find_api.core.config import settings
 class TestAppConfigVersion:
     """/api/config carries the backend package version (#355).
 
-    The Settings > About card and the sidebar footer both read it from here, so
-    neither has to hard-code a value that silently goes stale on release.
+    Settings > About reads it from here rather than hard-coding a value. Note
+    that the sidebar footer deliberately does NOT: scripts/bump_version.py
+    rewrites that literal on release and CI fails if it drifts, so it stays a
+    release-managed string.
     """
 
     def test_reports_the_package_version(self, client):

--- a/backend/tests/test_settings.py
+++ b/backend/tests/test_settings.py
@@ -6,7 +6,38 @@ hardware report reflects the persisted accel-mode preference once set.
 
 from unittest.mock import patch
 
+from find_api import __version__
 from find_api.core.config import settings
+
+
+class TestAppConfigVersion:
+    """/api/config carries the backend package version (#355).
+
+    The Settings > About card and the sidebar footer both read it from here, so
+    neither has to hard-code a value that silently goes stale on release.
+    """
+
+    def test_reports_the_package_version(self, client):
+        assert client.get("/api/config").json()["app_version"] == __version__
+
+    def test_version_is_not_placeholder(self, client):
+        version = client.get("/api/config").json()["app_version"]
+        assert isinstance(version, str)
+        assert version.strip()
+        assert version not in {"unknown", "0.0.0"}
+
+    def test_config_stays_free_of_secrets_and_paths(self, client):
+        """The card copies this payload's fields into a support summary."""
+        body = client.get("/api/config").json()
+        forbidden = {
+            "database_url",
+            "secret_key",
+            "minio_access_key",
+            "minio_secret_key",
+            "media_root",
+            "storage_path",
+        }
+        assert forbidden.isdisjoint(body.keys())
 
 
 class TestSettingsLocalMode:

--- a/frontend/e2e/nav-accessibility.spec.ts
+++ b/frontend/e2e/nav-accessibility.spec.ts
@@ -1,0 +1,212 @@
+import { expect, test } from "@playwright/test";
+
+/**
+ * Navigation accessibility E2E (#346).
+ *
+ * jsdom cannot prove either half of this issue: it has no CSS layout, so it
+ * cannot show whether the desktop nav is clipped at a given width, and it has
+ * no real focus order. Both live here instead, and like the other specs in this
+ * directory they need no backend -- the shell and nav render even when every
+ * API call fails.
+ */
+
+const THEMES = ["dark", "light"] as const;
+
+const NAV_LABELS = [
+  "Photos",
+  "Search",
+  "Map",
+  "People",
+  "Albums",
+  "Favorites",
+  "Duplicates",
+  "Clusters",
+  "Archive",
+  "Vault",
+  "Trash",
+  "Activity",
+  "Settings",
+] as const;
+
+const DRAWER = "[data-mobile-drawer]";
+
+async function applyTheme(
+  page: import("@playwright/test").Page,
+  theme: string,
+) {
+  await page.evaluate((t) => {
+    document.documentElement.classList.remove("light", "dark");
+    document.documentElement.classList.add(t);
+    document.documentElement.dataset.theme = t;
+  }, theme);
+}
+
+test.describe("desktop navigation is reachable, not clipped", () => {
+  // The issue called out the lg breakpoint specifically.
+  for (const width of [1024, 1280, 1440]) {
+    for (const theme of THEMES) {
+      test(`every link is fully inside the viewport at ${width}px (${theme})`, async ({
+        page,
+      }) => {
+        await page.setViewportSize({ width, height: 900 });
+        await page.goto("/timeline");
+        await applyTheme(page, theme);
+
+        const nav = page.getByRole("navigation", { name: "Main navigation" });
+        await expect(nav).toBeVisible();
+
+        for (const label of NAV_LABELS) {
+          const link = nav.getByRole("link", { name: label, exact: true });
+          await expect(link).toBeVisible();
+
+          const box = await link.boundingBox();
+          expect(box, `${label} has no layout box`).not.toBeNull();
+          if (!box) continue;
+
+          // Rendered with real size and not cut off on either edge.
+          expect(box.width, `${label} collapsed`).toBeGreaterThan(0);
+          expect(box.height, `${label} collapsed`).toBeGreaterThan(0);
+          expect(
+            box.x,
+            `${label} clipped at the left edge`,
+          ).toBeGreaterThanOrEqual(0);
+          expect(
+            box.x + box.width,
+            `${label} clipped at the right edge`,
+          ).toBeLessThanOrEqual(width + 0.5);
+        }
+      });
+    }
+  }
+});
+
+test.describe("mobile drawer behaves as an accessible modal", () => {
+  for (const theme of THEMES) {
+    test(`traps focus and restores the trigger (${theme})`, async ({
+      page,
+    }) => {
+      await page.setViewportSize({ width: 390, height: 844 });
+      await page.goto("/timeline");
+      await applyTheme(page, theme);
+
+      const trigger = page.getByRole("button", {
+        name: "Open navigation menu",
+      });
+      await expect(trigger).toBeVisible();
+      await expect(trigger).toHaveAttribute("aria-expanded", "false");
+
+      await trigger.click();
+
+      const drawer = page.getByRole("dialog", { name: "Navigation menu" });
+      await expect(drawer).toBeVisible();
+      await expect(drawer).toHaveAttribute("aria-modal", "true");
+
+      // Background is inert while the drawer owns the viewport. Being absent
+      // from the accessibility tree entirely is the assertion that matters --
+      // getByRole cannot see an aria-hidden landmark, which is the point.
+      await expect(page.getByRole("banner")).toHaveCount(0);
+      await expect(page.locator("header").first()).toHaveAttribute(
+        "aria-hidden",
+        "true",
+      );
+      await expect(
+        page.evaluate(() => getComputedStyle(document.body).overflow),
+      ).resolves.toBe("hidden");
+
+      // Focus starts inside.
+      await expect(
+        page.evaluate(
+          (sel) =>
+            !!document.querySelector(sel)?.contains(document.activeElement),
+          DRAWER,
+        ),
+      ).resolves.toBe(true);
+
+      // A full lap of tabbing never escapes.
+      for (let i = 0; i < NAV_LABELS.length + 6; i += 1) {
+        await page.keyboard.press("Tab");
+        const inside = await page.evaluate(
+          (sel) =>
+            !!document.querySelector(sel)?.contains(document.activeElement),
+          DRAWER,
+        );
+        expect(inside, `focus escaped on tab ${i + 1}`).toBe(true);
+      }
+
+      // Shift+Tab wraps backwards without escaping either.
+      for (let i = 0; i < 4; i += 1) {
+        await page.keyboard.press("Shift+Tab");
+        const inside = await page.evaluate(
+          (sel) =>
+            !!document.querySelector(sel)?.contains(document.activeElement),
+          DRAWER,
+        );
+        expect(inside, `focus escaped on shift+tab ${i + 1}`).toBe(true);
+      }
+
+      await page.keyboard.press("Escape");
+
+      await expect(drawer).toBeHidden();
+      await expect(
+        page.evaluate(() => document.body.style.overflow),
+      ).resolves.toBe("");
+      await expect(trigger).toBeFocused();
+      // The shell is handed back to assistive tech once the drawer closes.
+      await expect(page.getByRole("banner")).toHaveCount(1);
+    });
+
+    test(`drawer text stays readable in ${theme} mode`, async ({ page }) => {
+      await page.setViewportSize({ width: 390, height: 844 });
+      await page.goto("/timeline");
+      await applyTheme(page, theme);
+
+      await page.getByRole("button", { name: "Open navigation menu" }).click();
+      await expect(
+        page.getByRole("dialog", { name: "Navigation menu" }),
+      ).toBeVisible();
+
+      // Every colour resolves through CSS custom properties, so a theme/palette
+      // mismatch shows up as a label painted in its own effective background.
+      // The active link supplies its own background, so each label has to be
+      // compared against the nearest painted ancestor rather than the drawer.
+      const samples = await page.evaluate((sel) => {
+        const drawer = document.querySelector(sel) as HTMLElement;
+
+        const paintedBackground = (node: HTMLElement): string => {
+          let current: HTMLElement | null = node;
+          while (current) {
+            const bg = getComputedStyle(current).backgroundColor;
+            if (
+              bg &&
+              bg !== "transparent" &&
+              !bg.startsWith("rgba(0, 0, 0, 0")
+            ) {
+              return bg;
+            }
+            current = current.parentElement;
+          }
+          return "rgb(255, 255, 255)";
+        };
+
+        return Array.from(drawer.querySelectorAll("a")).map((link) => {
+          const label = link.querySelector("span") as HTMLElement;
+          return {
+            text: label.textContent ?? "",
+            fg: getComputedStyle(label).color,
+            bg: paintedBackground(label),
+          };
+        });
+      }, DRAWER);
+
+      expect(samples.length).toBeGreaterThan(0);
+      for (const { text, fg, bg } of samples) {
+        expect(fg, `${text} is invisible against its own background`).not.toBe(
+          bg,
+        );
+        expect(fg, `${text} has fully transparent text`).not.toBe(
+          "rgba(0, 0, 0, 0)",
+        );
+      }
+    });
+  }
+});

--- a/frontend/src/__tests__/about-settings.test.tsx
+++ b/frontend/src/__tests__/about-settings.test.tsx
@@ -1,0 +1,159 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import type { ReactElement } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AboutSettings } from "@/components/about-settings";
+
+const api = vi.hoisted(() => ({
+  getAppConfig: vi.fn(),
+  getRuntimeConfig: vi.fn(),
+}));
+
+vi.mock("@/lib/api", () => api);
+
+function renderWithClient(ui: ReactElement) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>{ui}</QueryClientProvider>,
+  );
+}
+
+const appConfig = {
+  app_version: "1.1.3",
+  ml_mode: "mock",
+  configured_ml_mode: "mock",
+  accel_mode: "cpu",
+  ai_enabled: true,
+  map_enabled: false,
+  build_profile: "mock",
+  supported_ml_modes: ["disabled", "mock"],
+};
+
+const runtimeConfig = {
+  build_profile: "mock",
+  supported_modes: ["disabled", "mock"],
+  configured_mode: "mock",
+  configured_accel_mode: "cpu",
+  ai_enabled: true,
+  map_enabled: false,
+  applied_mode: "mock",
+  installed_features: [],
+  restart_required: false,
+  unavailable_reason: null,
+  worker: { health: { state: "healthy", age_seconds: 8 }, applied: null },
+};
+
+function mockClipboard(writeText: ReturnType<typeof vi.fn>) {
+  Object.defineProperty(navigator, "clipboard", {
+    value: { writeText },
+    configurable: true,
+    writable: true,
+  });
+}
+
+beforeEach(() => {
+  api.getAppConfig.mockReset();
+  api.getRuntimeConfig.mockReset();
+  api.getAppConfig.mockResolvedValue(appConfig);
+  api.getRuntimeConfig.mockResolvedValue(runtimeConfig);
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("AboutSettings", () => {
+  it("renders the version, build profile, applied AI mode, and worker health", async () => {
+    renderWithClient(<AboutSettings />);
+
+    expect(
+      await screen.findByRole("heading", { name: "About this instance" }),
+    ).toBeInTheDocument();
+
+    const details = screen.getByTestId("about-details");
+    await waitFor(() => expect(details).toHaveTextContent("1.1.3"));
+    expect(details).toHaveTextContent("mock");
+    await waitFor(() => expect(details).toHaveTextContent("Healthy"));
+    expect(details).toHaveTextContent("last seen 8s ago");
+  });
+
+  it("notes when AI is switched off", async () => {
+    api.getAppConfig.mockResolvedValue({ ...appConfig, ai_enabled: false });
+    renderWithClient(<AboutSettings />);
+
+    await waitFor(() =>
+      expect(screen.getByTestId("about-details")).toHaveTextContent("(AI off)"),
+    );
+  });
+
+  it("copies the support summary and reports success", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    mockClipboard(writeText);
+    renderWithClient(<AboutSettings />);
+
+    await waitFor(() =>
+      expect(screen.getByTestId("about-details")).toHaveTextContent("1.1.3"),
+    );
+    fireEvent.click(screen.getByTestId("copy-support-summary"));
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledTimes(1));
+    const copied = writeText.mock.calls[0]?.[0] as string;
+    expect(copied).toContain("App version: 1.1.3");
+    expect(copied).toContain("Worker: healthy, last seen 8s ago");
+
+    await waitFor(() =>
+      expect(screen.getByTestId("copy-status")).toHaveTextContent(
+        "Support summary copied.",
+      ),
+    );
+  });
+
+  it("explains the fallback when the clipboard is unavailable", async () => {
+    const writeText = vi.fn().mockRejectedValue(new Error("denied"));
+    mockClipboard(writeText);
+    renderWithClient(<AboutSettings />);
+
+    fireEvent.click(screen.getByTestId("copy-support-summary"));
+
+    await waitFor(() =>
+      expect(screen.getByTestId("copy-status")).toHaveTextContent(
+        "Couldn't copy. Select the details above and copy manually.",
+      ),
+    );
+  });
+
+  it("surfaces an alert when the version cannot be read", async () => {
+    api.getAppConfig.mockRejectedValue(new Error("offline"));
+    renderWithClient(<AboutSettings />);
+
+    expect(await screen.findByTestId("about-error")).toHaveTextContent(
+      "Couldn't read the instance version.",
+    );
+    expect(screen.queryByTestId("about-details")).not.toBeInTheDocument();
+  });
+
+  it("still copies a summary when the worker state is unknown", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    mockClipboard(writeText);
+    api.getRuntimeConfig.mockRejectedValue(new Error("offline"));
+    renderWithClient(<AboutSettings />);
+
+    await waitFor(() =>
+      expect(screen.getByTestId("about-details")).toHaveTextContent("1.1.3"),
+    );
+    fireEvent.click(screen.getByTestId("copy-support-summary"));
+
+    await waitFor(() => expect(writeText).toHaveBeenCalled());
+    expect(writeText.mock.calls[0]?.[0]).toContain(
+      "Worker: unknown, last seen unknown",
+    );
+  });
+});

--- a/frontend/src/__tests__/app-shell.test.tsx
+++ b/frontend/src/__tests__/app-shell.test.tsx
@@ -1,13 +1,10 @@
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   cleanup,
   fireEvent,
   render,
   screen,
-  waitFor,
   within,
 } from "@testing-library/react";
-import type { ReactElement } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { AppShell } from "@/components/app-shell";
 
@@ -21,40 +18,9 @@ vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: navigation.push }),
 }));
 
-const api = vi.hoisted(() => ({
-  getAppConfig: vi.fn(),
-}));
-
-// Partial mock: the shell also mounts UniversalSearch, which pulls other
-// exports off this module, so only getAppConfig is replaced.
-vi.mock("@/lib/api", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("@/lib/api")>()),
-  getAppConfig: api.getAppConfig,
-}));
-
-function renderShell(ui: ReactElement) {
-  const client = new QueryClient({
-    defaultOptions: { queries: { retry: false } },
-  });
-  return render(
-    <QueryClientProvider client={client}>{ui}</QueryClientProvider>,
-  );
-}
-
 beforeEach(() => {
   navigation.pathname = "/timeline";
   navigation.push.mockReset();
-  api.getAppConfig.mockReset();
-  api.getAppConfig.mockResolvedValue({
-    app_version: "9.9.9",
-    ml_mode: "mock",
-    configured_ml_mode: "mock",
-    accel_mode: "cpu",
-    ai_enabled: true,
-    map_enabled: false,
-    build_profile: "mock",
-    supported_ml_modes: ["disabled", "mock"],
-  });
   localStorage.clear();
 });
 
@@ -68,7 +34,7 @@ afterEach(() => {
 
 describe("AppShell", () => {
   it("renders the private route groups and top-bar actions", () => {
-    renderShell(
+    render(
       <AppShell>
         <div>Timeline content</div>
       </AppShell>,
@@ -127,7 +93,7 @@ describe("AppShell", () => {
     "/auth/setup",
   ])("does not expose private chrome on %s", (pathname) => {
     navigation.pathname = pathname;
-    renderShell(
+    render(
       <AppShell>
         <div>Shell-free content</div>
       </AppShell>,
@@ -141,7 +107,7 @@ describe("AppShell", () => {
   });
 
   it("opens an accessible mobile drawer and closes it with Escape", () => {
-    renderShell(
+    render(
       <AppShell>
         <div>Content</div>
       </AppShell>,
@@ -163,7 +129,7 @@ describe("AppShell", () => {
   });
 
   it("locks page scroll, traps focus, and restores the menu trigger", () => {
-    renderShell(
+    render(
       <AppShell>
         <div>Content</div>
       </AppShell>,
@@ -200,7 +166,7 @@ describe("AppShell", () => {
   });
 
   it("opens Search from the global keyboard shortcut", () => {
-    renderShell(
+    render(
       <AppShell>
         <div>Content</div>
       </AppShell>,
@@ -220,7 +186,7 @@ describe("AppShell", () => {
     document.documentElement.classList.add(theme);
     document.documentElement.dataset.theme = theme;
 
-    renderShell(
+    render(
       <AppShell>
         <div>Content</div>
       </AppShell>,
@@ -255,34 +221,15 @@ describe("AppShell", () => {
     expect(trigger).toHaveFocus();
   });
 
-  it("shows the backend-reported version in the sidebar footer", async () => {
-    renderShell(
+  it("keeps the release-managed sidebar version visible", () => {
+    render(
       <AppShell>
         <div>Content</div>
       </AppShell>,
     );
 
-    await waitFor(() =>
-      expect(screen.getByTestId("sidebar-app-version")).toHaveTextContent(
-        "v9.9.9",
-      ),
-    );
-  });
-
-  it("leaves the sidebar version blank when the config request fails", async () => {
-    api.getAppConfig.mockRejectedValue(new Error("offline"));
-    renderShell(
-      <AppShell>
-        <div>Content</div>
-      </AppShell>,
-    );
-
-    // Wait for the request to actually settle before asserting the absence,
-    // otherwise this passes on the pre-fetch render and proves nothing.
-    await waitFor(() => expect(api.getAppConfig).toHaveBeenCalled());
-    await waitFor(() =>
-      expect(screen.getByTestId("sidebar-app-version")).toHaveTextContent(""),
-    );
-    expect(screen.getByTestId("sidebar-app-version").textContent).toBe("");
+    // scripts/bump_version.py rewrites this string on release and CI fails if
+    // it drifts, so it is asserted rather than fetched.
+    expect(screen.getByText(/^v\d+\.\d+\.\d+$/)).toBeInTheDocument();
   });
 });

--- a/frontend/src/__tests__/app-shell.test.tsx
+++ b/frontend/src/__tests__/app-shell.test.tsx
@@ -1,10 +1,13 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   cleanup,
   fireEvent,
   render,
   screen,
+  waitFor,
   within,
 } from "@testing-library/react";
+import type { ReactElement } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { AppShell } from "@/components/app-shell";
 
@@ -18,9 +21,40 @@ vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: navigation.push }),
 }));
 
+const api = vi.hoisted(() => ({
+  getAppConfig: vi.fn(),
+}));
+
+// Partial mock: the shell also mounts UniversalSearch, which pulls other
+// exports off this module, so only getAppConfig is replaced.
+vi.mock("@/lib/api", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/api")>()),
+  getAppConfig: api.getAppConfig,
+}));
+
+function renderShell(ui: ReactElement) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>{ui}</QueryClientProvider>,
+  );
+}
+
 beforeEach(() => {
   navigation.pathname = "/timeline";
   navigation.push.mockReset();
+  api.getAppConfig.mockReset();
+  api.getAppConfig.mockResolvedValue({
+    app_version: "9.9.9",
+    ml_mode: "mock",
+    configured_ml_mode: "mock",
+    accel_mode: "cpu",
+    ai_enabled: true,
+    map_enabled: false,
+    build_profile: "mock",
+    supported_ml_modes: ["disabled", "mock"],
+  });
   localStorage.clear();
 });
 
@@ -34,7 +68,7 @@ afterEach(() => {
 
 describe("AppShell", () => {
   it("renders the private route groups and top-bar actions", () => {
-    render(
+    renderShell(
       <AppShell>
         <div>Timeline content</div>
       </AppShell>,
@@ -93,7 +127,7 @@ describe("AppShell", () => {
     "/auth/setup",
   ])("does not expose private chrome on %s", (pathname) => {
     navigation.pathname = pathname;
-    render(
+    renderShell(
       <AppShell>
         <div>Shell-free content</div>
       </AppShell>,
@@ -107,7 +141,7 @@ describe("AppShell", () => {
   });
 
   it("opens an accessible mobile drawer and closes it with Escape", () => {
-    render(
+    renderShell(
       <AppShell>
         <div>Content</div>
       </AppShell>,
@@ -129,7 +163,7 @@ describe("AppShell", () => {
   });
 
   it("locks page scroll, traps focus, and restores the menu trigger", () => {
-    render(
+    renderShell(
       <AppShell>
         <div>Content</div>
       </AppShell>,
@@ -166,7 +200,7 @@ describe("AppShell", () => {
   });
 
   it("opens Search from the global keyboard shortcut", () => {
-    render(
+    renderShell(
       <AppShell>
         <div>Content</div>
       </AppShell>,
@@ -174,5 +208,81 @@ describe("AppShell", () => {
 
     fireEvent.keyDown(window, { key: "/" });
     expect(navigation.push).toHaveBeenCalledWith("/search");
+  });
+
+  // #346 asked for the drawer keyboard path to be exercised in both themes.
+  // The theme is a class on <html> that swaps CSS custom properties, so the
+  // same assertions must hold under either one.
+  it.each([
+    "light",
+    "dark",
+  ])("keeps the drawer keyboard contract in %s mode", (theme) => {
+    document.documentElement.classList.add(theme);
+    document.documentElement.dataset.theme = theme;
+
+    renderShell(
+      <AppShell>
+        <div>Content</div>
+      </AppShell>,
+    );
+
+    const trigger = screen.getByRole("button", {
+      name: "Open navigation menu",
+    });
+    fireEvent.click(trigger);
+
+    const drawer = screen.getByRole("dialog", { name: "Navigation menu" });
+    expect(drawer).toHaveAttribute("aria-modal", "true");
+    expect(drawer).toHaveAttribute("aria-hidden", "false");
+    expect(document.body.style.overflow).toBe("hidden");
+
+    const focusable = Array.from(
+      drawer.querySelectorAll<HTMLElement>(
+        'a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])',
+      ),
+    );
+    expect(focusable.at(0)).toHaveFocus();
+
+    // Background chrome is inert while the drawer owns the viewport.
+    expect(screen.getByRole("banner", { hidden: true })).toHaveAttribute(
+      "aria-hidden",
+      "true",
+    );
+
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(drawer).toHaveAttribute("aria-hidden", "true");
+    expect(document.body.style.overflow).toBe("");
+    expect(trigger).toHaveFocus();
+  });
+
+  it("shows the backend-reported version in the sidebar footer", async () => {
+    renderShell(
+      <AppShell>
+        <div>Content</div>
+      </AppShell>,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId("sidebar-app-version")).toHaveTextContent(
+        "v9.9.9",
+      ),
+    );
+  });
+
+  it("leaves the sidebar version blank when the config request fails", async () => {
+    api.getAppConfig.mockRejectedValue(new Error("offline"));
+    renderShell(
+      <AppShell>
+        <div>Content</div>
+      </AppShell>,
+    );
+
+    // Wait for the request to actually settle before asserting the absence,
+    // otherwise this passes on the pre-fetch render and proves nothing.
+    await waitFor(() => expect(api.getAppConfig).toHaveBeenCalled());
+    await waitFor(() =>
+      expect(screen.getByTestId("sidebar-app-version")).toHaveTextContent(""),
+    );
+    expect(screen.getByTestId("sidebar-app-version").textContent).toBe("");
   });
 });

--- a/frontend/src/__tests__/image-alt-text.test.tsx
+++ b/frontend/src/__tests__/image-alt-text.test.tsx
@@ -1,0 +1,133 @@
+/**
+ * Accessible names for media imagery (#338).
+ *
+ * Informative tiles must carry a useful name; genuinely decorative duplicates
+ * must be absent from the accessibility tree rather than announced with a
+ * placeholder label like "Person photo".
+ *
+ * Run with: pnpm vitest run src/__tests__/image-alt-text.test.tsx
+ */
+
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AssetViewer } from "@/components/asset-viewer";
+import { TimelineMediaView } from "@/components/timeline-media-view";
+import type { ViewerAsset } from "@/lib/viewer-preload";
+
+class FakeResizeObserver {
+  constructor(private callback: ResizeObserverCallback) {}
+
+  observe(target: Element) {
+    this.callback(
+      [
+        {
+          target,
+          contentRect: { width: 1000, height: 0 } as DOMRectReadOnly,
+        } as ResizeObserverEntry,
+      ],
+      this as unknown as ResizeObserver,
+    );
+  }
+
+  unobserve() {}
+  disconnect() {}
+}
+
+class FakeImage {
+  onload: (() => void) | null = null;
+  set src(_value: string) {}
+}
+
+const items = [
+  { id: 1, filename: "beach.jpg", createdAt: "2026-03-20T00:00:00Z" },
+  { id: 2, filename: "sunset.png", createdAt: "2026-03-19T00:00:00Z" },
+];
+
+beforeEach(() => {
+  vi.stubGlobal("ResizeObserver", FakeResizeObserver);
+  vi.stubGlobal("innerHeight", 5000);
+  vi.stubGlobal("scrollTo", vi.fn());
+  vi.stubGlobal("Image", FakeImage);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+function renderGrid(withAlt: boolean) {
+  render(
+    <TimelineMediaView
+      items={items}
+      getId={(item) => item.id}
+      getDate={(item) => item.createdAt}
+      getThumbnailUrl={(item) => `/thumb/${item.id}`}
+      getOriginalUrl={(item) => `/original/${item.id}`}
+      getAlt={withAlt ? (item) => item.filename : undefined}
+    />,
+  );
+}
+
+describe("media grid accessible names", () => {
+  it("names informative tiles from the filename", () => {
+    renderGrid(true);
+
+    expect(screen.getByRole("img", { name: "beach.jpg" })).toBeInTheDocument();
+    expect(screen.getByRole("img", { name: "sunset.png" })).toBeInTheDocument();
+  });
+
+  it("falls back to a stable per-asset label when no filename is supplied", () => {
+    renderGrid(false);
+
+    expect(screen.getByRole("img", { name: "Photo 1" })).toBeInTheDocument();
+    expect(screen.getByRole("img", { name: "Photo 2" })).toBeInTheDocument();
+  });
+
+  it("gives every tile a distinct name so they are not interchangeable", () => {
+    renderGrid(true);
+
+    const names = screen
+      .getAllByRole("img")
+      .map((node) => node.getAttribute("alt"));
+
+    expect(names).toHaveLength(new Set(names).size);
+    expect(names).not.toContain("");
+  });
+});
+
+describe("asset viewer accessible name", () => {
+  const assets: ViewerAsset[] = [
+    {
+      id: 7,
+      thumbnailUrl: "/thumb/7",
+      originalUrl: "/orig/7",
+      alt: "beach.jpg",
+    },
+  ];
+
+  it("prefers the supplied alt text", () => {
+    render(
+      <AssetViewer
+        assets={assets}
+        index={0}
+        onIndexChange={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("img", { name: "beach.jpg" })).toBeInTheDocument();
+  });
+
+  it("falls back to the asset id rather than an empty name", () => {
+    render(
+      <AssetViewer
+        assets={[{ id: 7, thumbnailUrl: "/thumb/7", originalUrl: "/orig/7" }]}
+        index={0}
+        onIndexChange={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("img", { name: "Photo 7" })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/settings-page.test.tsx
+++ b/frontend/src/__tests__/settings-page.test.tsx
@@ -16,24 +16,33 @@ import {
   render,
   screen,
   waitFor,
+  within,
 } from "@testing-library/react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import SettingsPage from "@/app/settings/page";
 import type { AppSettings, HardwareReport } from "@/lib/api";
 
-const { getSettings, updateSettings, getHardwareReport, getRuntimeConfig } =
-  vi.hoisted(() => ({
-    getSettings: vi.fn(),
-    updateSettings: vi.fn(),
-    getHardwareReport: vi.fn(),
-    getRuntimeConfig: vi.fn(),
-  }));
+const {
+  getSettings,
+  updateSettings,
+  getHardwareReport,
+  getRuntimeConfig,
+  getAppConfig,
+} = vi.hoisted(() => ({
+  getSettings: vi.fn(),
+  updateSettings: vi.fn(),
+  getHardwareReport: vi.fn(),
+  getRuntimeConfig: vi.fn(),
+  getAppConfig: vi.fn(),
+}));
 
 vi.mock("@/lib/api", () => ({
   getSettings,
   updateSettings,
   getHardwareReport,
   getRuntimeConfig,
+  // Read by the About card this page now renders.
+  getAppConfig,
 }));
 
 const REPORT: HardwareReport = {
@@ -68,6 +77,21 @@ function renderPage() {
 afterEach(() => {
   cleanup();
   vi.clearAllMocks();
+});
+
+// The About card mounts on every render of this page, so give it a default
+// rather than relying on each test to remember.
+beforeEach(() => {
+  getAppConfig.mockResolvedValue({
+    app_version: "1.1.3",
+    ml_mode: "full",
+    configured_ml_mode: "full",
+    accel_mode: "cpu",
+    ai_enabled: true,
+    map_enabled: false,
+    build_profile: "cpu",
+    supported_ml_modes: ["disabled", "mock", "full"],
+  });
 });
 
 describe("SettingsPage", () => {
@@ -171,7 +195,12 @@ describe("SettingsPage", () => {
     updateSettings.mockResolvedValue(settings({ ai_enabled: false }));
     renderPage();
 
-    expect(await screen.findByText("cpu")).toBeInTheDocument();
+    // Scoped to the AI section: the About card also reports the build profile,
+    // so a bare findByText("cpu") is ambiguous.
+    const aiSection = await screen.findByRole("region", {
+      name: "Local AI runtime",
+    });
+    expect(await within(aiSection).findByText("cpu")).toBeInTheDocument();
     const aiSwitch = screen.getByRole("switch", {
       name: /enable local ai processing/i,
     });

--- a/frontend/src/__tests__/support-summary.test.ts
+++ b/frontend/src/__tests__/support-summary.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildSupportSummary,
+  formatWorkerAge,
+  type SupportSummaryInput,
+} from "@/lib/support-summary";
+
+const input: SupportSummaryInput = {
+  appVersion: "1.1.3",
+  buildProfile: "cpu",
+  configuredMode: "full",
+  appliedMode: "full",
+  aiEnabled: true,
+  accelMode: "auto",
+  workerState: "healthy",
+  workerAgeSeconds: 12,
+};
+
+describe("formatWorkerAge", () => {
+  it("reports seconds, minutes, and hours", () => {
+    expect(formatWorkerAge(5)).toBe("5s ago");
+    expect(formatWorkerAge(150)).toBe("3m ago");
+    expect(formatWorkerAge(7200)).toBe("2h ago");
+  });
+
+  it("says unknown rather than inventing a number", () => {
+    expect(formatWorkerAge(null)).toBe("unknown");
+    expect(formatWorkerAge(undefined)).toBe("unknown");
+    expect(formatWorkerAge(Number.NaN)).toBe("unknown");
+  });
+
+  it("clamps a negative clock skew to zero", () => {
+    expect(formatWorkerAge(-4)).toBe("0s ago");
+  });
+});
+
+describe("buildSupportSummary", () => {
+  it("includes the runtime facts a maintainer needs", () => {
+    const summary = buildSupportSummary(input);
+
+    expect(summary).toContain("App version: 1.1.3");
+    expect(summary).toContain("Build profile: cpu");
+    expect(summary).toContain("AI: enabled");
+    expect(summary).toContain("AI mode: full configured, full applied");
+    expect(summary).toContain("Acceleration: auto");
+    expect(summary).toContain("Worker: healthy, last seen 12s ago");
+  });
+
+  it("marks AI off and flags a pending restart", () => {
+    const summary = buildSupportSummary({
+      ...input,
+      aiEnabled: false,
+      restartRequired: true,
+    });
+
+    expect(summary).toContain("AI: disabled");
+    expect(summary).toContain("Restart required: yes");
+  });
+
+  it("omits the restart line when none is pending", () => {
+    expect(buildSupportSummary(input)).not.toContain("Restart required");
+  });
+
+  // The privacy contract for #355: the summary is an allow-list, so anything
+  // resembling a path, filename, credential, or identifier must not appear
+  // even when a caller passes extra keys through.
+  it("never emits fields outside the allow-list", () => {
+    const summary = buildSupportSummary({
+      ...input,
+      ...({
+        databaseUrl: "postgresql://find:secret@localhost:5432/find",
+        mediaRoot: "/home/abhash/Pictures/private",
+        filename: "passport-scan.jpg",
+        sessionToken: "find_session_abcdef123456",
+        username: "abhash",
+        instanceId: "b4d1e0c2-9f3a-4e77-8c21-5a6f0d9e1b33",
+      } as unknown as SupportSummaryInput),
+    });
+
+    for (const leak of [
+      "postgresql://",
+      "secret",
+      "/home/abhash",
+      "passport-scan.jpg",
+      "find_session_abcdef123456",
+      "abhash",
+      "b4d1e0c2",
+    ]) {
+      expect(summary).not.toContain(leak);
+    }
+  });
+
+  it("degrades to unknown instead of empty values", () => {
+    const summary = buildSupportSummary({
+      appVersion: "unknown",
+      buildProfile: "unknown",
+      configuredMode: "unknown",
+      appliedMode: "unknown",
+      aiEnabled: false,
+      accelMode: "unknown",
+      workerState: "unavailable",
+      workerAgeSeconds: null,
+    });
+
+    expect(summary).toContain("App version: unknown");
+    expect(summary).toContain("Worker: unavailable, last seen unknown");
+  });
+});

--- a/frontend/src/app/people/page.tsx
+++ b/frontend/src/app/people/page.tsx
@@ -95,9 +95,14 @@ function PersonCard({
               className="relative h-full w-full overflow-hidden rounded-xl"
             >
               {mediaId && src ? (
+                // Decorative on purpose: these are up to four crops of the same
+                // person, and the card already announces that identity through
+                // the overlay button ("Open <name> group") and the name below.
+                // Naming each tile would make a screen reader read four
+                // near-identical labels that add nothing.
                 <Image
                   src={src}
-                  alt="Person photo"
+                  alt=""
                   fill
                   className="border border-[var(--frost)] object-cover"
                   sizes="(max-width: 768px) 25vw, 10vw"

--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -2,6 +2,7 @@
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
+  BadgeInfo,
   Cpu,
   MapPinned,
   Palette,
@@ -11,6 +12,7 @@ import {
   Sparkles,
   Trash2,
 } from "lucide-react";
+import { AboutSettings } from "@/components/about-settings";
 import { AiRuntimeSettings } from "@/components/ai-runtime-settings";
 import { AppearanceSettings } from "@/components/appearance-settings";
 import { HardwareAccelSettings } from "@/components/hardware-accel-settings";
@@ -24,6 +26,7 @@ const SECTIONS = [
   { href: "#ai-runtime-heading", label: "Local AI", icon: Sparkles },
   { href: "#privacy", label: "Privacy", icon: MapPinned },
   { href: "#trash-retention", label: "Trash", icon: Trash2 },
+  { href: "#about", label: "About", icon: BadgeInfo },
 ] as const;
 
 export default function SettingsPage() {
@@ -185,6 +188,7 @@ export default function SettingsPage() {
                     save.mutate({ trash_retention_days })
                   }
                 />
+                <AboutSettings />
               </div>
             )}
 

--- a/frontend/src/components/about-settings.tsx
+++ b/frontend/src/components/about-settings.tsx
@@ -1,0 +1,165 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { BadgeInfo, Check, ClipboardCopy } from "lucide-react";
+import { useState } from "react";
+import { getAppConfig, getRuntimeConfig } from "@/lib/api";
+import { buildSupportSummary, formatWorkerAge } from "@/lib/support-summary";
+
+type CopyState = "idle" | "copied" | "error";
+
+const WORKER_LABEL: Record<string, string> = {
+  healthy: "Healthy",
+  stale: "Stale",
+  unknown: "Unknown",
+  unavailable: "Unavailable",
+};
+
+function Row({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex items-baseline justify-between gap-4 py-1.5">
+      <dt className="text-sm text-[color:var(--silver)]">{label}</dt>
+      <dd className="truncate text-sm font-medium text-[color:var(--near-white)]">
+        {value}
+      </dd>
+    </div>
+  );
+}
+
+export function AboutSettings() {
+  const [copyState, setCopyState] = useState<CopyState>("idle");
+
+  const config = useQuery({
+    queryKey: ["app-config"],
+    queryFn: getAppConfig,
+    retry: false,
+  });
+  const runtime = useQuery({
+    queryKey: ["runtime-config"],
+    queryFn: getRuntimeConfig,
+    retry: false,
+  });
+
+  const workerState = runtime.data?.worker.health.state ?? "unknown";
+  const workerAgeSeconds = runtime.data?.worker.health.age_seconds ?? null;
+
+  const summaryInput = {
+    appVersion: config.data?.app_version ?? "unknown",
+    buildProfile: config.data?.build_profile ?? "unknown",
+    configuredMode: config.data?.configured_ml_mode ?? "unknown",
+    appliedMode: config.data?.ml_mode ?? "unknown",
+    aiEnabled: config.data?.ai_enabled ?? false,
+    accelMode: config.data?.accel_mode ?? "unknown",
+    workerState,
+    workerAgeSeconds,
+    restartRequired: runtime.data?.restart_required ?? false,
+  };
+
+  const onCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(buildSupportSummary(summaryInput));
+      setCopyState("copied");
+    } catch {
+      // Clipboard access is denied in some browsers and insecure contexts.
+      setCopyState("error");
+    }
+  };
+
+  return (
+    <section
+      id="about"
+      className="rounded-2xl border border-[color:var(--frost)] bg-[color:var(--surface-soft)] p-5 sm:p-6"
+      aria-labelledby="about-heading"
+    >
+      <div className="flex gap-3">
+        <BadgeInfo className="mt-0.5 h-5 w-5 text-[color:var(--silver)]" />
+        <div className="min-w-0 flex-1">
+          <h2 id="about-heading" className="font-semibold">
+            About this instance
+          </h2>
+          <p className="mt-1 text-sm text-[color:var(--silver)]">
+            Version and runtime state, plus a short summary you can paste into a
+            bug report. The summary carries no paths, filenames, credentials, or
+            identifiers.
+          </p>
+
+          {config.isError ? (
+            <p
+              role="alert"
+              data-testid="about-error"
+              className="mt-4 rounded-xl border border-[color:var(--red)]/30 bg-[color:var(--red-soft)] px-4 py-3 text-sm"
+            >
+              Couldn&apos;t read the instance version. Check the local API.
+            </p>
+          ) : (
+            <dl
+              data-testid="about-details"
+              className="mt-4 divide-y divide-[color:var(--frost-soft)]"
+            >
+              <Row
+                label="App version"
+                value={
+                  config.isPending
+                    ? "Loading…"
+                    : (config.data?.app_version ?? "unknown")
+                }
+              />
+              <Row
+                label="Build profile"
+                value={config.data?.build_profile ?? "unknown"}
+              />
+              <Row
+                label="AI mode applied"
+                value={
+                  config.data
+                    ? `${config.data.ml_mode}${
+                        config.data.ai_enabled ? "" : " (AI off)"
+                      }`
+                    : "unknown"
+                }
+              />
+              <Row
+                label="Worker"
+                value={`${WORKER_LABEL[workerState] ?? workerState} · last seen ${formatWorkerAge(
+                  workerAgeSeconds,
+                )}`}
+              />
+            </dl>
+          )}
+
+          <div className="mt-5 flex flex-wrap items-center gap-3">
+            <button
+              type="button"
+              data-testid="copy-support-summary"
+              onClick={onCopy}
+              aria-label="Copy support summary to the clipboard"
+              className="inline-flex h-10 items-center gap-2 rounded-xl border border-[color:var(--frost)] px-4 text-sm font-medium text-[color:var(--silver)] outline-none transition hover:bg-[color:var(--surface-hover)] hover:text-[color:var(--near-white)] focus-visible:ring-2 focus-visible:ring-[color:var(--blue)]"
+            >
+              {copyState === "copied" ? (
+                <Check aria-hidden="true" size={15} />
+              ) : (
+                <ClipboardCopy aria-hidden="true" size={15} />
+              )}
+              Copy support summary
+            </button>
+
+            {/* Kept mounted so the status is announced rather than newly inserted. */}
+            <p
+              aria-live="polite"
+              data-testid="copy-status"
+              className={`min-h-5 text-sm ${
+                copyState === "error"
+                  ? "text-[color:var(--status-failed-text)]"
+                  : "text-[color:var(--silver)]"
+              }`}
+            >
+              {copyState === "copied" && "Support summary copied."}
+              {copyState === "error" &&
+                "Couldn't copy. Select the details above and copy manually."}
+            </p>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useQuery } from "@tanstack/react-query";
 import {
   Menu,
   PanelLeftClose,
@@ -25,6 +26,7 @@ import {
   UploadStatusRing,
   useUploadStatus,
 } from "@/components/upload-status-indicator";
+import { getAppConfig } from "@/lib/api";
 import {
   applyThemePreference,
   readThemePreference,
@@ -62,6 +64,17 @@ export function AppShell({ children }: AppShellProps) {
   const drawerTriggerRef = useRef<HTMLButtonElement | null>(null);
   const shellless = isShelllessRoute(pathname);
   const uploadStatus = useUploadStatus();
+
+  // The footer version comes from the backend package version so it cannot
+  // drift from the real build the way a hard-coded string does. Shared cache
+  // key with Settings > About, so this is one request per session.
+  const appConfig = useQuery({
+    queryKey: ["app-config"],
+    queryFn: getAppConfig,
+    retry: false,
+    staleTime: Number.POSITIVE_INFINITY,
+    enabled: !shellless,
+  });
 
   useEffect(() => {
     const apply = () => applyThemePreference(readThemePreference());
@@ -287,7 +300,9 @@ export function AppShell({ children }: AppShellProps) {
               Copyright 2026 Find · AGPL-3.0 License
             </span>
           )}
-          <span className="shrink-0">v1.1.3</span>
+          <span className="shrink-0" data-testid="sidebar-app-version">
+            {appConfig.data ? `v${appConfig.data.app_version}` : ""}
+          </span>
         </div>
         <button
           type="button"

--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useQuery } from "@tanstack/react-query";
 import {
   Menu,
   PanelLeftClose,
@@ -26,7 +25,6 @@ import {
   UploadStatusRing,
   useUploadStatus,
 } from "@/components/upload-status-indicator";
-import { getAppConfig } from "@/lib/api";
 import {
   applyThemePreference,
   readThemePreference,
@@ -64,17 +62,6 @@ export function AppShell({ children }: AppShellProps) {
   const drawerTriggerRef = useRef<HTMLButtonElement | null>(null);
   const shellless = isShelllessRoute(pathname);
   const uploadStatus = useUploadStatus();
-
-  // The footer version comes from the backend package version so it cannot
-  // drift from the real build the way a hard-coded string does. Shared cache
-  // key with Settings > About, so this is one request per session.
-  const appConfig = useQuery({
-    queryKey: ["app-config"],
-    queryFn: getAppConfig,
-    retry: false,
-    staleTime: Number.POSITIVE_INFINITY,
-    enabled: !shellless,
-  });
 
   useEffect(() => {
     const apply = () => applyThemePreference(readThemePreference());
@@ -300,9 +287,10 @@ export function AppShell({ children }: AppShellProps) {
               Copyright 2026 Find · AGPL-3.0 License
             </span>
           )}
-          <span className="shrink-0" data-testid="sidebar-app-version">
-            {appConfig.data ? `v${appConfig.data.app_version}` : ""}
-          </span>
+          {/* Release-managed: scripts/bump_version.py keeps this in sync with
+              the backend package version and CI fails if it drifts. Do not
+              replace it with a fetched value. */}
+          <span className="shrink-0">v1.1.3</span>
         </div>
         <button
           type="button"

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -211,6 +211,8 @@ export interface JobStatus {
 }
 
 export interface AppConfig {
+  /** Backend package version (find_api.__version__), the single source of truth. */
+  app_version: string;
   ml_mode: "disabled" | "full" | "mock" | "unavailable";
   configured_ml_mode: "disabled" | "full" | "mock" | "remote";
   accel_mode: AccelMode;

--- a/frontend/src/lib/support-summary.ts
+++ b/frontend/src/lib/support-summary.ts
@@ -1,0 +1,61 @@
+/**
+ * Support summary formatting (pure, no React).
+ *
+ * Builds the short block behind Settings > About > "Copy support summary".
+ *
+ * The input type is a deliberately narrow allow-list: only the non-identifying
+ * runtime facts below are accepted, so environment values, filesystem paths,
+ * media metadata, filenames, credentials, session tokens, usernames, and
+ * instance identifiers cannot reach the clipboard even by accident. Widening
+ * this interface is the one change that needs a privacy review.
+ */
+
+export interface SupportSummaryInput {
+  /** Backend package version, e.g. "1.1.3". */
+  appVersion: string;
+  /** Modular build the artifact was produced from, e.g. "mock" or "cpu". */
+  buildProfile: string;
+  /** AI mode the user asked for. */
+  configuredMode: string;
+  /** AI mode the worker actually applied. */
+  appliedMode: string;
+  aiEnabled: boolean;
+  /** Acceleration preference enum ("auto" | "gpu" | "cpu"), never a device name. */
+  accelMode: string;
+  workerState: string;
+  /** Seconds since the worker last reported in, when known. */
+  workerAgeSeconds?: number | null;
+  restartRequired?: boolean;
+}
+
+/** "unknown" rather than a fabricated number when the field is absent. */
+export function formatWorkerAge(seconds: number | null | undefined): string {
+  if (seconds === null || seconds === undefined || !Number.isFinite(seconds)) {
+    return "unknown";
+  }
+  const whole = Math.max(0, Math.round(seconds));
+  if (whole < 60) return `${whole}s ago`;
+  if (whole < 3600) return `${Math.round(whole / 60)}m ago`;
+  return `${Math.round(whole / 3600)}h ago`;
+}
+
+/** Human-readable, copy-pasteable summary. Newline separated, no trailing newline. */
+export function buildSupportSummary(input: SupportSummaryInput): string {
+  const lines = [
+    "Find support summary",
+    `App version: ${input.appVersion}`,
+    `Build profile: ${input.buildProfile}`,
+    `AI: ${input.aiEnabled ? "enabled" : "disabled"}`,
+    `AI mode: ${input.configuredMode} configured, ${input.appliedMode} applied`,
+    `Acceleration: ${input.accelMode}`,
+    `Worker: ${input.workerState}, last seen ${formatWorkerAge(
+      input.workerAgeSeconds,
+    )}`,
+  ];
+
+  if (input.restartRequired) {
+    lines.push("Restart required: yes");
+  }
+
+  return lines.join("\n");
+}


### PR DESCRIPTION
## Summary

Closes #355, #338 and #346. Grouping them is deliberate and I'd rather be upfront about why: **two of the three were largely already done**, so this is one substantive change plus two small remainders, not three features. Each issue's actual remaining gap is called out below so review can skip the rest.

If you'd prefer these split, #355 is cleanly separable — say so and I'll break it out.

## What was actually still open

### #355 — Settings > About (the real work)

- `GET /api/config` now returns `app_version`, sourced from `find_api.__version__`.
- New `AboutSettings` card: app version, build profile, applied AI mode, worker health, plus a **Copy support summary** button with an `aria-live` status and an error path for when clipboard access is denied.
- `buildSupportSummary` sits in `lib/support-summary.ts` behind a deliberately narrow `SupportSummaryInput` allow-list, so env values, filesystem paths, media metadata, filenames, credentials, session tokens, usernames and instance identifiers cannot reach the clipboard even if a caller passes a wider object. A test asserts this by passing extra keys through and checking none surface.

Actual clipboard contents from the running mock stack:

```
Find support summary
App version: 1.1.3
Build profile: mock
AI: enabled
AI mode: mock configured, mock applied
Acceleration: cpu
Worker: healthy, last seen 26s ago
```

### #338 — meaningful accessible image labels

The premise is **stale**: there are no `biome-ignore lint/a11y/useAltText` suppressions left anywhere in the repo (the only suppressions are `noImgElement` and `useExhaustiveDependencies`), and nearly every tile already names itself from a filename, caption or date.

One real gap remained. The people page rendered four crops of the same person each labelled `"Person photo"`, so a screen reader read the same meaningless string four times per card. They're now correctly decorative — the card already announces identity via its `Open <name> group` button and the name beneath. The logo's `alt=""` in `app-shell.tsx` was checked and left alone; it is genuinely decorative beside the FIND. wordmark.

### #346 — focus-safe navigation drawer

**Already implemented and already tested** on `canary`: dialog semantics, focus move-in, two-way Tab trap, focus restore to the trigger, `inert` + `aria-hidden` on the background, scroll lock, and close on both Escape and route change. The "12-link desktop pill" the issue describes as clipping no longer exists — desktop nav is a vertical sidebar.

The one criterion still open was regression coverage **in both themes and at real viewport widths**, which jsdom cannot provide: no CSS layout, no real focus order. So `e2e/nav-accessibility.spec.ts` covers it in a browser — all 13 links fully inside the viewport at 1024/1280/1440 in both themes, and the full drawer keyboard contract in both themes, asserting the banner leaves the accessibility tree entirely while the drawer is open. Like the rest of that directory it needs no backend. A both-themes keyboard case was also added at the jsdom layer.

## A wrong turn, corrected in 19f9241

Worth reading before reviewing, since the first commit contains a mistake.

I initially replaced the sidebar footer's hard-coded `v1.1.3` with the fetched `app_version`, reasoning it would silently go stale on release. **That was wrong, and CI caught it.** `scripts/bump_version.py` treats `frontend/src/components/app-shell.tsx` as one of six files whose version it keeps synchronized, matching `>v(\d+\.\d+\.\d+)<` in exactly that span. The required `Release metadata and license` check failed with `RuntimeError: Version not found in .../app-shell.tsx`.

So the string was never drift waiting to happen — it is deliberately rewritten on release and CI fails if it falls out of sync. Reverted to the literal with a comment so the next person doesn't repeat it. The About card still sources its version from the backend package version, which is what the issue actually asked for, and dropping the shell query also removes the extra per-session request I'd flagged as a tradeoff — so the end state is strictly better than what I first pushed.

## Type of change

- [x] Feature
- [x] Bug fix

## Release impact

- [ ] No user-visible release note needed
- [x] Minor (backward-compatible feature)
- [ ] Patch (backward-compatible fix)
- [ ] Major (breaking change)
- [ ] Critical/security fix (keep sensitive details private)

## How to test

```bash
cd frontend && pnpm check && pnpm test && pnpm build && pnpm exec playwright test
cd backend  && uv run ruff check . && uv run ruff format --check . && uv run pytest tests/
python scripts/bump_version.py --check
```

- frontend: biome **0 errors** (23 warnings, all pre-existing and in untouched files), **300** vitest tests (40 files), **14** Playwright tests, production build OK
- backend: ruff check + format clean, **619 passed / 6 skipped**
- `bump_version.py --check` prints `1.1.3`

## Manually verified against the running stack

`docker compose -f compose.mock.yml up --build`, then driven in a real Chromium:

- Uploaded two images through `POST /api/upload`; the worker took both from `pending` to `indexed`, and `/api/activity` recorded `upload completed` for each — so the pipeline merged in #367/#376 works end to end.
- About card paints the real `1.1.3`, `mock` profile, and `Worker Healthy · last seen 26s ago`.
- Clicked **Copy support summary** and read the clipboard back to confirm the contents above and that nothing path-like, secret-like or identifying appears.
- 13 desktop nav links unclipped at 1024/1280/1440 in both themes.
- Drawer at 390px in both themes: modal semantics, scroll lock, focus moved in, focus held across a full tab lap, Escape closes, focus restored to the trigger, scroll lock released.
- Gallery tile announced as `beach-sunset.jpg`; timeline tiles announced by date; **zero** images announced as `Person photo`; the string is absent from every compiled chunk.
- No console or page errors during the run.

**Not verified:** the people-page change could not be exercised with real person cards, because the synthetic test images contain no faces, so no clusters formed. Its effect is confirmed by the string being gone from source and from the built bundle, plus the accessible-name unit tests — but not by a rendered person card.

## Checklist

- [x] I linked the related issues
- [x] I ran required checks from CONTRIBUTING.md
- [x] I updated docs/env notes if needed (no env or API-breaking change; `app_version` is additive)
- [ ] My PR is scoped to a single issue — **no**, see the note at the top
- [x] I followed commit message conventions
- [x] I am not committing secrets or local artifacts
- [x] This PR targets `canary`
