### PR TITLE
feat: add offline search evaluation harness

### DIFF
--- a/backend/scripts/evaluate_search.py
+++ b/backend/scripts/evaluate_search.py
@@ -150,6 +150,12 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--out", default=None, help="also write JSON to this path")
     args = parser.parse_args(argv)
 
+    # Checked here so a bad value produces the same "error: ..." line as every
+    # other input problem, rather than a raw traceback out of run_dataset.
+    if args.repetitions < 1:
+        print("error: --repetitions must be at least 1", file=sys.stderr)
+        return 2
+
     try:
         dataset = load_dataset(args.dataset)
         if args.stub:

--- a/backend/scripts/evaluate_search.py
+++ b/backend/scripts/evaluate_search.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""
+Offline search evaluation harness - score retrieval against a labeled dataset.
+
+Runs every query in a dataset through a retriever, then reports Precision@K,
+Recall@K, MRR, empty-result rate, and per-query latency. Output is JSON so two
+runs can be diffed directly.
+
+Everything stays on this machine. Nothing uploads images, embeddings, labels,
+or results, and datasets reference media by id only - never image bytes.
+
+Retrievers:
+
+  --stub RUN.json   Replay canned rankings. No database, no models, no photos.
+                    This is what the smoke fixture and CI use.
+
+  --api             Query a running Find instance over HTTP. Needs a live
+                    stack with an indexed library. Media ids in the dataset
+                    must be the media_id values that instance returns.
+
+Usage (from the backend directory):
+
+    # Smoke: proves the harness itself works
+    uv run python scripts/evaluate_search.py \
+        --dataset tests/fixtures/search_eval/smoke_dataset_v1.json \
+        --stub tests/fixtures/search_eval/smoke_run_v1.json
+
+    # Against a live local instance
+    uv run python scripts/evaluate_search.py \
+        --dataset my_dataset.json --api --base-url http://localhost:8000
+
+    # Machine-readable, for before/after comparison
+    uv run python scripts/evaluate_search.py ... --json --out baseline.json
+
+Note: results from ML_MODE=mock are meaningless as relevance measurements.
+The mock embedder is unrelated to the real weighting scheme. Use mock only to
+check that the plumbing runs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Sequence
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from find_api.evaluation.dataset import (  # noqa: E402
+    DatasetError,
+    EvalQuery,
+    load_dataset,
+    load_stub_run,
+)
+from find_api.evaluation.runner import (  # noqa: E402
+    run_dataset,
+    score_outcomes,
+    stub_retriever,
+)
+
+
+def _api_retriever(base_url: str, timeout: float, token: str | None):
+    """Retriever that queries a running instance's /api/search endpoint."""
+    import urllib.error
+    import urllib.parse
+    import urllib.request
+
+    def _retrieve(query: EvalQuery, k: int) -> Sequence[str]:
+        params = urllib.parse.urlencode({"q": query.query, "limit": k})
+        url = f"{base_url.rstrip('/')}/api/search?{params}"
+        request = urllib.request.Request(url)
+        if token:
+            request.add_header("Authorization", f"Bearer {token}")
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+        return [str(row["media_id"]) for row in payload.get("results", [])]
+
+    return _retrieve
+
+
+def _print_human(report: dict) -> None:
+    print(f"Dataset       : {report['dataset_id']}")
+    print(f"Queries       : {report['query_count']}")
+    print()
+
+    header = f"{'K':>4}  {'PRECISION@K':>12}  {'RECALL@K':>10}"
+    print(header)
+    print("-" * len(header))
+    for k, values in sorted(
+        report["metrics"]["at_k"].items(), key=lambda kv: int(kv[0])
+    ):
+        print(f"{k:>4}  {values['precision']:>12.4f}  {values['recall']:>10.4f}")
+
+    metrics = report["metrics"]
+    print()
+    print(f"MRR                : {metrics['mrr']:.4f}")
+    print(f"Empty-result rate  : {metrics['empty_result_rate']:.4f}")
+    print(f"Retriever errors   : {metrics['error_count']}")
+
+    latency = report["latency"]
+    print()
+    print(
+        f"Latency (ms)       : p50 {latency['p50_ms']}  p95 {latency['p95_ms']}  "
+        f"p99 {latency['p99_ms']}  mean {latency['mean_ms']}"
+    )
+
+    if report["by_category"]:
+        print()
+        print(f"{'CATEGORY':<18} {'N':>4}  {'MRR':>8}")
+        print("-" * 32)
+        for name, data in report["by_category"].items():
+            print(f"{name:<18} {data['count']:>4}  {data['mrr']:>8.4f}")
+
+    if report["worst_cases"]:
+        print()
+        print(f"Worst cases ({len(report['worst_cases'])}):")
+        for case in report["worst_cases"]:
+            detail = f" [{case['error']}]" if case["error"] else ""
+            print(
+                f"  - {case['query_id']}: RR={case['reciprocal_rank']:.2f} "
+                f"returned={case['returned']}{detail}"
+            )
+
+    if report["dataset_warnings"]:
+        print()
+        print("Dataset warnings:")
+        for warning in report["dataset_warnings"]:
+            print(f"  ! {warning}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Score Find's search retrieval against a labeled dataset.",
+    )
+    parser.add_argument("--dataset", required=True, help="path to a dataset JSON file")
+    source = parser.add_mutually_exclusive_group(required=True)
+    source.add_argument("--stub", metavar="RUN", help="replay canned rankings")
+    source.add_argument("--api", action="store_true", help="query a live instance")
+    parser.add_argument("--base-url", default="http://localhost:8000")
+    parser.add_argument("--token", default=None, help="bearer token for --api")
+    parser.add_argument("--timeout", type=float, default=30.0)
+    parser.add_argument(
+        "--repetitions",
+        type=int,
+        default=1,
+        help="re-run each query and keep the median latency",
+    )
+    parser.add_argument("--json", action="store_true", help="emit JSON only")
+    parser.add_argument("--out", default=None, help="also write JSON to this path")
+    args = parser.parse_args(argv)
+
+    try:
+        dataset = load_dataset(args.dataset)
+        if args.stub:
+            retrieve = stub_retriever(load_stub_run(args.stub))
+        else:
+            retrieve = _api_retriever(args.base_url, args.timeout, args.token)
+    except DatasetError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+    outcomes = run_dataset(dataset, retrieve, repetitions=args.repetitions)
+    report = score_outcomes(dataset, outcomes)
+
+    if args.json:
+        print(json.dumps(report, indent=2))
+    else:
+        _print_human(report)
+
+    if args.out:
+        Path(args.out).write_text(json.dumps(report, indent=2), encoding="utf-8")
+        if not args.json:
+            print(f"\nWrote {args.out}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/src/find_api/evaluation/__init__.py
+++ b/backend/src/find_api/evaluation/__init__.py
@@ -1,0 +1,40 @@
+"""Offline search evaluation harness.
+
+Local-only, by construction: nothing here uploads images, embeddings, labels,
+or results. Datasets carry media ids the operator chose, never image bytes.
+
+See ``docs/guides/search-evaluation.md`` for dataset authoring guidance and
+``backend/scripts/evaluate_search.py`` for the command-line entry point.
+"""
+
+from find_api.evaluation.dataset import (
+    SCHEMA_VERSION,
+    DatasetError,
+    EvalDataset,
+    EvalQuery,
+    load_dataset,
+    load_stub_run,
+    parse_dataset,
+)
+from find_api.evaluation.runner import (
+    RESULT_SCHEMA_VERSION,
+    QueryOutcome,
+    run_dataset,
+    score_outcomes,
+    stub_retriever,
+)
+
+__all__ = [
+    "RESULT_SCHEMA_VERSION",
+    "SCHEMA_VERSION",
+    "DatasetError",
+    "EvalDataset",
+    "EvalQuery",
+    "QueryOutcome",
+    "load_dataset",
+    "load_stub_run",
+    "parse_dataset",
+    "run_dataset",
+    "score_outcomes",
+    "stub_retriever",
+]

--- a/backend/src/find_api/evaluation/dataset.py
+++ b/backend/src/find_api/evaluation/dataset.py
@@ -1,0 +1,240 @@
+"""Versioned labeled-query dataset for offline search evaluation.
+
+A dataset maps queries to the media that *should* come back for them. It is
+plain JSON so it can be diffed, reviewed, and versioned alongside code, and it
+carries no image bytes — only stable media ids the operator chose.
+
+Format (``schema_version: 1``)::
+
+    {
+      "schema_version": 1,
+      "dataset_id": "smoke-v1",
+      "description": "what this set is for",
+      "k_values": [5, 10],
+      "queries": [
+        {
+          "id": "q-bicycle",
+          "query": "red bicycle",
+          "relevant": ["img-001", "img-004"],
+          "category": "object",          // optional, for per-slice reporting
+          "notes": "optional free text"
+        }
+      ]
+    }
+
+``dataset_id`` is recorded in every result file so a set of numbers can never
+be silently compared against a different dataset revision. Bump it whenever
+queries or relevance judgements change — revisions are not mergeable with
+their predecessors.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = 1
+
+
+class DatasetError(ValueError):
+    """Raised when a dataset file is missing, malformed, or self-inconsistent."""
+
+
+@dataclass(frozen=True)
+class EvalQuery:
+    id: str
+    query: str
+    relevant: tuple[str, ...]
+    category: str | None = None
+    notes: str | None = None
+
+
+@dataclass(frozen=True)
+class EvalDataset:
+    dataset_id: str
+    k_values: tuple[int, ...]
+    queries: tuple[EvalQuery, ...]
+    description: str = ""
+    warnings: tuple[str, ...] = field(default=())
+
+    @property
+    def max_k(self) -> int:
+        return max(self.k_values)
+
+
+def _require(condition: bool, message: str) -> None:
+    if not condition:
+        raise DatasetError(message)
+
+
+def parse_dataset(payload: Any, *, source: str = "<memory>") -> EvalDataset:
+    """Validate a decoded dataset payload and return it as an EvalDataset.
+
+    Every failure is a ``DatasetError`` naming the offending field, because a
+    silently-accepted bad dataset produces plausible numbers that are wrong,
+    which is worse than a crash.
+    """
+    _require(isinstance(payload, dict), f"{source}: top level must be an object")
+
+    version = payload.get("schema_version")
+    _require(
+        version == SCHEMA_VERSION,
+        f"{source}: unsupported schema_version {version!r}; "
+        f"this build understands {SCHEMA_VERSION}",
+    )
+
+    dataset_id = payload.get("dataset_id")
+    _require(
+        isinstance(dataset_id, str) and dataset_id.strip(),
+        f"{source}: dataset_id must be a non-empty string",
+    )
+
+    raw_k = payload.get("k_values", [10])
+    _require(
+        isinstance(raw_k, list) and raw_k,
+        f"{source}: k_values must be a non-empty list",
+    )
+    for value in raw_k:
+        _require(
+            isinstance(value, int) and not isinstance(value, bool) and value > 0,
+            f"{source}: k_values entries must be positive integers, got {value!r}",
+        )
+    k_values = tuple(sorted(set(raw_k)))
+
+    raw_queries = payload.get("queries")
+    _require(
+        isinstance(raw_queries, list) and raw_queries,
+        f"{source}: queries must be a non-empty list",
+    )
+
+    seen_ids: set[str] = set()
+    queries: list[EvalQuery] = []
+    warnings: list[str] = []
+
+    for index, raw in enumerate(raw_queries):
+        where = f"{source}: queries[{index}]"
+        _require(isinstance(raw, dict), f"{where} must be an object")
+
+        query_id = raw.get("id")
+        _require(
+            isinstance(query_id, str) and query_id.strip(),
+            f"{where}.id must be a non-empty string",
+        )
+        _require(query_id not in seen_ids, f"{where}.id duplicates {query_id!r}")
+        seen_ids.add(query_id)
+
+        text = raw.get("query")
+        _require(
+            isinstance(text, str) and text.strip(),
+            f"{where}.query must be a non-empty string",
+        )
+
+        relevant = raw.get("relevant")
+        _require(
+            isinstance(relevant, list) and relevant,
+            f"{where}.relevant must be a non-empty list; a query with no correct "
+            "answer belongs in a negative-case set, not here",
+        )
+        for item in relevant:
+            _require(
+                isinstance(item, str) and item.strip(),
+                f"{where}.relevant entries must be non-empty strings, got {item!r}",
+            )
+        _require(
+            len(set(relevant)) == len(relevant),
+            f"{where}.relevant contains duplicate ids",
+        )
+
+        # Not fatal, but recall@k is capped below 1.0 here and that silently
+        # drags the aggregate down, so it must be visible.
+        smallest_k = min(k_values)
+        if len(relevant) > smallest_k:
+            warnings.append(
+                f"{where} ({query_id!r}) has {len(relevant)} relevant items but the "
+                f"smallest k is {smallest_k}; recall@{smallest_k} cannot exceed "
+                f"{smallest_k / len(relevant):.2f} for this query"
+            )
+
+        category = raw.get("category")
+        _require(
+            category is None or isinstance(category, str),
+            f"{where}.category must be a string when present",
+        )
+        notes = raw.get("notes")
+        _require(
+            notes is None or isinstance(notes, str),
+            f"{where}.notes must be a string when present",
+        )
+
+        queries.append(
+            EvalQuery(
+                id=query_id,
+                query=text,
+                relevant=tuple(relevant),
+                category=category,
+                notes=notes,
+            )
+        )
+
+    description = payload.get("description", "")
+    _require(isinstance(description, str), f"{source}: description must be a string")
+
+    return EvalDataset(
+        dataset_id=dataset_id,
+        k_values=k_values,
+        queries=tuple(queries),
+        description=description,
+        warnings=tuple(warnings),
+    )
+
+
+def load_dataset(path: str | Path) -> EvalDataset:
+    """Read and validate a dataset file."""
+    file_path = Path(path)
+    if not file_path.is_file():
+        raise DatasetError(f"dataset not found: {file_path}")
+    try:
+        payload = json.loads(file_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise DatasetError(f"{file_path}: invalid JSON — {exc}") from exc
+    return parse_dataset(payload, source=str(file_path))
+
+
+def load_stub_run(path: str | Path) -> dict[str, list[str]]:
+    """Read a canned ranking file used by the stub retriever.
+
+    Shape: ``{"schema_version": 1, "run_id": "...", "rankings": {query_id: [id, …]}}``.
+    This exists so the smoke fixture can exercise the whole harness with no
+    database, no models, and no private photos.
+    """
+    file_path = Path(path)
+    if not file_path.is_file():
+        raise DatasetError(f"stub run not found: {file_path}")
+    try:
+        payload = json.loads(file_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise DatasetError(f"{file_path}: invalid JSON — {exc}") from exc
+
+    _require(isinstance(payload, dict), f"{file_path}: top level must be an object")
+    _require(
+        payload.get("schema_version") == SCHEMA_VERSION,
+        f"{file_path}: unsupported schema_version {payload.get('schema_version')!r}",
+    )
+    rankings = payload.get("rankings")
+    _require(isinstance(rankings, dict), f"{file_path}: rankings must be an object")
+
+    out: dict[str, list[str]] = {}
+    for query_id, ranking in rankings.items():
+        _require(
+            isinstance(ranking, list),
+            f"{file_path}: rankings[{query_id!r}] must be a list",
+        )
+        for item in ranking:
+            _require(
+                isinstance(item, str),
+                f"{file_path}: rankings[{query_id!r}] entries must be strings",
+            )
+        out[query_id] = list(ranking)
+    return out

--- a/backend/src/find_api/evaluation/metrics.py
+++ b/backend/src/find_api/evaluation/metrics.py
@@ -1,0 +1,132 @@
+"""Retrieval scoring math for the offline search evaluation harness.
+
+Pure functions over ranked id lists. Nothing here touches the database, the
+models, or the network, so the scoring can be unit-tested exactly and reused
+by any retriever.
+
+Conventions, stated explicitly because they change the numbers:
+
+- ``precision_at_k`` divides by ``k``, not by the number of results returned.
+  A query that returns 3 results for k=10 is penalised for the 7 it did not
+  return. This is the standard definition and it keeps runs with different
+  result counts comparable.
+- ``recall_at_k`` divides by the number of relevant items for that query, so a
+  query with more relevant items than ``k`` cannot reach 1.0. Datasets should
+  keep relevant sets smaller than the smallest ``k`` being reported, and the
+  loader warns when they do not.
+- Ranks are 1-based, matching how MRR is normally defined.
+- Duplicate ids in a ranking are counted once, at their first position.
+"""
+
+from __future__ import annotations
+
+from statistics import median
+from typing import Iterable, Sequence
+
+
+def _dedupe(ranking: Sequence[str]) -> list[str]:
+    """First occurrence wins, order preserved."""
+    seen: set[str] = set()
+    out: list[str] = []
+    for item in ranking:
+        if item not in seen:
+            seen.add(item)
+            out.append(item)
+    return out
+
+
+def precision_at_k(ranking: Sequence[str], relevant: Iterable[str], k: int) -> float:
+    """Fraction of the top ``k`` slots filled by a relevant item."""
+    if k <= 0:
+        raise ValueError("k must be positive")
+    relevant_set = set(relevant)
+    if not relevant_set:
+        return 0.0
+    top = _dedupe(ranking)[:k]
+    hits = sum(1 for item in top if item in relevant_set)
+    return hits / k
+
+
+def recall_at_k(ranking: Sequence[str], relevant: Iterable[str], k: int) -> float:
+    """Fraction of the relevant items that appear in the top ``k``."""
+    if k <= 0:
+        raise ValueError("k must be positive")
+    relevant_set = set(relevant)
+    if not relevant_set:
+        return 0.0
+    top = _dedupe(ranking)[:k]
+    hits = sum(1 for item in top if item in relevant_set)
+    return hits / len(relevant_set)
+
+
+def reciprocal_rank(ranking: Sequence[str], relevant: Iterable[str]) -> float:
+    """``1 / rank`` of the first relevant hit, or 0.0 if there is none."""
+    relevant_set = set(relevant)
+    if not relevant_set:
+        return 0.0
+    for index, item in enumerate(_dedupe(ranking), start=1):
+        if item in relevant_set:
+            return 1.0 / index
+    return 0.0
+
+
+def mean_reciprocal_rank(
+    rankings: Sequence[Sequence[str]], relevants: Sequence[Iterable[str]]
+) -> float:
+    """MRR across queries. Queries with no relevant hit contribute 0.0."""
+    if len(rankings) != len(relevants):
+        raise ValueError("rankings and relevants must be the same length")
+    if not rankings:
+        return 0.0
+    total = sum(
+        reciprocal_rank(ranking, relevant)
+        for ranking, relevant in zip(rankings, relevants)
+    )
+    return total / len(rankings)
+
+
+def empty_result_rate(rankings: Sequence[Sequence[str]]) -> float:
+    """Fraction of queries that returned nothing at all."""
+    if not rankings:
+        return 0.0
+    return sum(1 for ranking in rankings if len(ranking) == 0) / len(rankings)
+
+
+def percentile(values: Sequence[float], pct: float) -> float:
+    """Nearest-rank percentile.
+
+    Deliberately not interpolated: evaluation runs are small (tens of queries),
+    and an interpolated p95 over 20 samples invents a number that no query
+    actually produced. Nearest-rank always returns an observed value.
+    """
+    if not values:
+        return 0.0
+    if not 0 < pct <= 100:
+        raise ValueError("pct must be in (0, 100]")
+    ordered = sorted(values)
+    # Nearest-rank: ceil(pct/100 * n), 1-based, clamped to the last element.
+    rank = -(-int(pct * len(ordered)) // 100) or 1
+    return ordered[min(rank, len(ordered)) - 1]
+
+
+def latency_summary(samples: Sequence[float]) -> dict[str, float]:
+    """p50/p95/p99, mean, min, and max over per-query latencies in ms."""
+    if not samples:
+        return {
+            "count": 0,
+            "mean_ms": 0.0,
+            "p50_ms": 0.0,
+            "p95_ms": 0.0,
+            "p99_ms": 0.0,
+            "min_ms": 0.0,
+            "max_ms": 0.0,
+        }
+    return {
+        "count": len(samples),
+        "mean_ms": round(sum(samples) / len(samples), 2),
+        "p50_ms": round(median(samples), 2),
+        "p95_ms": round(percentile(samples, 95), 2),
+        "p99_ms": round(percentile(samples, 99), 2),
+        "min_ms": round(min(samples), 2),
+        "max_ms": round(max(samples), 2),
+    }

--- a/backend/src/find_api/evaluation/metrics.py
+++ b/backend/src/find_api/evaluation/metrics.py
@@ -20,7 +20,6 @@ Conventions, stated explicitly because they change the numbers:
 
 from __future__ import annotations
 
-from statistics import median
 from typing import Iterable, Sequence
 
 
@@ -124,7 +123,10 @@ def latency_summary(samples: Sequence[float]) -> dict[str, float]:
     return {
         "count": len(samples),
         "mean_ms": round(sum(samples) / len(samples), 2),
-        "p50_ms": round(median(samples), 2),
+        # percentile(), not statistics.median(): median averages the two middle
+        # values on an even-length sample, which would make p50 the one
+        # percentile here that reports a number no query actually produced.
+        "p50_ms": round(percentile(samples, 50), 2),
         "p95_ms": round(percentile(samples, 95), 2),
         "p99_ms": round(percentile(samples, 99), 2),
         "min_ms": round(min(samples), 2),

--- a/backend/src/find_api/evaluation/runner.py
+++ b/backend/src/find_api/evaluation/runner.py
@@ -5,8 +5,10 @@ path is identical whether the rankings came from a canned fixture, a live
 search endpoint, or a future experimental branch. Only then are two runs
 actually comparable.
 
-A retriever is any callable ``(query_text, k) -> Sequence[str]`` returning
-ranked media ids, most relevant first.
+A retriever is any callable ``(EvalQuery, k) -> Sequence[str]`` returning
+ranked media ids, most relevant first. It receives the whole query object, not
+just the text, so a retriever can key off the query id (as the stub does) or
+off ``category`` without a second lookup.
 """
 
 from __future__ import annotations
@@ -25,7 +27,7 @@ from find_api.evaluation.metrics import (
     reciprocal_rank,
 )
 
-Retriever = Callable[[str, int], Sequence[str]]
+Retriever = Callable[[EvalQuery, int], Sequence[str]]
 
 RESULT_SCHEMA_VERSION = 1
 
@@ -88,6 +90,10 @@ def run_dataset(
             if attempt == 0:
                 ranking = result
             if error:
+                # Discard any ranking an earlier repetition produced. A query
+                # that failed on some attempts must score as a miss, not keep
+                # credit for precision, recall, and MRR from a lucky first run.
+                ranking = []
                 break
 
         samples.sort()

--- a/backend/src/find_api/evaluation/runner.py
+++ b/backend/src/find_api/evaluation/runner.py
@@ -1,0 +1,172 @@
+"""Run a labeled dataset against a retriever and score the result.
+
+The retriever is injected, which is the whole point of the split: the scoring
+path is identical whether the rankings came from a canned fixture, a live
+search endpoint, or a future experimental branch. Only then are two runs
+actually comparable.
+
+A retriever is any callable ``(query_text, k) -> Sequence[str]`` returning
+ranked media ids, most relevant first.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import Any, Callable, Mapping, Sequence
+
+from find_api.evaluation.dataset import EvalDataset, EvalQuery
+from find_api.evaluation.metrics import (
+    empty_result_rate,
+    latency_summary,
+    mean_reciprocal_rank,
+    precision_at_k,
+    recall_at_k,
+    reciprocal_rank,
+)
+
+Retriever = Callable[[str, int], Sequence[str]]
+
+RESULT_SCHEMA_VERSION = 1
+
+
+@dataclass(frozen=True)
+class QueryOutcome:
+    query: EvalQuery
+    ranking: tuple[str, ...]
+    latency_ms: float
+    error: str | None = None
+
+
+def stub_retriever(
+    rankings: Mapping[str, Sequence[str]],
+) -> Callable[[EvalQuery, int], Sequence[str]]:
+    """Retriever backed by canned rankings keyed by query id.
+
+    Used by the smoke fixture so the harness is exercised end to end with no
+    database, no model weights, and no private media.
+    """
+
+    def _retrieve(query: EvalQuery, k: int) -> Sequence[str]:
+        return list(rankings.get(query.id, []))[:k]
+
+    return _retrieve
+
+
+def run_dataset(
+    dataset: EvalDataset,
+    retrieve: Callable[[EvalQuery, int], Sequence[str]],
+    *,
+    repetitions: int = 1,
+) -> list[QueryOutcome]:
+    """Execute every query, timing each call.
+
+    ``repetitions`` re-runs each query and keeps the median latency; rankings
+    are taken from the first run. Retrieval is expected to be deterministic,
+    so repeating it only sharpens the timing, never the relevance.
+    """
+    if repetitions < 1:
+        raise ValueError("repetitions must be at least 1")
+
+    k = dataset.max_k
+    outcomes: list[QueryOutcome] = []
+
+    for query in dataset.queries:
+        samples: list[float] = []
+        ranking: Sequence[str] = []
+        error: str | None = None
+
+        for attempt in range(repetitions):
+            started = time.perf_counter()
+            try:
+                result = retrieve(query, k)
+            except Exception as exc:  # noqa: BLE001 — one bad query must not
+                # abort the run; it is recorded and scored as a miss.
+                error = f"{type(exc).__name__}: {exc}"
+                result = []
+            samples.append((time.perf_counter() - started) * 1000)
+            if attempt == 0:
+                ranking = result
+            if error:
+                break
+
+        samples.sort()
+        outcomes.append(
+            QueryOutcome(
+                query=query,
+                ranking=tuple(ranking),
+                latency_ms=samples[len(samples) // 2],
+                error=error,
+            )
+        )
+
+    return outcomes
+
+
+def score_outcomes(
+    dataset: EvalDataset, outcomes: Sequence[QueryOutcome]
+) -> dict[str, Any]:
+    """Aggregate outcomes into a machine-readable result document."""
+    rankings = [list(o.ranking) for o in outcomes]
+    relevants = [list(o.query.relevant) for o in outcomes]
+
+    per_k: dict[str, dict[str, float]] = {}
+    for k in dataset.k_values:
+        precisions = [precision_at_k(o.ranking, o.query.relevant, k) for o in outcomes]
+        recalls = [recall_at_k(o.ranking, o.query.relevant, k) for o in outcomes]
+        per_k[str(k)] = {
+            "precision": round(sum(precisions) / len(precisions), 4)
+            if precisions
+            else 0.0,
+            "recall": round(sum(recalls) / len(recalls), 4) if recalls else 0.0,
+        }
+
+    # Per-category slices, because an aggregate hides a category that collapsed.
+    by_category: dict[str, dict[str, Any]] = {}
+    for outcome in outcomes:
+        key = outcome.query.category or "uncategorized"
+        by_category.setdefault(key, {"count": 0, "reciprocal_ranks": []})
+        by_category[key]["count"] += 1
+        by_category[key]["reciprocal_ranks"].append(
+            reciprocal_rank(outcome.ranking, outcome.query.relevant)
+        )
+    category_summary = {
+        name: {
+            "count": data["count"],
+            "mrr": round(sum(data["reciprocal_ranks"]) / data["count"], 4),
+        }
+        for name, data in sorted(by_category.items())
+    }
+
+    failures = [
+        {
+            "query_id": o.query.id,
+            "query": o.query.query,
+            "category": o.query.category,
+            "reciprocal_rank": round(reciprocal_rank(o.ranking, o.query.relevant), 4),
+            "returned": len(o.ranking),
+            "error": o.error,
+        }
+        for o in outcomes
+        if reciprocal_rank(o.ranking, o.query.relevant) == 0.0 or o.error
+    ]
+
+    return {
+        "result_schema_version": RESULT_SCHEMA_VERSION,
+        "dataset_id": dataset.dataset_id,
+        "query_count": len(outcomes),
+        "k_values": list(dataset.k_values),
+        "metrics": {
+            "at_k": per_k,
+            "mrr": round(mean_reciprocal_rank(rankings, relevants), 4),
+            "empty_result_rate": round(empty_result_rate(rankings), 4),
+            "error_count": sum(1 for o in outcomes if o.error),
+        },
+        "latency": latency_summary([o.latency_ms for o in outcomes]),
+        "by_category": category_summary,
+        # Worst cases are a required output, not a footnote: a variant that
+        # lifts the mean while destroying one query class is worse for users
+        # than its average suggests.
+        "worst_cases": sorted(failures, key=lambda f: f["query_id"]),
+        "dataset_warnings": list(dataset.warnings),
+    }

--- a/backend/tests/fixtures/search_eval/smoke_dataset_v1.json
+++ b/backend/tests/fixtures/search_eval/smoke_dataset_v1.json
@@ -1,0 +1,43 @@
+{
+  "schema_version": 1,
+  "dataset_id": "smoke-v1",
+  "description": "Deterministic smoke dataset for the search evaluation harness. The media ids are synthetic and refer to no real image, so this file can live in the repository and run in CI. It exists to prove the harness scores correctly end to end, and carries no claim about Find's retrieval quality.",
+  "k_values": [5, 10],
+  "queries": [
+    {
+      "id": "q-object-bicycle",
+      "query": "red bicycle leaning on a wall",
+      "relevant": ["smoke-001", "smoke-002"],
+      "category": "object",
+      "notes": "Perfect case: both relevant ids rank first in the smoke run."
+    },
+    {
+      "id": "q-document-invoice",
+      "query": "invoice from March",
+      "relevant": ["smoke-010"],
+      "category": "document",
+      "notes": "Text-heavy case: the single relevant id ranks third."
+    },
+    {
+      "id": "q-scene-sunset",
+      "query": "sunset over the sea",
+      "relevant": ["smoke-020", "smoke-021"],
+      "category": "scene",
+      "notes": "Partial case: one of two relevant ids is retrieved."
+    },
+    {
+      "id": "q-miss-unicorn",
+      "query": "a unicorn in the kitchen",
+      "relevant": ["smoke-030"],
+      "category": "hard-negative",
+      "notes": "Deliberate miss: nothing relevant is retrieved, so this query must land in worst_cases and drag MRR down."
+    },
+    {
+      "id": "q-empty-response",
+      "query": "query that returns nothing at all",
+      "relevant": ["smoke-040"],
+      "category": "hard-negative",
+      "notes": "Exercises the empty-result path: the retriever returns zero rows."
+    }
+  ]
+}

--- a/backend/tests/fixtures/search_eval/smoke_run_v1.json
+++ b/backend/tests/fixtures/search_eval/smoke_run_v1.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "run_id": "smoke-run-v1",
+  "description": "Canned rankings for smoke-v1, consumed by the stub retriever. Chosen so every metric has a non-trivial, hand-checkable value: one perfect query, one mid-rank hit, one partial hit, one total miss, and one empty response.",
+  "rankings": {
+    "q-object-bicycle": ["smoke-001", "smoke-002", "smoke-003", "smoke-004", "smoke-005"],
+    "q-document-invoice": ["smoke-011", "smoke-012", "smoke-010", "smoke-013", "smoke-014"],
+    "q-scene-sunset": ["smoke-022", "smoke-020", "smoke-023", "smoke-024", "smoke-025"],
+    "q-miss-unicorn": ["smoke-031", "smoke-032", "smoke-033"],
+    "q-empty-response": []
+  }
+}

--- a/backend/tests/test_search_eval.py
+++ b/backend/tests/test_search_eval.py
@@ -1,0 +1,287 @@
+"""Tests for the offline search evaluation harness.
+
+Two things are covered, because they are the two ways a harness lies:
+the scoring math being subtly wrong, and a malformed dataset being accepted
+and producing plausible-but-meaningless numbers.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from find_api.evaluation.dataset import (
+    SCHEMA_VERSION,
+    DatasetError,
+    load_dataset,
+    load_stub_run,
+    parse_dataset,
+)
+from find_api.evaluation.metrics import (
+    empty_result_rate,
+    latency_summary,
+    mean_reciprocal_rank,
+    percentile,
+    precision_at_k,
+    recall_at_k,
+    reciprocal_rank,
+)
+from find_api.evaluation.runner import run_dataset, score_outcomes, stub_retriever
+
+FIXTURES = "tests/fixtures/search_eval"
+
+
+def _dataset(**overrides):
+    payload = {
+        "schema_version": SCHEMA_VERSION,
+        "dataset_id": "unit",
+        "k_values": [5],
+        "queries": [{"id": "q1", "query": "a cat", "relevant": ["m1"]}],
+    }
+    payload.update(overrides)
+    return payload
+
+
+class TestPrecisionAtK:
+    def test_divides_by_k_not_by_results_returned(self):
+        # Two hits in a 3-long ranking, scored at k=10, is 0.2 — not 0.667.
+        # Returning fewer results than k is a failure to fill the slots.
+        assert precision_at_k(["a", "b", "c"], {"a", "b"}, 10) == pytest.approx(0.2)
+
+    def test_only_counts_the_top_k(self):
+        assert precision_at_k(["x", "y", "a"], {"a"}, 2) == 0.0
+        assert precision_at_k(["x", "y", "a"], {"a"}, 3) == pytest.approx(1 / 3)
+
+    def test_duplicates_count_once_at_first_position(self):
+        assert precision_at_k(["a", "a", "a"], {"a"}, 3) == pytest.approx(1 / 3)
+
+    def test_empty_relevant_set_scores_zero(self):
+        assert precision_at_k(["a"], set(), 5) == 0.0
+
+    def test_rejects_non_positive_k(self):
+        with pytest.raises(ValueError):
+            precision_at_k(["a"], {"a"}, 0)
+
+
+class TestRecallAtK:
+    def test_divides_by_relevant_count(self):
+        assert recall_at_k(["a", "b", "c"], {"a", "b"}, 10) == pytest.approx(1.0)
+        assert recall_at_k(["a", "z"], {"a", "b"}, 10) == pytest.approx(0.5)
+
+    def test_capped_by_k(self):
+        # Three relevant items but only two slots: 2/3 is the ceiling.
+        assert recall_at_k(["a", "b", "c"], {"a", "b", "c"}, 2) == pytest.approx(2 / 3)
+
+    def test_duplicates_do_not_inflate(self):
+        assert recall_at_k(["a", "a"], {"a", "b"}, 5) == pytest.approx(0.5)
+
+
+class TestReciprocalRank:
+    def test_is_one_based(self):
+        assert reciprocal_rank(["a"], {"a"}) == 1.0
+        assert reciprocal_rank(["x", "a"], {"a"}) == pytest.approx(0.5)
+        assert reciprocal_rank(["x", "y", "a"], {"a"}) == pytest.approx(1 / 3)
+
+    def test_uses_first_relevant_hit(self):
+        assert reciprocal_rank(["x", "a", "b"], {"a", "b"}) == pytest.approx(0.5)
+
+    def test_no_hit_is_zero(self):
+        assert reciprocal_rank(["x", "y"], {"a"}) == 0.0
+        assert reciprocal_rank([], {"a"}) == 0.0
+
+    def test_mean_counts_misses_as_zero(self):
+        # (1.0 + 0.0) / 2 — a missed query must drag the mean down, not be
+        # skipped, or MRR silently rewards returning nothing.
+        assert mean_reciprocal_rank([["a"], ["x"]], [{"a"}, {"b"}]) == pytest.approx(
+            0.5
+        )
+
+    def test_mean_rejects_mismatched_lengths(self):
+        with pytest.raises(ValueError):
+            mean_reciprocal_rank([["a"]], [{"a"}, {"b"}])
+
+
+class TestEmptyResultRate:
+    def test_counts_only_zero_length_rankings(self):
+        assert empty_result_rate([["a"], [], ["b"], []]) == pytest.approx(0.5)
+        assert empty_result_rate([["a"]]) == 0.0
+        assert empty_result_rate([]) == 0.0
+
+
+class TestPercentileAndLatency:
+    def test_nearest_rank_returns_an_observed_value(self):
+        values = [10.0, 20.0, 30.0, 40.0]
+        assert percentile(values, 50) in values
+        assert percentile(values, 100) == 40.0
+        assert percentile(values, 1) == 10.0
+
+    def test_rejects_out_of_range_percentile(self):
+        with pytest.raises(ValueError):
+            percentile([1.0], 0)
+        with pytest.raises(ValueError):
+            percentile([1.0], 101)
+
+    def test_summary_of_empty_samples_is_zeroed_not_an_error(self):
+        summary = latency_summary([])
+        assert summary["count"] == 0
+        assert summary["p95_ms"] == 0.0
+
+    def test_summary_reports_expected_fields(self):
+        summary = latency_summary([5.0, 15.0, 25.0])
+        assert summary["count"] == 3
+        assert summary["min_ms"] == 5.0
+        assert summary["max_ms"] == 25.0
+        assert summary["p50_ms"] == 15.0
+
+
+class TestDatasetValidation:
+    def test_accepts_a_minimal_valid_dataset(self):
+        dataset = parse_dataset(_dataset())
+        assert dataset.dataset_id == "unit"
+        assert dataset.max_k == 5
+        assert dataset.queries[0].relevant == ("m1",)
+
+    def test_rejects_unknown_schema_version(self):
+        with pytest.raises(DatasetError, match="schema_version"):
+            parse_dataset(_dataset(schema_version=99))
+
+    def test_rejects_non_object_payload(self):
+        with pytest.raises(DatasetError, match="top level"):
+            parse_dataset([1, 2, 3])
+
+    def test_rejects_missing_dataset_id(self):
+        payload = _dataset()
+        del payload["dataset_id"]
+        with pytest.raises(DatasetError, match="dataset_id"):
+            parse_dataset(payload)
+
+    def test_rejects_empty_queries(self):
+        with pytest.raises(DatasetError, match="queries"):
+            parse_dataset(_dataset(queries=[]))
+
+    def test_rejects_duplicate_query_ids(self):
+        with pytest.raises(DatasetError, match="duplicates"):
+            parse_dataset(
+                _dataset(
+                    queries=[
+                        {"id": "q1", "query": "a", "relevant": ["m1"]},
+                        {"id": "q1", "query": "b", "relevant": ["m2"]},
+                    ]
+                )
+            )
+
+    def test_rejects_empty_relevant_list(self):
+        with pytest.raises(DatasetError, match="relevant"):
+            parse_dataset(
+                _dataset(queries=[{"id": "q1", "query": "a", "relevant": []}])
+            )
+
+    def test_rejects_duplicate_relevant_ids(self):
+        with pytest.raises(DatasetError, match="duplicate"):
+            parse_dataset(
+                _dataset(queries=[{"id": "q1", "query": "a", "relevant": ["m1", "m1"]}])
+            )
+
+    def test_rejects_blank_query_text(self):
+        with pytest.raises(DatasetError, match="query"):
+            parse_dataset(
+                _dataset(queries=[{"id": "q1", "query": "   ", "relevant": ["m1"]}])
+            )
+
+    @pytest.mark.parametrize("bad_k", [[], [0], [-1], ["5"], [True]])
+    def test_rejects_invalid_k_values(self, bad_k):
+        with pytest.raises(DatasetError, match="k_values"):
+            parse_dataset(_dataset(k_values=bad_k))
+
+    def test_warns_when_relevant_set_exceeds_smallest_k(self):
+        dataset = parse_dataset(
+            _dataset(
+                k_values=[2],
+                queries=[{"id": "q1", "query": "a", "relevant": ["m1", "m2", "m3"]}],
+            )
+        )
+        assert dataset.warnings
+        assert "recall@2" in dataset.warnings[0]
+
+    def test_missing_file_is_a_dataset_error(self, tmp_path):
+        with pytest.raises(DatasetError, match="not found"):
+            load_dataset(tmp_path / "nope.json")
+
+    def test_invalid_json_is_a_dataset_error(self, tmp_path):
+        bad = tmp_path / "bad.json"
+        bad.write_text("{not json", encoding="utf-8")
+        with pytest.raises(DatasetError, match="invalid JSON"):
+            load_dataset(bad)
+
+
+class TestStubRunValidation:
+    def test_rejects_wrong_schema_version(self, tmp_path):
+        path = tmp_path / "run.json"
+        path.write_text(json.dumps({"schema_version": 99, "rankings": {}}), "utf-8")
+        with pytest.raises(DatasetError, match="schema_version"):
+            load_stub_run(path)
+
+    def test_rejects_non_list_ranking(self, tmp_path):
+        path = tmp_path / "run.json"
+        path.write_text(
+            json.dumps({"schema_version": SCHEMA_VERSION, "rankings": {"q1": "m1"}}),
+            "utf-8",
+        )
+        with pytest.raises(DatasetError, match="must be a list"):
+            load_stub_run(path)
+
+
+class TestRunnerScoring:
+    def test_scores_the_shipped_smoke_fixture_to_known_values(self):
+        dataset = load_dataset(f"{FIXTURES}/smoke_dataset_v1.json")
+        rankings = load_stub_run(f"{FIXTURES}/smoke_run_v1.json")
+        report = score_outcomes(dataset, run_dataset(dataset, stub_retriever(rankings)))
+
+        # Hand-computed from the fixture; see the guide for the working.
+        assert report["metrics"]["at_k"]["5"]["precision"] == pytest.approx(0.16)
+        assert report["metrics"]["at_k"]["5"]["recall"] == pytest.approx(0.5)
+        assert report["metrics"]["at_k"]["10"]["precision"] == pytest.approx(0.08)
+        assert report["metrics"]["mrr"] == pytest.approx(0.3667, abs=1e-4)
+        assert report["metrics"]["empty_result_rate"] == pytest.approx(0.2)
+        assert report["metrics"]["error_count"] == 0
+
+    def test_reports_per_category_slices(self):
+        dataset = load_dataset(f"{FIXTURES}/smoke_dataset_v1.json")
+        rankings = load_stub_run(f"{FIXTURES}/smoke_run_v1.json")
+        report = score_outcomes(dataset, run_dataset(dataset, stub_retriever(rankings)))
+        assert report["by_category"]["object"]["mrr"] == pytest.approx(1.0)
+        assert report["by_category"]["hard-negative"]["mrr"] == 0.0
+        assert report["by_category"]["hard-negative"]["count"] == 2
+
+    def test_lists_misses_and_empty_responses_in_worst_cases(self):
+        dataset = load_dataset(f"{FIXTURES}/smoke_dataset_v1.json")
+        rankings = load_stub_run(f"{FIXTURES}/smoke_run_v1.json")
+        report = score_outcomes(dataset, run_dataset(dataset, stub_retriever(rankings)))
+        ids = {case["query_id"] for case in report["worst_cases"]}
+        assert ids == {"q-miss-unicorn", "q-empty-response"}
+
+    def test_result_document_is_json_serialisable(self):
+        dataset = load_dataset(f"{FIXTURES}/smoke_dataset_v1.json")
+        rankings = load_stub_run(f"{FIXTURES}/smoke_run_v1.json")
+        report = score_outcomes(dataset, run_dataset(dataset, stub_retriever(rankings)))
+        # Strict: before/after comparison depends on this being writable.
+        json.dumps(report)
+        assert report["dataset_id"] == "smoke-v1"
+        assert report["result_schema_version"] == 1
+
+    def test_a_failing_retriever_is_recorded_not_raised(self):
+        dataset = parse_dataset(_dataset())
+
+        def _broken(query, k):
+            raise RuntimeError("retriever exploded")
+
+        report = score_outcomes(dataset, run_dataset(dataset, _broken))
+        assert report["metrics"]["error_count"] == 1
+        assert report["metrics"]["empty_result_rate"] == 1.0
+        assert "retriever exploded" in report["worst_cases"][0]["error"]
+
+    def test_rejects_zero_repetitions(self):
+        dataset = parse_dataset(_dataset())
+        with pytest.raises(ValueError):
+            run_dataset(dataset, stub_retriever({}), repetitions=0)

--- a/backend/tests/test_search_eval.py
+++ b/backend/tests/test_search_eval.py
@@ -285,3 +285,38 @@ class TestRunnerScoring:
         dataset = parse_dataset(_dataset())
         with pytest.raises(ValueError):
             run_dataset(dataset, stub_retriever({}), repetitions=0)
+
+
+class TestReviewRegressions:
+    """Cases for bugs found in review of the harness itself."""
+
+    def test_p50_reports_an_observed_sample_on_even_length_input(self):
+        # statistics.median() averages the two middle values, so an even-length
+        # sample produced a p50 no query actually recorded — the one percentile
+        # here that broke the "always an observed value" promise.
+        summary = latency_summary([10.0, 20.0])
+        assert summary["p50_ms"] in (10.0, 20.0)
+        assert summary["p50_ms"] != 15.0
+
+    def test_odd_length_p50_is_unchanged(self):
+        assert latency_summary([5.0, 15.0, 25.0])["p50_ms"] == 15.0
+
+    def test_a_later_repetition_failing_scores_as_a_miss(self):
+        # The first attempt succeeds and the second raises. Keeping the first
+        # ranking would credit precision, recall, and MRR for a query that
+        # errored.
+        dataset = parse_dataset(_dataset())
+        calls = {"n": 0}
+
+        def _flaky(query, k):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                return ["m1"]
+            raise RuntimeError("second attempt exploded")
+
+        report = score_outcomes(dataset, run_dataset(dataset, _flaky, repetitions=3))
+        assert report["metrics"]["error_count"] == 1
+        assert report["metrics"]["mrr"] == 0.0
+        assert report["metrics"]["at_k"]["5"]["precision"] == 0.0
+        assert report["metrics"]["at_k"]["5"]["recall"] == 0.0
+        assert report["metrics"]["empty_result_rate"] == 1.0

--- a/docs/guides/search-evaluation.md
+++ b/docs/guides/search-evaluation.md
@@ -1,0 +1,177 @@
+# Search Evaluation Harness
+
+- **Status:** Implemented
+- **Related:** Issue #100. Dependency for #99 and
+  `docs/research/search-retrieval-benchmark-plan.md`.
+
+Repeatable, local, offline scoring for Find's semantic search. Search changes
+cannot be judged from screenshots, and "it feels better" is not a result that
+survives the next change. This produces numbers two runs apart can be diffed.
+
+**Nothing leaves the machine.** No images, embeddings, labels, or results are
+uploaded. Datasets reference media by id only and never contain image bytes.
+
+## Quick start
+
+Prove the harness itself works, with no database, models, or photos:
+
+```bash
+cd backend
+uv run python scripts/evaluate_search.py \
+    --dataset tests/fixtures/search_eval/smoke_dataset_v1.json \
+    --stub tests/fixtures/search_eval/smoke_run_v1.json
+```
+
+Score a live instance with an indexed library:
+
+```bash
+uv run python scripts/evaluate_search.py \
+    --dataset my_dataset.json --api --base-url http://localhost:8000 \
+    --json --out baseline.json
+```
+
+Then, after a change, produce `candidate.json` the same way and diff the two.
+
+> **`ML_MODE=mock` results are not relevance measurements.** The mock embedder
+> is unrelated to the real weighting scheme. Mock is for checking that the
+> plumbing runs, nothing more.
+
+## Dataset format
+
+Versioned JSON, `schema_version: 1`:
+
+```json
+{
+  "schema_version": 1,
+  "dataset_id": "my-library-v1",
+  "description": "what this set is for",
+  "k_values": [5, 10],
+  "queries": [
+    {
+      "id": "q-bicycle",
+      "query": "red bicycle leaning on a wall",
+      "relevant": ["1042", "1189"],
+      "category": "object",
+      "notes": "optional free text"
+    }
+  ]
+}
+```
+
+`relevant` holds the `media_id` values your instance returns. `category` is
+optional and drives per-slice reporting — use it, because an aggregate hides a
+category that collapsed.
+
+**`dataset_id` is load-bearing.** It is recorded in every result file, so a set
+of numbers can never be silently compared against a different revision. Bump it
+whenever queries or judgements change. Revisions are not mergeable with their
+predecessors; a changed dataset invalidates prior results rather than extending
+them.
+
+## Metrics, and how they are defined
+
+The exact conventions matter, because they change the numbers:
+
+| Metric | Definition | Note |
+| --- | --- | --- |
+| Precision@K | hits in top K **/ K** | Returning fewer than K results is penalised for the slots left empty |
+| Recall@K | hits in top K / **number of relevant** | Cannot reach 1.0 if a query has more relevant items than K |
+| MRR | mean of 1/(rank of first hit) | Misses contribute 0, so they drag the mean down rather than being skipped |
+| Empty-result rate | queries returning zero rows / all queries | |
+| Latency | p50/p95/p99, nearest-rank | Not interpolated — an interpolated p95 over 20 samples invents a number no query produced |
+
+Ranks are 1-based. Duplicate ids in a ranking count once, at their first
+position.
+
+If a query lists more relevant items than the smallest `k`, the loader emits a
+warning into `dataset_warnings`, because that query's recall is capped below 1.0
+and quietly drags the aggregate down.
+
+## Writing a dataset without fooling yourself
+
+This is the part that decides whether the numbers mean anything.
+
+**Write queries before you look at results.** If you run a search, see what
+comes back, and then write down what was relevant, you have measured that
+search's current behaviour and called it ground truth. Every later change will
+look like a regression. Decide what *should* match, then measure.
+
+**Judge relevance by the query, not by the ranking.** An item is relevant
+because it satisfies what the user asked, not because it scored well.
+
+**Cover the categories that fail differently.** At minimum:
+
+- text-heavy documents (receipts, screenshots, invoices)
+- faces and people
+- scenes with no salient object (landscapes, textures)
+- single-word queries
+- multi-concept queries ("dog on a beach at sunset")
+- hard negatives — queries with no correct answer in the corpus, which catch a
+  system that returns something plausible-looking for everything
+
+**Keep relevant sets small.** Aim for fewer relevant items than the smallest
+`k`. Large relevant sets cap recall and compress the differences you are trying
+to see.
+
+**Do not tune the dataset to make a change look good.** If a variant fails on
+some queries, that is the result. Deleting inconvenient queries produces a
+dataset that only rewards the change you already wanted to ship.
+
+**Include queries you expect to fail.** A dataset every candidate passes cannot
+distinguish between candidates.
+
+**Size.** 30–50 queries is enough to see a real effect and small enough to
+maintain honestly. Below ~20, single-query noise dominates the aggregate.
+
+## Adding cases to an existing dataset
+
+1. Add the query object with a new unique `id`.
+2. Fill `relevant` by deciding what *should* match, then confirming those ids
+   exist in your library.
+3. Bump `dataset_id` — adding queries changes what the aggregate means.
+4. Re-run the baseline. Prior numbers are not comparable across the bump.
+
+## Output
+
+`--json` (and `--out`) emit a `result_schema_version: 1` document containing
+`dataset_id`, per-K precision and recall, MRR, empty-result rate, error count,
+latency percentiles, per-category MRR, and `worst_cases` — every query with no
+relevant hit, plus any retriever error.
+
+`worst_cases` is a required output rather than a footnote. A variant that lifts
+mean recall while destroying one query class is worse for real users than its
+average suggests, and only the per-query view shows that.
+
+## Extending with a new retriever
+
+A retriever is any callable `(EvalQuery, k) -> Sequence[str]` returning ranked
+media ids. Two ship today: `stub_retriever` (canned rankings) and the `--api`
+retriever (HTTP against a live instance). Scoring is identical for both — which
+is the point, since two runs are only comparable when the scoring path is the
+same. To benchmark an experimental branch, add a retriever rather than forking
+the scoring.
+
+## Validation
+
+```bash
+cd backend
+uv run python scripts/evaluate_search.py \
+    --dataset tests/fixtures/search_eval/smoke_dataset_v1.json \
+    --stub tests/fixtures/search_eval/smoke_run_v1.json
+uv run ruff check . && uv run ruff format --check .
+ML_MODE=mock uv run pytest -q
+```
+
+The smoke fixture is deterministic and hand-checkable. Its five queries cover a
+perfect hit, a mid-rank hit, a partial hit, a total miss, and an empty response,
+giving P@5 = 0.16, R@5 = 0.50, MRR = 0.3667, empty-result rate = 0.20. Those
+values are asserted in `backend/tests/test_search_eval.py`, so a change to the
+scoring math fails the suite rather than silently shifting every future result.
+
+## References
+
+- `docs/research/search-retrieval-benchmark-plan.md` — the experiment matrix
+  this harness feeds
+- `docs/plans/partial/local-search-quality-roadmap.md` — target metrics
+- `backend/src/find_api/evaluation/` — dataset, metrics, runner
+- `backend/scripts/evaluate_search.py` — CLI entry point

--- a/docs/index.md
+++ b/docs/index.md
@@ -41,6 +41,7 @@ This directory is organized by document purpose and implementation status.
 - [Real ML Troubleshooting](guides/real-ml-troubleshooting.md)
 - [Features Guide](guides/features.md)
 - [Hardware Acceleration](guides/hardware-acceleration.md)
+- [Search Evaluation Harness](guides/search-evaluation.md)
 - [PR Triage Automation Dry Run](guides/pr-triage-dry-run.md)
 - [TestSprite PR Testing](guides/testsprite-ci.md)
 


### PR DESCRIPTION
## Summary

Closes #100. Unblocks #99, which cannot start comparisons until one labeled dataset and one metric implementation can evaluate every candidate.

Repeatable, local, offline scoring for semantic search. Nothing uploads images, embeddings, labels, or results; datasets reference media by id only and never contain image bytes.

## What changed

`find_api.evaluation`, split so the scoring path is identical regardless of where rankings came from — the only way two runs are genuinely comparable:

| Module | Role |
| --- | --- |
| `metrics.py` | Pure scoring math over ranked id lists. No DB, models, or network, so it is exactly unit-testable |
| `dataset.py` | Versioned labeled-query format + validator that names the offending field on every failure |
| `runner.py` | Runs a dataset against an injected retriever, aggregates to a machine-readable document |
| `scripts/evaluate_search.py` | CLI: `--stub` (canned rankings) or `--api` (live instance), `--json`/`--out` for before/after diffing |

## Scoring conventions are documented and asserted, not assumed

They change the numbers, so they are pinned: precision@k divides by **k** rather than by results returned; recall@k divides by the relevant count; ranks are 1-based; missed queries contribute **0** to MRR rather than being skipped; latency percentiles use **nearest-rank**, so a p95 over 20 samples returns a value some query actually produced instead of an interpolated invention.

## Smoke fixture

Deterministic, synthetic media ids, so it runs in CI with no database, no model weights, and no private photos. Five queries cover a perfect hit, a mid-rank hit, a partial hit, a total miss, and an empty response — pinning every metric to a hand-checkable value:

```
P@5 0.16   R@5 0.50   P@10 0.08   MRR 0.3667   empty-result rate 0.20
```

Those are asserted in the suite, so a change to the scoring math fails tests rather than quietly shifting every future result.

Results also carry per-category MRR and a `worst_cases` list — a variant that lifts the mean while destroying one query class is worse for users than its average suggests, and only the per-query view shows it.

## Docs

`docs/guides/search-evaluation.md` covers the format, metric definitions, adding cases, and how to write a dataset without fooling yourself — most importantly writing queries **before** looking at results, since labelling from observed output measures current behaviour and calls it ground truth.

## Acceptance criteria

- [x] Versioned labeled query-to-relevant-image format
- [x] Repeatable command for evaluating a local dataset
- [x] Precision@K, Recall@K, MRR, empty-result rate, and latency
- [x] Machine-readable output for before/after comparison
- [x] Dataset creation, bias avoidance, and adding cases documented
- [x] Deterministic smoke fixtures that need no private photos
- [x] Tests cover scoring math and invalid dataset input

## Validation

```
smoke run against its fixture   OK
ruff check / ruff format        clean
ML_MODE=mock pytest -q          731 passed, 7 skipped
```

## Type of change

- [x] Feature

## Release impact

- [x] No user-visible release note needed

## Notes

No production search behaviour changes. No claim is made about Find's retrieval quality — the smoke numbers describe the fixture, not the product. Per the issue's own out-of-scope note, `ML_MODE=mock` results are not relevance measurements.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an offline search evaluation tool supporting labeled datasets, live or canned rankings, retrieval metrics, latency analysis, category breakdowns, and worst-case reporting.
  * Added validation for evaluation datasets and ranking results, with human-readable or JSON output.

* **Documentation**
  * Added setup, schema, metric, authoring, and usage guidance for the search evaluation harness.

* **Tests**
  * Added coverage for metrics, validation, scoring, error handling, serialization, and reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->