### PR TITLE
docs: research notes for encrypted BYO storage sync (#187) and search benchmarking (#99)

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -52,6 +52,8 @@ This directory is organized by document purpose and implementation status.
 ## Research
 
 - [Vector Search Benchmark Evaluation](research/vector-search-benchmarks.md)
+- [Search Retrieval and Ranking Benchmark Plan](research/search-retrieval-benchmark-plan.md) - experiment design; results blocked on the evaluation harness.
+- [Encrypted Bring-Your-Own-Storage Sync](research/encrypted-byo-storage-sync.md) - provider comparison and v1 boundary for optional encrypted backup.
 
 ## Assets
 

--- a/docs/research/encrypted-byo-storage-sync.md
+++ b/docs/research/encrypted-byo-storage-sync.md
@@ -1,0 +1,239 @@
+# Research: Encrypted Bring-Your-Own-Storage Sync
+
+- **Status:** Research complete, implementation not started
+- **Date:** 2026-08-03
+- **Related:** Issue #187. Builds on `docs/plans/not-started/storage-provider-neutrality-adr.md`,
+  `docs/plans/partial/vault-encryption-design.md`, and the installer/model-cache direction in #45.
+- **Scope:** Design comparison only. No provider integration, no hosted Find storage, no credential
+  handling code, and no automatic upload is proposed for implementation here.
+
+## Summary
+
+Find should offer optional backup to storage the user already owns, with media encrypted on the
+local machine before it leaves. The recommended v1 boundary is **a manual, encrypted, resumable
+snapshot pushed to a generic S3-compatible endpoint or a local/mounted filesystem path, through a
+sync target interface that is deliberately separate from the live `StorageBackend`.** Consumer
+drive providers (Google Drive, Dropbox, OneDrive) are explicitly deferred, and the reasons are in
+[Provider comparison](#provider-comparison).
+
+Two findings from the current codebase shape everything below and are easy to get wrong:
+
+1. **The provider-neutral storage abstraction has already landed.** `storage_abstract.py`,
+   `storage_factory.py`, `storage_local.py`, and `storage_minio.py` exist and `storage.py` is now a
+   facade over them. The ADR in `docs/plans/not-started/` still says no abstraction has landed;
+   that status line is stale and should be corrected when this work starts.
+2. **The vault no longer encrypts media at rest.** Per `vault-encryption-design.md`, Find 1.1.3
+   keeps hidden media in the ordinary private object store behind password-gated, memory-only vault
+   sessions, and migrates legacy AES-256-GCM blobs back into plain private storage after first
+   unlock. The vault is currently an *access-control* boundary, not a cryptographic one.
+
+Finding 2 is the important one. The issue's requirement that "vault blobs are encrypted locally
+before upload" **cannot be satisfied by reusing what the vault does today**, because today it does
+not encrypt. Sync must own its own encryption layer and treat everything it uploads as ciphertext
+it produced itself. Anything else would ship exactly the false confidence the vault design note
+warns against.
+
+## Why sync is not another StorageBackend
+
+The tempting shortcut is to add `storage_s3.py` or `storage_gdrive.py` alongside the existing
+backends and call it sync. That is the wrong shape, for three reasons:
+
+- **Different lifecycle.** `StorageBackend` is a *live, authoritative* blob store: the app reads
+  through it on every gallery request and expects low latency and read-after-write. A backup target
+  is written occasionally, read almost never, and may be offline for weeks.
+- **Different failure semantics.** A failed `get_file` on the live backend is a broken page. A
+  failed backup upload is a retry. Collapsing them means one set of error handling has to serve
+  both, and the stricter one wins by accident.
+- **Different content.** The live backend stores plaintext bytes. The backup target must only ever
+  see ciphertext. If backup is a `StorageBackend`, every existing caller becomes a potential path
+  for plaintext to reach it.
+
+The v1 shape is therefore a separate, narrow interface — call it `SyncTarget` — with roughly
+`put_object(key, stream)`, `get_object(key)`, `list_prefix(prefix)`, `delete_object(key)`, and
+`capabilities()`. It is used only by an explicit sync command, never by request handlers.
+
+## Provider comparison
+
+Assessed on the criteria the issue asks for. "Maintenance" means ongoing cost to Find, not to the
+user: SDK churn, auth flows that break, provider policy changes.
+
+| Option | Privacy | Portability | Cost | Offline behaviour | Maintenance |
+| --- | --- | --- | --- | --- | --- |
+| **Local/mounted filesystem** (external drive, NAS, SMB/NFS mount) | Best — bytes never touch a network Find controls or a third party | Best — a directory tree the user can copy, inspect, `rsync` | Zero beyond the disk | Native; the target simply is or is not mounted | Lowest — `pathlib` and `os.replace`, no SDK |
+| **Generic S3-compatible** (MinIO, Backblaze B2, Wasabi, Garage, Ceph, Hetzner, AWS) | Good — ciphertext only; provider sees object sizes and timing | Good — one protocol, many vendors, no lock-in | User's own bill; egress varies sharply by vendor | Poor while offline, but retry is clean and resumable | Low — one stable protocol, already a dependency via MinIO SDK |
+| **Consumer drive** (Google Drive, Dropbox, OneDrive) | Weaker — OAuth means a Find-registered app identity sits in the trust path | Poor — proprietary file IDs, per-provider semantics | Free tiers exist; quota and throttling are real constraints | Poor; SDKs assume connectivity | **Highest** — OAuth client registration, consent screens, token refresh, provider review, per-provider quirks |
+| **Local encrypted export** (single archive the user moves themselves) | Best — Find never speaks to a network at all | Best — one file | Zero | Perfect; it is inherently offline | Very low |
+
+### Detailed notes
+
+**Local/mounted filesystem** is the strongest option on every axis except convenience, and it costs
+almost nothing to build because the target is a path. It also covers the NAS case, which is common
+among exactly the self-hosting users Find is aimed at. It should be in v1.
+
+**Generic S3-compatible** is the right *network* option because it is a protocol rather than a
+vendor. The user picks endpoint, region, bucket, and keys; Find never learns who the provider is
+and never needs a per-provider integration. The MinIO SDK already in the dependency tree speaks it,
+so this adds no new dependency. It should be in v1.
+
+**Consumer drive providers** are where this gets expensive. OAuth for Drive/Dropbox/OneDrive
+requires Find to register a *client application*, which means a Find-controlled identity is
+structurally in the trust path even though Find hosts no storage — a meaningful weakening of the
+local-first promise, not just an engineering cost. The alternative, asking users to register their
+own OAuth app, is a genuinely bad user experience. They also have the highest ongoing maintenance:
+consent screens get re-reviewed, scopes get deprecated, refresh tokens expire in provider-specific
+ways.
+
+The recommendation is to satisfy this demand **indirectly**: because the v1 target is a plain
+directory, users who want Drive or Dropbox can point Find at a folder that the provider's own
+desktop client syncs, or at an `rclone mount`. That covers the use case in v1 with zero provider
+code, and it keeps the option of a native integration open for later without committing to it now.
+
+**Local encrypted export** is a degenerate case of the filesystem target — same code path, no
+scheduling. Worth exposing as its own command because "give me one file I can put on a USB stick"
+is a distinct and reasonable user request.
+
+## Credentials: what the user supplies and where it may live
+
+Exactly two credential sets, and they are handled very differently.
+
+**Storage credentials.** For S3-compatible targets: endpoint URL, region, bucket, access key ID,
+secret access key, and a TLS flag. For filesystem targets: a path, and nothing else.
+
+- Supplied by the user at configuration time.
+- Stored in the existing settings/env mechanism, the same way `MINIO_ACCESS_KEY` is today. They are
+  deployment configuration, not user secrets.
+- **Never** written into the database, the backup manifest, or any log line. The diagnostics bundle
+  redaction added in #428 already denies `access_key`, `secret_key`, and `*_url` keys, and the
+  bundle is a good model for what sync logging must not emit.
+- Scoped as narrowly as the provider allows — a bucket-scoped key with put/get/list/delete, never a
+  root account key. This must be in the user-facing documentation.
+
+**The backup passphrase.** This is the one genuine user secret and it is categorically different.
+
+- Supplied interactively when the user creates or restores a backup.
+- **Never persisted anywhere** — not in the database, not in settings, not in the OS keychain for
+  v1. Held in process memory for the duration of the operation only, matching how vault sessions
+  already work.
+- Losing it means losing the backup. This is stated plainly in the UI, not buried in docs. There is
+  no recovery path and Find must not pretend otherwise.
+
+Deliberately excluded from v1: OS keychain integration, passphrase caching across runs, and any
+"remember me" affordance. Each is a real convenience feature and each needs its own threat-model
+review.
+
+## Encryption design
+
+Reuse the primitives the vault design already settled on rather than inventing a second scheme.
+
+- **Content encryption:** AES-256-GCM, streaming, so large images are never fully resident.
+  ChaCha20-Poly1305 remains an acceptable alternative on hardware without AES-NI; the vault note
+  already covers this trade-off.
+- **Key derivation:** Argon2id from the backup passphrase, with a per-backup random salt stored in
+  the manifest. Parameters recorded in the manifest so a future parameter change stays readable.
+- **Key hierarchy:** the passphrase derives a key-encryption key; a random per-backup data key is
+  wrapped by it. Rotating the passphrase then rewrites one small header instead of re-encrypting
+  every object.
+- **Associated data:** every object's AAD binds format version, backup ID, and object key, so
+  ciphertext cannot be swapped between entries by someone with write access to the bucket. This is
+  the same reasoning the vault note gives for binding AAD to `media_id` and `file_hash`.
+- **Encryption timing:** at the sync boundary, streaming from the live storage backend into the
+  target. Plaintext is never written to a temporary file on the way out. The uploaded object is
+  ciphertext from the first byte.
+
+### What still leaks
+
+Stating this precisely matters more than the cipher choice:
+
+- **Object count and individual sizes.** Padding to size buckets would mitigate this at a storage
+  cost. Not proposed for v1, but the manifest format should leave room for it.
+- **Timing.** When backups run, and roughly how much changed.
+- **The manifest**, unless it is encrypted too — it must be, since it contains object keys and
+  sizes. Only a small unencrypted header (format version, KDF parameters, salt) stays readable, and
+  it must contain nothing user-specific.
+- **`file_hash` must not be uploaded in plaintext.** It is a SHA-256 of the raw image bytes and, as
+  the vault note already says, fingerprints a known image without the blob. It belongs inside the
+  encrypted manifest, never in an object key or a plaintext index.
+
+## Sync behaviour
+
+**Identity.** Each backup destination gets a random `backup_id` (UUIDv4) generated on first use and
+recorded in the encrypted manifest. Deliberately *not* derived from hostname, user, or install ID —
+those leak, and they break when a user restores onto new hardware, which is the primary reason
+anyone has a backup at all.
+
+**Object keys.** `{backup_id}/objects/{HMAC(data_key, media_uuid)}`. The HMAC means the key reveals
+nothing about content or ordering while staying deterministic, so re-uploading the same media
+converges instead of duplicating.
+
+**Conflict.** v1 declares **the local library authoritative and sync one-directional**. This is the
+single most important scope decision in the document. Bidirectional sync needs vector clocks or
+similar causality tracking, a merge UI for genuine conflicts, and tombstone reconciliation — and
+gets it wrong quietly. Two machines pointed at one destination is a *detected and refused*
+condition in v1: the manifest records the writer's `backup_id`, and a second writer refuses and
+tells the user, rather than interleaving.
+
+**Retry.** Per-object, resumable, idempotent. Objects are content-addressed by their HMAC key, so a
+retry either finds the object present and skips it, or re-uploads it whole. Exponential backoff
+with a cap; a failed run leaves a valid older manifest in place — the manifest is written **last**,
+after every object it references, so an interrupted run never produces a manifest pointing at
+objects that were never uploaded.
+
+**Deletion.** Deletions do not propagate automatically in v1. A local delete leaves the remote
+object in place until an explicit prune, which is opt-in, reports what it will remove first, and
+honours a configurable grace period. Silent propagating deletion turns "backup" into "mirror," and
+a mirror faithfully reproduces the accident that made the user want a backup.
+
+**Restore.** Reads the manifest, prompts for the passphrase, verifies the KDF header, then streams
+objects back through the live storage backend. Restore is always explicit, never automatic, and
+must be verifiable without writing anything — a `--verify` mode that walks the manifest, checks
+every AEAD tag, and reports drift. A backup nobody has tested restoring is not a backup.
+
+## Recommended v1 boundary
+
+Ship exactly this:
+
+1. A `SyncTarget` interface, separate from `StorageBackend`, with filesystem and S3-compatible
+   implementations.
+2. Manual, user-triggered backup and restore. No scheduling, no daemon, no background upload.
+3. AES-256-GCM content encryption with Argon2id key derivation, applied at the sync boundary.
+4. An encrypted manifest, written last, with a minimal plaintext header.
+5. One-directional sync with local authoritative, and second-writer detection.
+6. An explicit, opt-in prune, and a restore `--verify` mode.
+
+Why this boundary: it delivers the actual user value — "my library survives this disk dying" —
+without a Find-hosted service, without OAuth, without a background process touching user data
+unattended, and without the causality problems of bidirectional sync. Every deferred item below can
+be added later without changing the on-disk format, because the manifest is versioned.
+
+## What must not be implemented yet
+
+- Bidirectional or multi-writer sync, and any automatic conflict merging.
+- Native Google Drive, Dropbox, or OneDrive integration, and any OAuth client registration.
+- Scheduled or background sync, including "on idle" triggers.
+- Passphrase persistence of any kind, including OS keychain storage.
+- Automatic deletion propagation.
+- Any Find-hosted relay, coordinator, or credential broker.
+- Sharing a backup destination between users, or any multi-tenant key hierarchy.
+- Size-bucket padding — noted as a known leak, deferred deliberately.
+
+## Open questions for implementation
+
+1. Does the backup include derived data — thumbnails, embeddings, captions — or only originals plus
+   the database rows needed to rebuild them? Originals-only is smaller and more portable;
+   including derived data makes restore dramatically faster on large libraries. Needs a measured
+   answer, and the model-cache direction in #45 is relevant since restore may otherwise require
+   re-downloading model weights before the library is usable again.
+2. Argon2id parameters for a *backup* passphrase, where a multi-second derivation is acceptable and
+   should probably be much higher than an interactive login would tolerate.
+3. Whether the encrypted manifest needs chunking for very large libraries, or whether a single
+   object is adequate to a realistic ceiling.
+
+## References
+
+- `docs/plans/not-started/storage-provider-neutrality-adr.md` — provider-neutral direction; its
+  "current implementation status" is stale as described above
+- `docs/plans/partial/vault-encryption-design.md` — threat model, cipher and KDF rationale, AAD
+  requirement, and the current no-encryption-at-rest status
+- `backend/src/find_api/core/storage_abstract.py` — the live backend contract this must not reuse
+- `backend/src/find_api/diagnostics/redact.py` — deny-by-default redaction, a good model for what
+  sync logging must never emit

--- a/docs/research/encrypted-byo-storage-sync.md
+++ b/docs/research/encrypted-byo-storage-sync.md
@@ -103,8 +103,11 @@ secret access key, and a TLS flag. For filesystem targets: a path, and nothing e
 - Stored in the existing settings/env mechanism, the same way `MINIO_ACCESS_KEY` is today. They are
   deployment configuration, not user secrets.
 - **Never** written into the database, the backup manifest, or any log line. The diagnostics bundle
-  redaction added in #428 already denies `access_key`, `secret_key`, and `*_url` keys, and the
-  bundle is a good model for what sync logging must not emit.
+  redaction in `backend/src/find_api/diagnostics/redact.py` is the model to copy here: it is
+  allowlist-first, so an unrecognised key is denied by default rather than needing a matching deny
+  rule, with explicit patterns for names like `access_key` / `secret_key` and for named URL keys
+  such as `database_url` and `redis_url`. Sync logging should adopt the same posture — deny unless
+  the field was deliberately allowed — rather than trying to enumerate what to hide.
 - Scoped as narrowly as the provider allows — a bucket-scoped key with put/get/list/delete, never a
   root account key. This must be in the user-facing documentation.
 
@@ -125,9 +128,19 @@ review.
 
 Reuse the primitives the vault design already settled on rather than inventing a second scheme.
 
-- **Content encryption:** AES-256-GCM, streaming, so large images are never fully resident.
+- **Content encryption:** AES-256-GCM, so large images are never fully resident.
   ChaCha20-Poly1305 remains an acceptable alternative on hardware without AES-NI; the vault note
   already covers this trade-off.
+- **Chunk framing is mandatory, and this is the easiest thing here to get catastrophically wrong.**
+  AES-GCM has no safe "streaming" mode of its own: a nonce may never repeat under a given key, and
+  a partial plaintext must never be released before its tag verifies. So an object is split into
+  fixed-size chunks, each encrypted as its own AEAD message with a nonce derived deterministically
+  as `nonce_prefix || chunk_counter` (random 32-bit prefix per object, 64-bit counter), and each
+  chunk's AAD binds the object key **and its chunk index** so chunks cannot be reordered, dropped,
+  or spliced between objects. The final chunk is flagged in its AAD so truncation is detectable.
+  Decryption verifies each chunk before emitting it. Resume works at chunk boundaries only, and a
+  resumed upload must reuse the same nonce prefix and counter sequence — never restart the counter.
+  Implementation must use a reviewed construction rather than hand-rolling this.
 - **Key derivation:** Argon2id from the backup passphrase, with a per-backup random salt stored in
   the manifest. Parameters recorded in the manifest so a future parameter change stays readable.
 - **Key hierarchy:** the passphrase derives a key-encryption key; a random per-backup data key is

--- a/docs/research/search-retrieval-benchmark-plan.md
+++ b/docs/research/search-retrieval-benchmark-plan.md
@@ -27,11 +27,17 @@ Before comparing anything, the assumed baseline had to be checked against the co
 have drifted, and the third materially affects how #99 must be run.
 
 **1. Reranking is not absent; it is partial.** The roadmap lists "no reranking stage" as a current
-weakness, but `backend/src/find_api/ml/search_ranking.py` already exists and applies text-aware
-boosting driven by a `TEXT_QUERY_TERMS` set (`invoice`, `receipt`, `screenshot`, `document`, …)
-plus object-label extraction. The baseline for #99 is therefore *vector retrieval plus a keyword-
-triggered metadata boost*, not raw cosine ranking. Measuring "add reranking" against a baseline
-that already reranks would attribute the wrong effect.
+weakness, but `backend/src/find_api/ml/search_ranking.py` already exists and reranks. Its
+`compute_textual_boost()` scores **token overlap between the query and every text signal** —
+caption at 0.015 per overlapping token, OCR at 0.035, object labels at 0.01 — capped at 0.25, then
+adds a flat 0.05 when the query intersects a hardcoded `TEXT_QUERY_TERMS` set (`invoice`,
+`receipt`, `screenshot`, `document`, …) *and* the media has OCR text. `rerank_results()` then sorts
+by boosted score with the raw vector score as a tiebreak.
+
+So the boost is overlap-driven for any query, not gated on a keyword list; the keyword set only
+contributes an extra bump. The baseline for #99 is therefore *vector retrieval plus a graded
+metadata boost*, not raw cosine ranking, and measuring "add reranking" against a baseline that
+already reranks would attribute the wrong effect.
 
 **2. Latency instrumentation is already in place.** `routers/search.py` records `embedding_ms` and
 separates query-embedding time from retrieval. #99 does not need to add timing plumbing; it needs
@@ -118,12 +124,13 @@ Baseline is B0 plus the existing `search_ranking` boost, exact retrieval.
 
 | ID | Variant | Question it answers |
 | --- | --- | --- |
-| C0 | Current: static threshold + existing keyword boost | Reference |
+| C0 | Current: static threshold + existing overlap boost | Reference |
 | C1 | No threshold | How many valid results does the static cutoff discard? The roadmap already flags this as suspected |
 | C2 | Adaptive threshold from score distribution | Can the cutoff adapt to per-query score spread instead of a constant? |
 | C3 | Wider candidate pool, then metadata rerank | The issue's "candidate-pool reranking" requirement — retrieve k=100, rerank to 24 |
 | C4 | C3 plus recency/favourite/album signals | Do non-semantic signals help or just add noise? |
-| C5 | Query expansion for `TEXT_QUERY_TERMS` | Is the hardcoded keyword list earning its place, or is it overfit? |
+| C5 | Drop or expand the `TEXT_QUERY_TERMS` bonus | Is the hardcoded 0.05 keyword bump earning its place on top of the overlap score, or is it overfit? |
+| C6 | Reweight the per-signal boost coefficients | Are 0.015 / 0.035 / 0.01 and the 0.25 cap the right shape, or were they picked by feel? |
 
 C1 and C5 are deliberately framed as *challenges to existing behaviour*. Both are currently
 unjustified by measurement, and a benchmark that only ever proposes additions will never remove
@@ -235,6 +242,6 @@ cheapest measurement that could invalidate the plan runs first.
 - `docs/research/vector-search-benchmarks.md` — index performance, ANN candidates, adoption gates
 - `docs/plans/partial/local-search-quality-roadmap.md` — target metrics and stage sequencing
 - `backend/src/find_api/workers/processors.py` — `generate_hybrid_embedding`, the B0 baseline
-- `backend/src/find_api/ml/search_ranking.py` — existing keyword/object boosting
+- `backend/src/find_api/ml/search_ranking.py` — existing overlap-based boost and rerank
 - `backend/src/find_api/routers/search.py` — retrieval query, static threshold, timing instrumentation
 - `backend/alembic/versions/add_hnsw_vector_index.py` — the HNSW index and its default parameters

--- a/docs/research/search-retrieval-benchmark-plan.md
+++ b/docs/research/search-retrieval-benchmark-plan.md
@@ -1,0 +1,240 @@
+# Research: Search Retrieval and Ranking Benchmark Plan
+
+- **Status:** Experimental design complete. **Results are blocked on #100** and are deliberately
+  absent from this document.
+- **Date:** 2026-08-03
+- **Related:** Issue #99. Depends on the evaluation harness in #100. Extends
+  `docs/research/vector-search-benchmarks.md` (index performance) and
+  `docs/plans/partial/local-search-quality-roadmap.md` (targets and sequencing).
+- **Scope:** Protocol, candidate matrix, and decision gates only. No production search change is
+  proposed here, and no cloud or private evaluation service is used.
+
+## Why there are no numbers in this document
+
+Issue #99 states plainly: *"Do not start final comparisons until the same labeled dataset and
+metrics can evaluate every candidate."* Issue #100, which builds that harness and defines the
+versioned labeled query set, is still open.
+
+Publishing relevance numbers before that exists would produce figures that cannot be reproduced,
+cannot be compared across candidates, and would nonetheless get cited in later decisions. So this
+document delivers everything that does **not** depend on the harness — the baseline audit, the
+candidate matrix, the measurement protocol, and the adoption gates — and stops precisely where real
+data is required. When #100 lands, the results table can be filled in without redesigning anything.
+
+## Baseline audit: three stale assumptions
+
+Before comparing anything, the assumed baseline had to be checked against the code. Three things
+have drifted, and the third materially affects how #99 must be run.
+
+**1. Reranking is not absent; it is partial.** The roadmap lists "no reranking stage" as a current
+weakness, but `backend/src/find_api/ml/search_ranking.py` already exists and applies text-aware
+boosting driven by a `TEXT_QUERY_TERMS` set (`invoice`, `receipt`, `screenshot`, `document`, …)
+plus object-label extraction. The baseline for #99 is therefore *vector retrieval plus a keyword-
+triggered metadata boost*, not raw cosine ranking. Measuring "add reranking" against a baseline
+that already reranks would attribute the wrong effect.
+
+**2. Latency instrumentation is already in place.** `routers/search.py` records `embedding_ms` and
+separates query-embedding time from retrieval. #99 does not need to add timing plumbing; it needs
+to record what is already emitted.
+
+**3. Find is very likely already serving approximate results, and recall has never been measured.**
+This is the important one. Migration `hnsw_vector_idx_001` created
+`ix_media_vector_hnsw ON media USING hnsw (vector vector_cosine_ops)`, and search issues
+`ORDER BY vector <=> :embedding … LIMIT :limit`, which the Postgres planner will normally satisfy
+from that index. Meanwhile `docs/research/vector-search-benchmarks.md` still describes exact
+pgvector scan as "current default" and frames its adoption gates as *when to start* evaluating ANN.
+
+Two consequences follow:
+
+- The index was created with **default HNSW build parameters** (`m`, `ef_construction`), and
+  **`hnsw.ef_search` is never set anywhere in the codebase**, so pgvector's default query-time
+  candidate list applies. Nobody chose these values against Find's data.
+- The "recall is perfect by definition because exact search is still used" line in the existing gate
+  list is no longer safe to rely on. **Recall against exact search is now an unmeasured quantity in
+  production**, and quantifying it is the single highest-value measurement in this whole effort.
+
+Practical effect on the protocol: every embedding-quality comparison below must pin retrieval to
+exact search (`SET LOCAL enable_indexscan = off`, or a dedicated exact query path) so that ANN
+approximation error cannot be mistaken for an embedding effect. That separation is also what the
+issue's "separate embedding-quality findings from index-performance findings" criterion demands.
+
+## Division of labour with the existing benchmark doc
+
+`vector-search-benchmarks.md` already covers index performance thoroughly — ANN candidate
+comparison, DB latency percentiles, build time, memory, and numeric adoption gates. That work is
+not repeated here.
+
+| Concern | Owner |
+| --- | --- |
+| ANN candidates (HNSW/IVFFlat/FAISS/hnswlib/Annoy), build time, index memory, DB latency percentiles, ANN adoption gates | `vector-search-benchmarks.md` |
+| Embedding composition, query-side handling, reranking signals, threshold behaviour, end-to-end relevance | This document |
+| Measured recall of the **currently deployed** HNSW configuration vs exact | This document — see [Track A](#track-a-index-fidelity) |
+
+## Experiment tracks
+
+### Track A: index fidelity
+
+One question, and it is a correctness question rather than a tuning one: **how much recall is the
+deployed HNSW configuration actually costing?**
+
+- A1 — Exact search (`enable_indexscan = off`). Ground truth for every other measurement.
+- A2 — Current HNSW, default build params, default `ef_search`. The configuration users run today.
+- A3 — Current HNSW with `hnsw.ef_search` swept (e.g. 40 / 100 / 200 / 400).
+- A4 — HNSW rebuilt with raised `m` / `ef_construction`, `ef_search` swept again.
+
+Report recall@10 of each against A1 on identical query vectors, with DB latency percentiles
+alongside. A2's recall number is the headline result of this track: if it is high, the existing gate
+framing simply needs correcting; if it is low, this is a live quality regression that predates #99
+and should be raised immediately rather than waiting for the full benchmark.
+
+### Track B: embedding quality
+
+All Track B runs use exact retrieval, so differences are attributable to the vector alone.
+
+The current production vector is built by `generate_hybrid_embedding` in `workers/processors.py`:
+image, caption, and detected-object text are embedded separately and combined by a weighted average
+whose weights depend on which signals are present — equal thirds with all three, halves with two,
+image alone otherwise — with OCR-aware weights renormalised across active signals when OCR text
+exists. Empty strings are deliberately never embedded, because CLIP maps them to a fixed non-zero
+vector that would bias every image lacking that signal.
+
+| ID | Variant | Question it answers |
+| --- | --- | --- |
+| B0 | Current hybrid (baseline) | Reference for every delta |
+| B1 | Image-only | How much do text signals contribute at all? Also the honest fallback if captioning proves unreliable |
+| B2 | Text-weighted | Does upweighting caption/OCR help conceptual queries, and what does it cost on visual ones? |
+| B3 | OCR/object-aware | Does routing weights by *query* type beat fixed per-image weights? |
+| B4 | Caption-free | Isolates caption contribution — directly informs the caption-reliability stage of the roadmap |
+| B5 | Dual-vector | Store image and text vectors separately, combine at query time. Costs storage and an index; buys per-query weighting instead of per-image |
+
+B5 is the only variant that changes the storage schema. It is included because fixing the
+image/text ratio at *index* time is the baseline's most questionable property — the right ratio
+plainly differs between "photos of my dog" and "invoice from March" — but its cost means it needs
+the clearest evidence before adoption.
+
+### Track C: query-side and ranking
+
+Baseline is B0 plus the existing `search_ranking` boost, exact retrieval.
+
+| ID | Variant | Question it answers |
+| --- | --- | --- |
+| C0 | Current: static threshold + existing keyword boost | Reference |
+| C1 | No threshold | How many valid results does the static cutoff discard? The roadmap already flags this as suspected |
+| C2 | Adaptive threshold from score distribution | Can the cutoff adapt to per-query score spread instead of a constant? |
+| C3 | Wider candidate pool, then metadata rerank | The issue's "candidate-pool reranking" requirement — retrieve k=100, rerank to 24 |
+| C4 | C3 plus recency/favourite/album signals | Do non-semantic signals help or just add noise? |
+| C5 | Query expansion for `TEXT_QUERY_TERMS` | Is the hardcoded keyword list earning its place, or is it overfit? |
+
+C1 and C5 are deliberately framed as *challenges to existing behaviour*. Both are currently
+unjustified by measurement, and a benchmark that only ever proposes additions will never remove
+anything.
+
+## Measurement protocol
+
+**Dataset.** Whatever #100 defines, unchanged, at its pinned version. Recorded in every result row.
+No candidate may be evaluated on a different set, and any dataset revision invalidates prior rows
+rather than being merged with them.
+
+**Library sizes.** The issue requires small/medium local results, not only synthetic scale. Report
+three tiers separately and never average across them:
+
+| Tier | Indexed media | Represents |
+| --- | --- | --- |
+| Small | ~1k | A new or casual library |
+| Medium | ~10k | A realistic personal library — **the primary decision tier** |
+| Synthetic scale | 50k+ | Where index behaviour, not embedding quality, dominates |
+
+**Metrics per run.** Relevance: recall@5, recall@10, precision@10, MRR, empty-result rate. Latency:
+p50/p95/p99 for query embedding, retrieval, and rerank separately, plus end-to-end. Cost: peak
+worker RSS during indexing, wall-clock reindex time for the full corpus, per-image index time,
+stored bytes per media. Failure modes: qualitative, and mandatory — see below.
+
+**Repetitions.** Five runs per configuration, report median and spread. Latency on a laptop under
+thermal variance is noisy enough that a single run can invert an ordering.
+
+**Environment.** Record CPU model, RAM, `ML_MODE`, `ACCEL_MODE`, resolved device, Postgres version,
+pgvector version, and whether the machine was on battery. Runs on different hardware are not
+comparable and must not share a table.
+
+**Isolation.** `ML_MODE=mock` must never be used for relevance measurement — the mock embedder's
+fixed 0.45/0.55 blend is unrelated to the real weighting scheme and would produce meaningless
+numbers. Mock is appropriate only for exercising harness plumbing.
+
+**Failure-mode reporting is a required output, not a footnote.** For each variant, record the
+queries where it does worst, not only its aggregate. A variant that lifts mean recall while
+catastrophically failing one query class is worse for real users than its average suggests, and
+aggregates hide exactly that. Minimum categories to report per variant: text-heavy documents,
+faces/people, scenes with no salient object, queries with no correct answer in the corpus, and
+single-word queries.
+
+## Decision gates and rollback boundaries
+
+**Adopt an embedding variant** only when, at the medium tier: recall@10 improves by ≥ 3 points
+absolute over B0; no reported failure category regresses by more than 2 points; indexing time and
+worker RSS stay within the local-first budget; and reindex cost is stated in wall-clock terms for a
+10k library, because adoption implies a full reindex.
+
+**Adopt a ranking variant** when: precision@10 improves by ≥ 3 points with recall@10 not regressing;
+added rerank latency keeps end-to-end p95 under the roadmap's 500 ms target; and it introduces no
+new service.
+
+**Reject outright**, regardless of relevance: anything requiring a network service, anything
+requiring a model that cannot be fetched by the existing model-cache path, anything pushing p95
+end-to-end past 500 ms, and anything degrading `ML_MODE=mock` startup so the offline developer
+experience breaks.
+
+**Rollback boundaries**, by blast radius:
+
+| Change class | Rollback | Reversible without reindex? |
+| --- | --- | --- |
+| `hnsw.ef_search` tuning | Change one setting | Yes — runtime only |
+| Threshold / rerank logic (Track C) | Revert code | Yes — query-side only |
+| HNSW rebuild with new `m` / `ef_construction` | Rebuild index | Yes, but requires an index build window |
+| Embedding weights (B1–B4) | Revert code **and full reindex** | No |
+| Dual-vector storage (B5) | Revert code, migration, **and full reindex** | No |
+
+Anything below the line in that table needs a reindex to undo. That asymmetry, not the relevance
+delta alone, should drive how much evidence is demanded: an `ef_search` change can ship on thin
+evidence because it is free to revert; a schema change cannot.
+
+## Suggested sequence
+
+1. **Track A2 first**, immediately when #100 lands. It is one measurement, it validates or
+   invalidates the existing gate framing, and it may surface a live regression.
+2. Track A3/A4 — cheap, runtime-only, fully reversible.
+3. Track C — query-side only, no reindex, so iteration is fast.
+4. Track B1/B4 — establishes how much the text signals actually contribute before anything is tuned.
+5. Track B2/B3 — tuning, only if B1/B4 show headroom.
+6. Track B5 — last, and only with clear evidence, since it is the only irreversible schema change.
+
+Ordering rationale: everything reversible is measured before anything irreversible, and the
+cheapest measurement that could invalidate the plan runs first.
+
+## Out of scope
+
+- Shipping a production search rewrite.
+- Any private or cloud evaluation service; all measurement stays local.
+- Replacing SigLIP with a different backbone — that is a separate question with its own model-cache
+  and download-size implications, and it would invalidate every baseline here.
+- ANN engine selection beyond pgvector, which `vector-search-benchmarks.md` already owns.
+
+## Follow-ups this audit raises
+
+1. `docs/research/vector-search-benchmarks.md` describes exact scan as the current default and
+   frames its gates as "when to start ANN evaluation." An HNSW index has since landed. That
+   status needs correcting once Track A2 quantifies the actual recall.
+2. `docs/plans/partial/local-search-quality-roadmap.md` lists "no reranking stage" as a current
+   weakness; `search_ranking.py` exists. Worth correcting so the roadmap does not motivate work
+   that is partly done.
+3. No `hnsw.ef_search` is set anywhere. Even before benchmarking, making this an explicit,
+   documented setting rather than an inherited default is worthwhile — it is currently a
+   production-visible knob nobody chose.
+
+## References
+
+- `docs/research/vector-search-benchmarks.md` — index performance, ANN candidates, adoption gates
+- `docs/plans/partial/local-search-quality-roadmap.md` — target metrics and stage sequencing
+- `backend/src/find_api/workers/processors.py` — `generate_hybrid_embedding`, the B0 baseline
+- `backend/src/find_api/ml/search_ranking.py` — existing keyword/object boosting
+- `backend/src/find_api/routers/search.py` — retrieval query, static threshold, timing instrumentation
+- `backend/alembic/versions/add_hnsw_vector_index.py` — the HNSW index and its default parameters


### PR DESCRIPTION
## Summary

Two research deliverables for the issues assigned to me.

Closes #187. Addresses #99 as far as it can go while #100 is open.

## #187 — `docs/research/encrypted-byo-storage-sync.md`

Compares local export, filesystem/NAS targets, generic S3-compatible storage, and consumer drive providers on privacy, portability, cost, offline behaviour, and maintenance. Recommends a v1 boundary of **manual, encrypted, resumable snapshots to an S3-compatible endpoint or a filesystem path**, behind a `SyncTarget` interface kept deliberately separate from the live `StorageBackend`.

Two findings from the code shaped the design:

- The provider-neutral storage abstraction **has already landed** (`storage_abstract.py`, `storage_factory.py`, …), so the ADR's "not started" status line is stale.
- **The vault no longer encrypts media at rest.** Per the vault design note, 1.1.3 keeps hidden media in the ordinary private store behind password-gated sessions and migrates legacy AES-GCM blobs back to plaintext. It is an access-control boundary, not a cryptographic one — so the requirement that "vault blobs are encrypted locally before upload" **cannot be met by reusing vault behaviour**. Sync must own its own encryption layer.

Consumer drive providers are deferred with reasons: OAuth puts a Find-registered client identity in the trust path, which weakens the local-first promise beyond the engineering cost. Users wanting Drive/Dropbox can point the filesystem target at a provider-synced folder or an `rclone mount` — covers the case in v1 with zero provider code.

## #99 — `docs/research/search-retrieval-benchmark-plan.md`

#99 is blocked on #100 and says explicitly not to start comparisons until one labeled dataset can evaluate every candidate. So this adds everything that does **not** depend on the harness — baseline audit, candidate matrix, measurement protocol, adoption gates, rollback boundaries — and stops where real data is required. **No relevance numbers are included, deliberately.** When #100 lands the results table fills in without redesigning anything.

The baseline audit found three drifted assumptions, one of them material:

> An HNSW index has landed (`ix_media_vector_hnsw`) and search does `ORDER BY vector <=> … LIMIT`, so Find is very likely **already serving approximate results** — while `vector-search-benchmarks.md` still frames exact scan as "current default" and states recall is "perfect by definition". The index uses **default build parameters** and **`hnsw.ef_search` is never set anywhere** in the codebase.

Measuring deployed recall against exact search is therefore the highest-value single measurement available, and it is sequenced first — it may surface a live quality regression that predates #99.

Also corrects the record that reranking is *partial* rather than absent (`search_ranking.py` exists), and that latency instrumentation is already in place.

## Type of change

- [x] Documentation update

## Release impact

- [x] No user-visible release note needed

## How to test

Docs only, no code changes. Every cited file path and quoted status line was verified against the tree on this branch.

## Checklist

- [x] I linked the related issues
- [x] My PR is scoped to the assigned issues
- [x] I followed commit message conventions
- [x] I am not committing secrets or local artifacts
- [x] This PR targets `canary`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added research documentation for encrypted synchronization with customer-managed storage.
  * Added a benchmark plan for evaluating local search retrieval and ranking.
  * Updated the documentation index to include both research documents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->