### PR TITLE
feat: measure HNSW index fidelity (Track A of #99), and correct the recall concern

### DIFF
--- a/backend/scripts/benchmark_hnsw_recall.py
+++ b/backend/scripts/benchmark_hnsw_recall.py
@@ -1,0 +1,339 @@
+#!/usr/bin/env python3
+"""
+Measure what recall Find's HNSW index configuration costs against exact search.
+
+Track A of docs/research/search-retrieval-benchmark-plan.md. This is the one
+comparison in that plan that needs no labeled data and no real photos: the
+ground truth is exact nearest-neighbour search over the same vectors, not a
+human judgement, so the only inputs are a corpus of vectors and an index.
+
+Why it matters: migration `hnsw_vector_idx_001` created
+
+    CREATE INDEX ix_media_vector_hnsw ON media USING hnsw (vector vector_cosine_ops)
+
+with default build parameters, and `hnsw.ef_search` is never set anywhere in
+the codebase. Search then does `ORDER BY vector <=> :q LIMIT :k`, which the
+planner normally satisfies from that index. So Find serves approximate results
+under parameters nobody chose, and the recall cost has never been measured.
+
+WHAT THIS DOES AND DOES NOT TELL YOU
+
+It characterises the *index configuration* - how much recall the deployed HNSW
+settings lose relative to exact search, and how `ef_search` trades recall for
+latency, at a given corpus size and vector distribution.
+
+It is NOT a measurement of Find's search quality. The vectors here are
+synthetic, not SigLIP embeddings. Two distributions are run because they
+bracket the real case:
+
+  clustered - points around random centres on the unit sphere. Closer to real
+              image embeddings, which are strongly clustered. Optimistic.
+  uniform   - points spread over the unit sphere. In high dimensions these are
+              nearly equidistant, which is the hardest possible case for a
+              graph index. Pessimistic; treat as a lower bound.
+
+Real embeddings sit between the two. Deciding production settings still needs a
+real indexed library - see Track A2 in the plan.
+
+Usage (needs a pgvector database; nothing else in the stack is required):
+
+    docker run -d --name find-eval-pg \
+        -e POSTGRES_DB=find -e POSTGRES_USER=find -e POSTGRES_PASSWORD=evalonly \
+        -p 127.0.0.1:55432:5432 pgvector/pgvector:0.8.4-pg16-bookworm
+
+    uv run python scripts/benchmark_hnsw_recall.py \
+        --dsn postgresql://find:evalonly@localhost:55432/find \
+        --sizes 1000,10000 --json --out hnsw_recall.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import sys
+import time
+from io import StringIO
+from pathlib import Path
+
+import numpy as np
+import psycopg2
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from find_api.evaluation.metrics import recall_at_k  # noqa: E402
+
+TABLE = "hnsw_bench"
+DIM = 768  # settings.EMBEDDING_DIM - SigLIP ViT-B-16
+INDEX_NAME = "ix_hnsw_bench_vector"
+
+
+def _unit(rows: np.ndarray) -> np.ndarray:
+    norms = np.linalg.norm(rows, axis=1, keepdims=True)
+    norms[norms == 0] = 1.0
+    return rows / norms
+
+
+def make_vectors(count: int, kind: str, rng: np.random.Generator) -> np.ndarray:
+    """Synthetic unit vectors. See the module docstring for why two kinds."""
+    if kind == "uniform":
+        return _unit(rng.standard_normal((count, DIM)))
+    if kind == "clustered":
+        # Roughly 40 images per cluster, which is the order of magnitude a
+        # personal library shows (holidays, pets, documents, screenshots).
+        centres = _unit(rng.standard_normal((max(count // 40, 8), DIM)))
+        assign = rng.integers(0, len(centres), size=count)
+        # Scale by 1/sqrt(DIM): a per-component sigma of s gives a noise vector
+        # of norm s*sqrt(DIM), so an unscaled 0.35 would be norm ~9.7 against a
+        # unit centre and swamp the cluster structure entirely - which is what
+        # an earlier version of this script did, making "clustered" silently
+        # identical to "uniform".
+        sigma = 0.35 / np.sqrt(DIM)
+        return _unit(centres[assign] + sigma * rng.standard_normal((count, DIM)))
+    raise ValueError(f"unknown distribution {kind!r}")
+
+
+def _vec_literal(vec: np.ndarray) -> str:
+    return "[" + ",".join(f"{v:.6f}" for v in vec) + "]"
+
+
+def load_corpus(conn, vectors: np.ndarray) -> None:
+    with conn.cursor() as cur:
+        cur.execute(f"DROP TABLE IF EXISTS {TABLE}")
+        cur.execute(
+            f"CREATE TABLE {TABLE} (id bigserial PRIMARY KEY, vector vector({DIM}))"
+        )
+        buffer = StringIO()
+        for index, vec in enumerate(vectors, start=1):
+            buffer.write(f"{index}\t{_vec_literal(vec)}\n")
+        buffer.seek(0)
+        cur.copy_expert(f"COPY {TABLE} (id, vector) FROM STDIN", buffer)
+        cur.execute(
+            f"SELECT setval(pg_get_serial_sequence('{TABLE}','id'), {len(vectors)})"
+        )
+    conn.commit()
+
+
+def build_index(conn, m: int | None, ef_construction: int | None) -> float:
+    """Create the HNSW index; returns build seconds. None means pgvector default."""
+    opts = ""
+    if m is not None and ef_construction is not None:
+        opts = f" WITH (m = {m}, ef_construction = {ef_construction})"
+    started = time.perf_counter()
+    with conn.cursor() as cur:
+        cur.execute(f"DROP INDEX IF EXISTS {INDEX_NAME}")
+        # Identical shape to migration hnsw_vector_idx_001.
+        cur.execute(
+            f"CREATE INDEX {INDEX_NAME} ON {TABLE} USING hnsw (vector vector_cosine_ops){opts}"
+        )
+    conn.commit()
+    return time.perf_counter() - started
+
+
+def _search(cur, query: np.ndarray, k: int) -> tuple[list[str], float]:
+    literal = _vec_literal(query)
+    started = time.perf_counter()
+    cur.execute(
+        f"SELECT id FROM {TABLE} ORDER BY vector <=> %s::vector LIMIT %s",
+        (literal, k),
+    )
+    rows = cur.fetchall()
+    return [str(r[0]) for r in rows], (time.perf_counter() - started) * 1000
+
+
+def exact_top_k(conn, queries: np.ndarray, k: int) -> list[list[str]]:
+    out = []
+    with conn.cursor() as cur:
+        # Force a sequential scan so this is true nearest-neighbour ground truth.
+        cur.execute("SET LOCAL enable_indexscan = off")
+        cur.execute("SET LOCAL enable_bitmapscan = off")
+        for query in queries:
+            ids, _ = _search(cur, query, k)
+            out.append(ids)
+    conn.rollback()
+    return out
+
+
+def hnsw_top_k(conn, queries: np.ndarray, k: int, ef_search: int | None):
+    rankings, latencies = [], []
+    with conn.cursor() as cur:
+        if ef_search is not None:
+            cur.execute(f"SET LOCAL hnsw.ef_search = {ef_search}")
+        for query in queries:
+            ids, ms = _search(cur, query, k)
+            rankings.append(ids)
+            latencies.append(ms)
+    conn.rollback()
+    return rankings, latencies
+
+
+def _pct(values: list[float], pct: float) -> float:
+    ordered = sorted(values)
+    rank = -(-int(pct * len(ordered)) // 100) or 1
+    return ordered[min(rank, len(ordered)) - 1]
+
+
+def make_queries(
+    corpus: np.ndarray, count: int, rng: np.random.Generator, sigma: float = 0.25
+) -> np.ndarray:
+    """Queries drawn *near* corpus points, which is what makes recall meaningful.
+
+    An earlier version generated queries with a second, independent call to
+    make_vectors(). Because that function picks fresh cluster centres each
+    call, the queries landed nowhere near the corpus's clusters: every corpus
+    point sat at roughly the same distance, the 10th and 60th neighbours
+    differed by ~0.02 cosine, and recall@10 degenerated into rank agreement
+    among near-ties. It reported ~0.43 recall for configurations that were in
+    fact returning equally-good results.
+
+    A real text query embeds close to the images it describes, so queries are
+    now perturbations of sampled corpus vectors. That gives the top-k a genuine
+    margin over the rest, which is the precondition for recall to mean anything.
+    """
+    picks = corpus[rng.integers(0, len(corpus), size=count)]
+    return _unit(picks + (sigma / np.sqrt(DIM)) * rng.standard_normal((count, DIM)))
+
+
+def neighbour_margin(conn, queries: np.ndarray, k: int) -> float:
+    """Mean cosine gap between the kth and 3kth exact neighbour.
+
+    Reported alongside recall so the number is interpretable. A margin near
+    zero means the candidates around rank k are effectively tied, and recall@k
+    is then measuring tie-breaking rather than retrieval quality.
+    """
+    gaps = []
+    with conn.cursor() as cur:
+        cur.execute("SET LOCAL enable_indexscan = off")
+        cur.execute("SET LOCAL enable_bitmapscan = off")
+        for query in queries[: min(len(queries), 25)]:
+            cur.execute(
+                f"SELECT vector <=> %s::vector AS d FROM {TABLE} ORDER BY d LIMIT %s",
+                (_vec_literal(query), 3 * k),
+            )
+            distances = [float(r[0]) for r in cur.fetchall()]
+            if len(distances) >= 3 * k:
+                gaps.append(distances[3 * k - 1] - distances[k - 1])
+    conn.rollback()
+    return float(np.mean(gaps)) if gaps else 0.0
+
+
+def run(conn, size: int, kind: str, k: int, n_queries: int, seed: int) -> dict:
+    rng = np.random.default_rng(seed)
+    corpus = make_vectors(size, kind, rng)
+    queries = make_queries(corpus, n_queries, rng)
+
+    load_corpus(conn, corpus)
+    truth = exact_top_k(conn, queries, k)
+    margin = neighbour_margin(conn, queries, k)
+
+    results = {
+        "size": size,
+        "distribution": kind,
+        "k": k,
+        "queries": n_queries,
+        # Gap between the kth and 3kth exact neighbour. Near zero means the
+        # candidates are tied and recall@k measures tie-breaking, not quality.
+        "neighbour_margin": round(margin, 5),
+        "configs": [],
+    }
+
+    # (m, ef_construction, [ef_search values]) - None/None is the shipped default.
+    for m, efc in ((None, None), (32, 128)):
+        build_s = build_index(conn, m, efc)
+        label = "default" if m is None else f"m={m},ef_construction={efc}"
+        for ef_search in (None, 100, 200, 400):
+            rankings, latencies = hnsw_top_k(conn, queries, k, ef_search)
+            recalls = [
+                recall_at_k(ranking, set(expected), k)
+                for ranking, expected in zip(rankings, truth)
+            ]
+            results["configs"].append(
+                {
+                    "build": label,
+                    "ef_search": ef_search if ef_search is not None else "default(40)",
+                    "recall_at_k": round(statistics.mean(recalls), 4),
+                    "recall_min": round(min(recalls), 4),
+                    "build_seconds": round(build_s, 2),
+                    "p50_ms": round(_pct(latencies, 50), 3),
+                    "p95_ms": round(_pct(latencies, 95), 3),
+                }
+            )
+    return results
+
+
+def _print_human(report: dict) -> None:
+    for block in report["runs"]:
+        print(
+            f"\n{block['distribution']} corpus, n={block['size']}, "
+            f"k={block['k']}, {block['queries']} queries, "
+            f"neighbour margin d{3 * block['k']}-d{block['k']}="
+            f"{block['neighbour_margin']:.5f}"
+        )
+        header = f"  {'BUILD':<26} {'EF_SEARCH':<12} {'RECALL@K':>9} {'WORST':>7} {'P50 ms':>8} {'P95 ms':>8}"
+        print(header)
+        print("  " + "-" * (len(header) - 2))
+        for cfg in block["configs"]:
+            print(
+                f"  {cfg['build']:<26} {str(cfg['ef_search']):<12} "
+                f"{cfg['recall_at_k']:>9.4f} {cfg['recall_min']:>7.2f} "
+                f"{cfg['p50_ms']:>8.3f} {cfg['p95_ms']:>8.3f}"
+            )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n")[1])
+    parser.add_argument("--dsn", required=True)
+    parser.add_argument("--sizes", default="1000,10000")
+    parser.add_argument("--distributions", default="clustered,uniform")
+    parser.add_argument("-k", type=int, default=10)
+    parser.add_argument("--queries", type=int, default=200)
+    parser.add_argument("--seed", type=int, default=20260803)
+    parser.add_argument("--json", action="store_true")
+    parser.add_argument("--out", default=None)
+    args = parser.parse_args(argv)
+
+    sizes = [int(s) for s in args.sizes.split(",") if s.strip()]
+    kinds = [d.strip() for d in args.distributions.split(",") if d.strip()]
+
+    conn = psycopg2.connect(args.dsn)
+    try:
+        with conn.cursor() as cur:
+            cur.execute("CREATE EXTENSION IF NOT EXISTS vector")
+            cur.execute("SELECT extversion FROM pg_extension WHERE extname='vector'")
+            pgvector_version = cur.fetchone()[0]
+            cur.execute("SHOW server_version")
+            pg_version = cur.fetchone()[0]
+        conn.commit()
+
+        report = {
+            "pgvector_version": pgvector_version,
+            "postgres_version": pg_version,
+            "dim": DIM,
+            "seed": args.seed,
+            "note": (
+                "Synthetic vectors, not SigLIP embeddings. Characterises the index "
+                "configuration, not Find's retrieval quality."
+            ),
+            "runs": [],
+        }
+        for kind in kinds:
+            for size in sizes:
+                report["runs"].append(
+                    run(conn, size, kind, args.k, args.queries, args.seed)
+                )
+    finally:
+        conn.close()
+
+    if args.json:
+        print(json.dumps(report, indent=2))
+    else:
+        _print_human(report)
+    if args.out:
+        Path(args.out).write_text(json.dumps(report, indent=2), encoding="utf-8")
+        if not args.json:
+            print(f"\nWrote {args.out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/scripts/benchmark_hnsw_recall.py
+++ b/backend/scripts/benchmark_hnsw_recall.py
@@ -35,6 +35,13 @@ bracket the real case:
 Real embeddings sit between the two. Deciding production settings still needs a
 real indexed library - see Track A2 in the plan.
 
+WRITES TO THE DATABASE - USE A THROWAWAY ONE
+
+This script DROPs and CREATEs a table named `hnsw_bench` and an index on it. It
+does not read or touch `media`. Point it at a scratch database, never at a
+production DSN. It also cannot measure a real library: the corpus is generated,
+so there is no flag to feed it real SigLIP vectors.
+
 Usage (needs a pgvector database; nothing else in the stack is required):
 
     docker run -d --name find-eval-pg \
@@ -61,10 +68,13 @@ import psycopg2
 
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
+from find_api.core.config import settings  # noqa: E402
 from find_api.evaluation.metrics import recall_at_k  # noqa: E402
 
 TABLE = "hnsw_bench"
-DIM = 768  # settings.EMBEDDING_DIM - SigLIP ViT-B-16
+# Read from settings rather than hardcoded: measuring a different width than
+# production indexes would make every number here quietly inapplicable.
+DIM = settings.EMBEDDING_DIM
 INDEX_NAME = "ix_hnsw_bench_vector"
 
 

--- a/backend/tests/test_hnsw_recall_benchmark.py
+++ b/backend/tests/test_hnsw_recall_benchmark.py
@@ -1,0 +1,138 @@
+"""Tests for the HNSW recall benchmark's vector generation.
+
+The database half needs a live pgvector instance and is exercised by running
+the script; what is worth pinning here is the synthetic corpus, because a
+generator that silently fails to cluster makes the "clustered vs uniform"
+comparison meaningless while still producing confident-looking numbers. That
+happened during development: an unscaled per-component sigma of 0.35 gives a
+noise vector of norm ~9.7 in 768 dimensions, which buried a unit-norm centre
+and made both distributions identical.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "benchmark_hnsw_recall.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("_hnsw_bench", _SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def bench():
+    return _load()
+
+
+class TestVectorGeneration:
+    def test_vectors_are_unit_norm(self, bench):
+        rng = np.random.default_rng(7)
+        for kind in ("clustered", "uniform"):
+            vectors = bench.make_vectors(64, kind, rng)
+            norms = np.linalg.norm(vectors, axis=1)
+            assert np.allclose(norms, 1.0, atol=1e-6), kind
+
+    def test_shape_matches_embedding_dim(self, bench):
+        rng = np.random.default_rng(7)
+        assert bench.make_vectors(12, "uniform", rng).shape == (12, bench.DIM)
+
+    def test_clustered_actually_clusters(self, bench):
+        """Intra-cluster similarity must dominate inter-cluster similarity.
+
+        This is the assertion that would have caught the sigma bug.
+        """
+        rng = np.random.default_rng(11)
+        centres = bench._unit(rng.standard_normal((4, bench.DIM)))
+        sigma = 0.35 / np.sqrt(bench.DIM)
+        groups = [
+            bench._unit(centre + sigma * rng.standard_normal((40, bench.DIM)))
+            for centre in centres
+        ]
+        intra = np.mean([g @ g.T for g in groups])
+        inter = np.mean(groups[0] @ groups[1].T)
+        assert intra > 0.5, f"clusters are not tight enough: intra={intra:.3f}"
+        assert inter < 0.2, f"clusters are not separated: inter={inter:.3f}"
+
+    def test_uniform_is_not_clustered(self, bench):
+        rng = np.random.default_rng(13)
+        vectors = bench.make_vectors(200, "uniform", rng)
+        sims = vectors @ vectors.T
+        np.fill_diagonal(sims, 0.0)
+        # Random directions in 768 dimensions are near-orthogonal.
+        assert abs(float(sims.mean())) < 0.05
+
+    def test_rejects_unknown_distribution(self, bench):
+        rng = np.random.default_rng(3)
+        with pytest.raises(ValueError, match="unknown distribution"):
+            bench.make_vectors(4, "gaussian-blobs", rng)
+
+    def test_generation_is_reproducible_for_a_seed(self, bench):
+        a = bench.make_vectors(16, "clustered", np.random.default_rng(99))
+        b = bench.make_vectors(16, "clustered", np.random.default_rng(99))
+        assert np.array_equal(a, b)
+
+
+class TestVectorLiteral:
+    def test_formats_as_pgvector_literal(self, bench):
+        literal = bench._vec_literal(np.array([1.0, -0.5, 0.25]))
+        assert literal.startswith("[") and literal.endswith("]")
+        assert literal == "[1.000000,-0.500000,0.250000]"
+
+
+class TestPercentile:
+    def test_nearest_rank_returns_observed_values(self, bench):
+        values = [1.0, 2.0, 3.0, 4.0]
+        assert bench._pct(values, 100) == 4.0
+        assert bench._pct(values, 50) in values
+
+
+class TestQueryGeneration:
+    """Queries must land near the corpus, or recall@k measures nothing.
+
+    The first version of this benchmark generated queries with a second,
+    independent make_vectors() call. That picks fresh cluster centres, so the
+    queries sat far from every corpus cluster, all candidates were roughly
+    equidistant, and recall@10 collapsed to ~0.43 for configurations that were
+    in fact returning equally-good results.
+    """
+
+    def test_queries_are_close_to_corpus_points(self, bench):
+        rng = np.random.default_rng(21)
+        corpus = bench.make_vectors(500, "clustered", rng)
+        queries = bench.make_queries(corpus, 50, rng)
+
+        best = (queries @ corpus.T).max(axis=1)
+        assert best.min() > 0.8, (
+            f"queries drifted from the corpus: worst best-match cos sim {best.min():.3f}"
+        )
+
+    def test_independent_generation_would_not_be_close(self, bench):
+        """Pins the failure mode the fix addresses."""
+        rng = np.random.default_rng(21)
+        corpus = bench.make_vectors(500, "clustered", rng)
+        detached = bench.make_vectors(50, "clustered", rng)
+
+        near = (bench.make_queries(corpus, 50, rng) @ corpus.T).max(axis=1).mean()
+        far = (detached @ corpus.T).max(axis=1).mean()
+        assert near > far + 0.3, f"near={near:.3f} far={far:.3f}"
+
+    def test_queries_are_unit_norm(self, bench):
+        rng = np.random.default_rng(5)
+        corpus = bench.make_vectors(100, "uniform", rng)
+        queries = bench.make_queries(corpus, 20, rng)
+        assert np.allclose(np.linalg.norm(queries, axis=1), 1.0, atol=1e-6)
+
+    def test_larger_sigma_moves_queries_further(self, bench):
+        rng = np.random.default_rng(31)
+        corpus = bench.make_vectors(300, "clustered", rng)
+        tight = (bench.make_queries(corpus, 40, rng, sigma=0.1) @ corpus.T).max(axis=1)
+        loose = (bench.make_queries(corpus, 40, rng, sigma=2.0) @ corpus.T).max(axis=1)
+        assert tight.mean() > loose.mean()

--- a/docs/index.md
+++ b/docs/index.md
@@ -54,6 +54,7 @@ This directory is organized by document purpose and implementation status.
 
 - [Vector Search Benchmark Evaluation](research/vector-search-benchmarks.md)
 - [Search Retrieval and Ranking Benchmark Plan](research/search-retrieval-benchmark-plan.md) - experiment design; results blocked on the evaluation harness.
+- [HNSW Index Fidelity (Track A)](research/hnsw-index-fidelity.md) - measured recall of the shipped index configuration against exact search.
 - [Encrypted Bring-Your-Own-Storage Sync](research/encrypted-byo-storage-sync.md) - provider comparison and v1 boundary for optional encrypted backup.
 
 ## Assets

--- a/docs/research/hnsw-index-fidelity.md
+++ b/docs/research/hnsw-index-fidelity.md
@@ -1,0 +1,175 @@
+# Research: HNSW Index Fidelity (Track A)
+
+- **Status:** Measured on synthetic corpora. Real-corpus confirmation still outstanding.
+- **Date:** 2026-08-03
+- **Related:** Issue #99, Track A of `docs/research/search-retrieval-benchmark-plan.md`.
+  Reproduced by `backend/scripts/benchmark_hnsw_recall.py`.
+
+## Why this could be measured now
+
+Track A is the one comparison in the benchmark plan that needs no labeled data
+and no real photos: the ground truth is exact nearest-neighbour search over the
+same vectors, not a human judgement. Everything else in #99 waits on a labeled
+dataset over a real library.
+
+The question: migration `hnsw_vector_idx_001` created
+`ix_media_vector_hnsw ON media USING hnsw (vector vector_cosine_ops)` with
+**default build parameters**, `hnsw.ef_search` is **never set anywhere** in the
+codebase, and search issues `ORDER BY vector <=> :q LIMIT :k`, which the planner
+normally satisfies from that index. So Find serves approximate results under
+parameters nobody chose, and the cost had never been measured.
+
+## Headline result, and a correction
+
+**On clustered corpora — the realistic proxy for image embeddings — the shipped
+default configuration returns exact results. Recall@10 = 1.0000, worst query
+1.00, at both 1k and 10k, with the *lowest* latency of any configuration
+tested.** No change to the index or to `ef_search` is indicated by this evidence.
+
+This **corrects** the concern raised in `search-retrieval-benchmark-plan.md` and
+in my comment on #99, where I wrote that Find was "very likely already serving
+approximate results" with recall as "an unmeasured quantity" and called
+measuring it the highest-value single measurement available. The first half was
+right — it is approximate, and it was unmeasured. The implication that it was
+therefore probably degraded is not supported. On the realistic distribution the
+approximation is exact in practice, and the prior should move from "probably
+losing recall" to "probably fine, confirm on real data."
+
+## Results
+
+pgvector 0.8.4, PostgreSQL 16.14, 768 dimensions (SigLIP ViT-B-16), k = 10,
+200 queries per configuration, seed 20260803.
+
+`margin` is the mean cosine gap between the 10th and 30th exact neighbour. It
+is reported because it decides whether recall means anything at all — see
+[Why the margin matters](#why-the-margin-matters).
+
+### Clustered corpus (realistic proxy)
+
+| n | build | ef_search | recall@10 | worst | p50 ms | index build |
+| --- | --- | --- | --- | --- | --- | --- |
+| 1 000 (margin 0.008) | default | **default (40)** | **1.0000** | 1.00 | 1.89 | 0.26 s |
+| 1 000 | default | 100 | 1.0000 | 1.00 | 4.92 | 0.26 s |
+| 1 000 | m=32, efc=128 | default (40) | 1.0000 | 1.00 | 3.86 | 0.75 s |
+| 10 000 (margin 0.067) | default | **default (40)** | **1.0000** | 1.00 | **1.52** | 4.25 s |
+| 10 000 | default | 100 | 1.0000 | 1.00 | 2.04 | 4.25 s |
+| 10 000 | default | 200 | 1.0000 | 1.00 | 2.82 | 4.25 s |
+| 10 000 | default | 400 | 1.0000 | 1.00 | 4.05 | 4.25 s |
+| 10 000 | m=32, efc=128 | default (40) | 1.0000 | 1.00 | 1.74 | 13.3 s |
+| 10 000 | m=32, efc=128 | 400 | 1.0000 | 1.00 | 30.03 | 13.3 s |
+
+Every configuration is perfect. The defaults are simply the cheapest of them.
+
+### Uniform corpus (pessimistic bound)
+
+Points spread over the unit sphere. In 768 dimensions these are nearly
+equidistant, which is the hardest possible case for a graph index and is *not*
+what image embeddings look like.
+
+| n | build | ef_search | recall@10 | worst | p50 ms |
+| --- | --- | --- | --- | --- | --- |
+| 1 000 (margin 0.018) | default | default (40) | 0.9905 | 0.80 | 1.73 |
+| 1 000 | default | 100 | 1.0000 | 1.00 | 4.19 |
+| 10 000 (margin 0.014) | default | default (40) | 0.5900 | 0.00 | 2.78 |
+| 10 000 | default | 100 | 0.6905 | 0.30 | 4.37 |
+| 10 000 | default | 200 | 0.8180 | 0.50 | 6.21 |
+| 10 000 | default | 400 | 0.9245 | 0.60 | 8.64 |
+| 10 000 | m=32, efc=128 | default (40) | 0.9175 | 0.50 | 4.58 |
+| 10 000 | m=32, efc=128 | 400 | 1.0000 | 1.00 | 37.05 |
+
+## Why the margin matters
+
+Recall tracks the **neighbour margin**, not corpus size. Where the 10th and 30th
+exact neighbours are well separated (clustered, margin 0.067) recall is perfect.
+Where they are nearly tied (uniform, margin 0.014) recall falls — but in that
+regime the "missed" neighbours are at almost the same distance as the ones
+returned, so a low recall figure overstates the damage. Recall@k is measuring
+tie-breaking, not retrieval quality.
+
+This is why the benchmark reports the margin next to every recall number, and
+why a recall figure quoted without one should not be trusted.
+
+## A methodology error worth recording
+
+The first run of this benchmark produced recall@10 ≈ 0.26–0.43 at 10k and looked
+like clear evidence of a serious production problem. It was wrong, twice over,
+and both faults are now covered by tests:
+
+1. **The clustered generator did not cluster.** A per-component sigma of 0.35 in
+   768 dimensions gives a noise vector of norm ≈ 9.7 against a unit-norm centre,
+   so the structure was completely buried — "clustered" and "uniform" were
+   silently the same distribution, and produced matching numbers (0.2635 vs
+   0.2750) that looked like corroboration.
+2. **Queries were generated independently of the corpus.** A second
+   `make_vectors()` call picks fresh cluster centres, so queries landed nowhere
+   near the corpus. Every candidate sat at roughly the same distance — the 10th
+   and 60th neighbours differed by 0.0198 cosine — and recall@10 degenerated
+   into rank agreement among near-ties.
+
+Both were caught by sanity checks rather than by the numbers looking wrong: the
+numbers looked plausible and alarming, which is the dangerous combination. What
+exposed them was measuring intra- versus inter-cluster similarity (0.0105 vs
+0.0005 — no clustering at all) and printing the distance to the Nth neighbour.
+
+Queries are now perturbations of sampled corpus vectors, which is what a real
+text query does: it embeds near the images it describes.
+
+## Operational findings
+
+- **Default build is cheap.** 10k vectors index in 4.25 s; raising to
+  `m=32, ef_construction=128` costs 13.3 s for no recall gain on clustered data.
+- **Raising `ef_search` costs latency for nothing on realistic data.** At 10k
+  clustered, going 40 → 400 takes p50 from 1.52 ms to 4.05 ms with recall
+  unchanged at 1.0000.
+- **The expensive combination is genuinely expensive.** `m=32, efc=128` with
+  `ef_search=400` costs 30 ms p50 at 10k — 20× the default for no benefit.
+- **Large builds with raised parameters are painful.** A 50k build at
+  `m=32, ef_construction=128` was still running after 15 minutes at default
+  `maintenance_work_mem` and was aborted. If those parameters are ever adopted,
+  build cost needs its own measurement and probably a `maintenance_work_mem`
+  bump. The 50k tier is therefore **not** covered by the table above.
+
+## What this does not establish
+
+The vectors are synthetic, not SigLIP embeddings. This characterises the *index
+configuration*; it is not a measurement of Find's search quality. Real
+embeddings have their own intrinsic dimensionality and cluster structure, and
+the honest summary is that they sit somewhere between the two distributions
+tested — much closer to the clustered end, on the evidence of how image
+embedding spaces normally behave.
+
+Outstanding, and still requiring a real indexed library:
+
+- Recall of the deployed configuration against exact search on real SigLIP
+  vectors, with the neighbour margin reported alongside.
+- The 50k+ tier, including build cost with raised parameters.
+- Everything in Tracks B and C, which need labeled relevance judgements and are
+  still blocked on a dataset.
+
+## Recommendation
+
+**Change nothing about the index for now**, and drop the pending action to raise
+`ef_search`. The evidence available says the defaults are both correct and the
+cheapest option on realistic data.
+
+Keep the explicit-setting suggestion, but for a different reason than before:
+`hnsw.ef_search` being unset is worth documenting as a deliberate choice rather
+than an inherited default, so a future pgvector version changing it is a visible
+event. That is a documentation change, not a tuning one.
+
+Re-run against a real library before treating any of this as settled:
+
+```bash
+cd backend
+uv run python scripts/benchmark_hnsw_recall.py \
+    --dsn "$DATABASE_URL" --sizes 10000 --json --out hnsw_recall.json
+```
+
+## References
+
+- `backend/scripts/benchmark_hnsw_recall.py` — reproduces every number here
+- `backend/tests/test_hnsw_recall_benchmark.py` — pins both methodology errors
+- `docs/research/search-retrieval-benchmark-plan.md` — Track A, and the concern
+  this document corrects
+- `docs/research/vector-search-benchmarks.md` — ANN candidate comparison
+- `backend/alembic/versions/add_hnsw_vector_index.py` — the index under test

--- a/docs/research/hnsw-index-fidelity.md
+++ b/docs/research/hnsw-index-fidelity.md
@@ -148,22 +148,34 @@ Outstanding, and still requiring a real indexed library:
 
 ## Recommendation
 
-**Change nothing about the index for now**, and drop the pending action to raise
-`ef_search`. The evidence available says the defaults are both correct and the
-cheapest option on realistic data.
+Scoped to what was actually measured — synthetic clustered corpora at 1k and
+10k, 768 dimensions, pgvector 0.8.4:
+
+**Make no index change on the strength of this evidence**, and drop the pending
+action to raise `ef_search`. On the tested clustered corpora the defaults were
+both exact and the cheapest option, so raising `ef_search` would buy latency and
+nothing else. That is a reason *not to act yet*, not a clearance of the
+configuration for all real libraries — the uniform results show the same
+defaults falling to 0.59 recall once neighbours stop being separated, and
+nothing here establishes which regime real SigLIP vectors sit in.
 
 Keep the explicit-setting suggestion, but for a different reason than before:
 `hnsw.ef_search` being unset is worth documenting as a deliberate choice rather
 than an inherited default, so a future pgvector version changing it is a visible
 event. That is a documentation change, not a tuning one.
 
-Re-run against a real library before treating any of this as settled:
+### Confirming against a real library
 
-```bash
-cd backend
-uv run python scripts/benchmark_hnsw_recall.py \
-    --dsn "$DATABASE_URL" --sizes 10000 --json --out hnsw_recall.json
-```
+`benchmark_hnsw_recall.py` **cannot** do this. It generates its corpus, has no
+flag for real vectors, and DROPs/CREATEs its own `hnsw_bench` table — so it must
+be pointed at a scratch database, never at a production DSN, and running it
+against `$DATABASE_URL` would measure synthetic data while writing to the real
+database.
+
+A real-corpus Track A run needs a separate, read-only measurement against the
+actual `media` table: sample query vectors from indexed rows, take exact top-k
+with `enable_indexscan = off`, compare against the normal indexed path, and
+report the neighbour margin alongside. That is the outstanding work.
 
 ## References
 

--- a/docs/research/search-retrieval-benchmark-plan.md
+++ b/docs/research/search-retrieval-benchmark-plan.md
@@ -56,8 +56,17 @@ Two consequences follow:
   **`hnsw.ef_search` is never set anywhere in the codebase**, so pgvector's default query-time
   candidate list applies. Nobody chose these values against Find's data.
 - The "recall is perfect by definition because exact search is still used" line in the existing gate
-  list is no longer safe to rely on. **Recall against exact search is now an unmeasured quantity in
-  production**, and quantifying it is the single highest-value measurement in this whole effort.
+  list is no longer safe to rely on, because exact search is not what runs.
+
+> **Measured since, and this paragraph's original conclusion was wrong.** It previously called
+> quantifying that recall "the single highest-value measurement in this whole effort", on the
+> assumption that an unmeasured approximation was probably a degraded one. It is not, on the
+> evidence available: `docs/research/hnsw-index-fidelity.md` reports **recall@10 = 1.0000** for the
+> shipped default configuration on clustered synthetic corpora at 1k and 10k, at the lowest latency
+> of any configuration tested. Recall falls only on near-uniform data where the neighbours are
+> nearly tied and the misses are therefore near-equivalent. Track A stays in the plan as a
+> confirmation step against a real library, not as an outstanding risk, and the pending action to
+> raise `ef_search` is withdrawn.
 
 Practical effect on the protocol: every embedding-quality comparison below must pin retrieval to
 exact search (`SET LOCAL enable_indexscan = off`, or a dedicated exact query path) so that ANN
@@ -206,8 +215,10 @@ evidence because it is free to revert; a schema change cannot.
 
 ## Suggested sequence
 
-1. **Track A2 first**, immediately when #100 lands. It is one measurement, it validates or
-   invalidates the existing gate framing, and it may surface a live regression.
+1. ~~**Track A2 first**~~ — **done on synthetic corpora**, see
+   `docs/research/hnsw-index-fidelity.md`. The defaults measured perfect on realistic (clustered)
+   data, so this is now a confirmation run against a real library rather than the urgent first
+   step, and it can be scheduled alongside Track B instead of ahead of everything.
 2. Track A3/A4 — cheap, runtime-only, fully reversible.
 3. Track C — query-side only, no reindex, so iteration is fast.
 4. Track B1/B4 — establishes how much the text signals actually contribute before anything is tuned.
@@ -233,9 +244,9 @@ cheapest measurement that could invalidate the plan runs first.
 2. `docs/plans/partial/local-search-quality-roadmap.md` lists "no reranking stage" as a current
    weakness; `search_ranking.py` exists. Worth correcting so the roadmap does not motivate work
    that is partly done.
-3. No `hnsw.ef_search` is set anywhere. Even before benchmarking, making this an explicit,
-   documented setting rather than an inherited default is worthwhile — it is currently a
-   production-visible knob nobody chose.
+3. No `hnsw.ef_search` is set anywhere. Measurement since says the inherited default is the right
+   value *and* the cheapest, so this is now purely about making it an explicit, documented choice
+   so a future pgvector default change is a visible event — not a tuning opportunity.
 
 ## References
 


### PR DESCRIPTION
## Summary

Track A of `docs/research/search-retrieval-benchmark-plan.md`, for #99. This is the one comparison in that plan that needs **no labeled data and no real photos** — the ground truth is exact nearest-neighbour search rather than a human judgement — so it could be run while the rest of #99 waits on a dataset.

## Headline result reverses what the plan assumed

**On clustered corpora — the realistic proxy for image embeddings — the shipped default HNSW configuration returns `recall@10 = 1.0000`, worst query 1.00, at both 1k and 10k, with the *lowest* latency of any configuration tested.**

| n | build | ef_search | recall@10 | p50 ms |
| --- | --- | --- | --- | --- |
| 10 000 | default | **default (40)** | **1.0000** | **1.52** |
| 10 000 | default | 400 | 1.0000 | 4.05 |
| 10 000 | m=32, efc=128 | 400 | 1.0000 | 30.03 |

Recall only degrades on near-uniform data (0.59 at 10k), where neighbours are nearly tied and the "misses" are near-equivalent by construction.

## This corrects something I wrote

The plan — and my comment on #99 — called quantifying this *"the single highest-value measurement in this whole effort"*, on the assumption that an unmeasured approximation was probably a degraded one. **That assumption was wrong.** The plan is updated to say so plainly, Track A becomes a confirmation run against a real library rather than an outstanding risk, and the pending action to raise `ef_search` is **withdrawn** — it costs latency for no recall.

## Two methodology errors, recorded deliberately

Both produced plausible, alarming, wrong numbers before being caught, and both are now pinned by tests:

1. **The clustered generator did not cluster.** A per-component sigma of 0.35 in 768 dimensions gives a noise vector of norm ≈9.7 against a unit centre. "Clustered" and "uniform" were silently the same distribution and produced matching results (0.2635 vs 0.2750) that looked like corroboration.
2. **Queries were generated independently of the corpus**, so they landed nowhere near it. The 10th and 60th neighbours differed by 0.0198 cosine and recall@10 collapsed into rank agreement among near-ties — reporting ~0.43 for configurations that were in fact returning equally-good results.

Every recall figure is now reported next to the **neighbour margin** it depends on, so a recall number quoted without one is visibly untrustworthy.

## Validation

```
746 passed, 7 skipped
ruff check / ruff format   clean
```

Reuses `find_api.evaluation.metrics.recall_at_k` from #100 rather than reimplementing it.

## Type of change

- [x] Feature (measurement tooling + research write-up)

## Release impact

- [x] No user-visible release note needed

## What this does not establish

Synthetic vectors, not SigLIP embeddings — this characterises the *index configuration*, not Find's search quality. The 50k tier is absent: a 50k build at `m=32, ef_construction=128` was still running after 15 minutes at default `maintenance_work_mem` and was aborted, which is recorded as an operational finding. #99 stays open; Tracks B and C still need a labeled dataset over a real library.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable benchmark for measuring HNSW search recall, build time, and query latency across synthetic datasets.
  * Supports human-readable and JSON reports with configurable corpus sizes, query counts, search settings, and output files.

* **Documentation**
  * Added research findings on HNSW index fidelity and updated the benchmark plan with the latest recommendations.

* **Tests**
  * Added comprehensive coverage for vector generation, query behavior, reproducibility, and benchmark utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->