### PR TITLE
feat: make the CPU runtime profile build, run, and report its cost (#339)

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -9,3 +9,16 @@ vault_storage
 *.db
 *.sqlite
 *.sqlite3
+
+# Model weights. Ultralytics downloads yolo*.pt into the working directory on
+# first use, so a contributor who has ever run the worker outside Docker has one
+# sitting in backend/. .gitignore keeps it out of git but not out of the build
+# context, so without this it is baked into every image — which makes image size
+# depend on whose machine built it. The runtime fetches weights into the model
+# cache volume at first run; none of them belong in the image.
+*.pt
+*.pth
+*.onnx
+*.pdparams
+*.pdmodel
+*.safetensors

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -125,6 +125,17 @@ torchvision = [
 # which is GHSA-affected (<83.0.0). The build-system pin above only governs
 # building this package, not the resolved environment, so constrain it here.
 constraint-dependencies = ["setuptools>=83.0.0"]
+# The container images are linux/amd64, but uv only guarantees the lock has
+# wheels for the platform it was locked on. Locking on Windows let the cpu
+# extra pick torchvision 0.24.1+d801a34, a local-version variant that ships a
+# win_arm64 wheel and nothing else, for the linux x86_64 marker branch — so
+# `uv sync --locked --extra cpu` inside the Dockerfile failed outright. Naming
+# the container platform here makes uv resolve to a build that actually has a
+# linux x86_64 wheel, and makes a future recurrence a lock-time error on the
+# contributor's machine instead of a build-time one in CI.
+required-environments = [
+  "sys_platform == 'linux' and platform_machine == 'x86_64'",
+]
 conflicts = [
   [
     { extra = "cpu" },

--- a/backend/scripts/cpu_profile_report.py
+++ b/backend/scripts/cpu_profile_report.py
@@ -15,8 +15,8 @@ one process is also the honest arrangement: that is what a Find worker does.
 
 Everything is local. No image, caption, OCR text, embedding, or measurement
 leaves the machine. Model weights are fetched from their normal upstream caches
-on first run exactly as the worker would fetch them; pass --skip-download-check
-off (the default) to fail fast instead of downloading.
+on first run exactly as the worker would fetch them, so the first run of each
+stage includes download time and is reported separately from steady state.
 
 Usage (from the backend directory, inside a CPU-profile container):
 
@@ -202,11 +202,12 @@ def _environment() -> dict:
     try:
         from find_api.core.hardware import detect_capabilities
 
-        report = detect_capabilities()
-        info["capabilities"] = {
-            "cuda_available": getattr(report, "cuda_available", None),
-            "onnx_providers": list(getattr(report, "onnx_providers", []) or []),
-        }
+        # Field names come from CapabilityReport in core/hardware.py. Spelling
+        # them wrong is silent -- getattr's default turns a typo into a
+        # plausible "no GPU detected" reading, which is exactly the claim this
+        # report exists to substantiate -- so use to_dict() and let the
+        # dataclass own the shape.
+        info["capabilities"] = detect_capabilities().to_dict()
     except Exception as exc:  # noqa: BLE001 - capability probing is best effort
         info["capabilities_error"] = f"{type(exc).__name__}: {exc}"
 
@@ -403,6 +404,17 @@ def main(argv: list[str] | None = None) -> int:
         Path(args.out).write_text(json.dumps(report, indent=2), encoding="utf-8")
         if not args.json:
             print(f"\nWrote {args.out}")
+
+    # A stage that could not run is the most important thing this report can
+    # surface, and the report is still worth keeping when one does. Exit 1 so a
+    # caller notices without having to parse the JSON -- which is how the
+    # PaddleOCR oneDNN breakage stayed invisible until a run was read by eye.
+    failed = sorted(
+        name for name, data in report["stages"].items() if data["status"] != "ok"
+    )
+    if failed:
+        print(f"\nStages did not complete: {', '.join(failed)}", file=sys.stderr)
+        return 1
 
     return 0
 

--- a/backend/scripts/cpu_profile_report.py
+++ b/backend/scripts/cpu_profile_report.py
@@ -1,0 +1,411 @@
+#!/usr/bin/env python3
+"""
+CPU runtime profile measurement - what the CPU-only pack costs to run.
+
+Issue #339 asks for image size, idle RAM, peak RAM, and per-image latency
+recorded on a CPU-only machine. This produces the last three by loading each ML
+stage in turn and running it over a fixed set of images, sampling process RSS
+throughout. Image size comes from `docker image inspect` and is recorded in
+docs/guides/cpu-runtime-profile.md rather than here.
+
+Stages are measured in a deliberate order - cheapest to load first - and each
+stage reports RSS *delta* over the previous steady state, so the numbers add up
+to the peak rather than each claiming the whole process. Loading every model in
+one process is also the honest arrangement: that is what a Find worker does.
+
+Everything is local. No image, caption, OCR text, embedding, or measurement
+leaves the machine. Model weights are fetched from their normal upstream caches
+on first run exactly as the worker would fetch them; pass --skip-download-check
+off (the default) to fail fast instead of downloading.
+
+Usage (from the backend directory, inside a CPU-profile container):
+
+    uv run python scripts/cpu_profile_report.py --images 10
+    uv run python scripts/cpu_profile_report.py --json --out cpu-profile.json
+    uv run python scripts/cpu_profile_report.py --stages embedding,ocr
+"""
+
+from __future__ import annotations
+
+import argparse
+import gc
+import json
+import platform
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+STAGE_ORDER = ("embedding", "objects", "ocr", "caption", "faces")
+
+
+def _rss_bytes() -> int:
+    """Resident set size of this process.
+
+    psutil is a dev dependency and is not in the runtime image, so fall back to
+    /proc, which is what the containers this runs in actually have.
+    """
+    try:
+        import psutil
+
+        return psutil.Process().memory_info().rss
+    except ImportError:
+        pass
+
+    try:
+        with open("/proc/self/status", encoding="utf-8") as handle:
+            for line in handle:
+                if line.startswith("VmRSS:"):
+                    return int(line.split()[1]) * 1024
+    except OSError:
+        pass
+    return 0
+
+
+def _human_bytes(n: int) -> str:
+    value = float(n)
+    for unit in ("B", "MB", "GB"):
+        if unit == "B":
+            if value < 1024 * 1024:
+                return f"{int(value)} B"
+            value /= 1024 * 1024
+            continue
+        if value < 1024 or unit == "GB":
+            return f"{value:.1f} {unit}"
+        value /= 1024
+    return f"{value:.1f} GB"
+
+
+def _make_images(count: int, size: int = 1024):
+    """Synthetic images with structure every stage can find something in.
+
+    Real photos would give more representative captions and detections, but they
+    cannot be committed, and a run whose inputs differ from machine to machine is
+    not a measurement. These are fixed and reproducible: latency is dominated by
+    the fixed-size forward pass, not by content. Detection *counts* from this set
+    are therefore not meaningful, and the report says so.
+    """
+    from PIL import Image, ImageDraw
+
+    images = []
+    for index in range(count):
+        image = Image.new("RGB", (size, size), (240 - index % 40, 240, 245))
+        draw = ImageDraw.Draw(image)
+        draw.rectangle(
+            [size // 8, size // 8, size // 2, size // 2],
+            fill=(30 + index % 60, 90, 160),
+        )
+        draw.ellipse(
+            [size // 2, size // 3, size - size // 8, size - size // 4],
+            fill=(200, 60 + index % 40, 60),
+        )
+        draw.text((size // 10, size - size // 6), f"INVOICE {index:04d} TOTAL 42.00")
+        images.append(image)
+    return images
+
+
+def _time_stage(fn, images) -> tuple[list[float], int, str | None]:
+    """Run `fn` over every image, returning per-image ms, peak RSS, and any error."""
+    samples: list[float] = []
+    peak = _rss_bytes()
+    for image in images:
+        started = time.perf_counter()
+        try:
+            fn(image)
+        except Exception as exc:  # noqa: BLE001 - one failing stage must not
+            # abort the run; a partial report is still worth having, and the
+            # failure itself is a result.
+            return samples, peak, f"{type(exc).__name__}: {exc}"
+        samples.append((time.perf_counter() - started) * 1000)
+        peak = max(peak, _rss_bytes())
+    return samples, peak, None
+
+
+def _percentile(sorted_samples: list[float], fraction: float) -> float:
+    if not sorted_samples:
+        return 0.0
+    index = min(int(fraction * len(sorted_samples)), len(sorted_samples) - 1)
+    return round(sorted_samples[index], 2)
+
+
+def _summarize(samples: list[float]) -> dict:
+    ordered = sorted(samples)
+    return {
+        "count": len(ordered),
+        "p50_ms": _percentile(ordered, 0.50),
+        "p95_ms": _percentile(ordered, 0.95),
+        "min_ms": round(ordered[0], 2) if ordered else 0.0,
+        "max_ms": round(ordered[-1], 2) if ordered else 0.0,
+        "mean_ms": round(sum(ordered) / len(ordered), 2) if ordered else 0.0,
+    }
+
+
+def _stage_runners() -> dict:
+    """Lazy loaders, so a stage that is not measured is never imported."""
+
+    def embedding():
+        from find_api.ml.clip_embedder import get_clip_embedder
+
+        return get_clip_embedder().embed_image
+
+    def objects():
+        from find_api.ml.object_detector import get_object_detector
+
+        return get_object_detector().detect
+
+    def ocr():
+        from find_api.ml.ocr import get_ocr_extractor
+
+        return get_ocr_extractor().extract_text
+
+    def caption():
+        from find_api.ml.captioner import get_image_captioner
+
+        return get_image_captioner().generate_caption
+
+    def faces():
+        from find_api.ml.face_detector import get_face_detector
+
+        return get_face_detector().detect_faces
+
+    return {
+        "embedding": embedding,
+        "objects": objects,
+        "ocr": ocr,
+        "caption": caption,
+        "faces": faces,
+    }
+
+
+def _environment() -> dict:
+    """Everything needed to decide whether two runs are comparable.
+
+    The protocol in docs/research/search-retrieval-benchmark-plan.md makes the
+    same demand of search benchmarks, and for the same reason: latency numbers
+    from different hardware must never share a table.
+    """
+    import os
+
+    info = {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "python": platform.python_version(),
+        "platform": platform.platform(),
+        "machine": platform.machine(),
+        "cpu_count": os.cpu_count(),
+        "build_profile": os.environ.get("FIND_BUILD_PROFILE"),
+        "ml_mode": os.environ.get("ML_MODE"),
+        "accel_mode": os.environ.get("ACCEL_MODE"),
+    }
+
+    try:
+        from find_api.core.hardware import detect_capabilities
+
+        report = detect_capabilities()
+        info["capabilities"] = {
+            "cuda_available": getattr(report, "cuda_available", None),
+            "onnx_providers": list(getattr(report, "onnx_providers", []) or []),
+        }
+    except Exception as exc:  # noqa: BLE001 - capability probing is best effort
+        info["capabilities_error"] = f"{type(exc).__name__}: {exc}"
+
+    try:
+        import torch
+
+        info["torch"] = {
+            "version": torch.__version__,
+            "cuda_available": torch.cuda.is_available(),
+            "cuda_build": torch.version.cuda,
+            "threads": torch.get_num_threads(),
+        }
+    except Exception as exc:  # noqa: BLE001
+        info["torch_error"] = f"{type(exc).__name__}: {exc}"
+
+    return info
+
+
+def build_report(stages: list[str], image_count: int, warmup: int) -> dict:
+    runners = _stage_runners()
+    images = _make_images(image_count)
+    warmup_images = images[:warmup] if warmup else []
+
+    baseline_rss = _rss_bytes()
+    results: dict[str, dict] = {}
+    peak_rss = baseline_rss
+    previous_rss = baseline_rss
+
+    for stage in stages:
+        load_started = time.perf_counter()
+        try:
+            fn = runners[stage]()
+        except Exception as exc:  # noqa: BLE001 - a stage that will not load is
+            # the single most important thing this report can surface.
+            results[stage] = {
+                "status": "load_failed",
+                "error": f"{type(exc).__name__}: {exc}",
+            }
+            continue
+        load_ms = (time.perf_counter() - load_started) * 1000
+
+        # Warm up outside the timed window. First-call cost includes lazy weight
+        # materialisation and kernel autotuning, and folding that into p50 would
+        # overstate steady-state latency by an order of magnitude on some stages.
+        first_call_ms = None
+        if warmup_images:
+            started = time.perf_counter()
+            try:
+                fn(warmup_images[0])
+                first_call_ms = round((time.perf_counter() - started) * 1000, 2)
+                for image in warmup_images[1:]:
+                    fn(image)
+            except Exception as exc:  # noqa: BLE001
+                results[stage] = {
+                    "status": "warmup_failed",
+                    "error": f"{type(exc).__name__}: {exc}",
+                    "load_ms": round(load_ms, 2),
+                }
+                continue
+
+        loaded_rss = _rss_bytes()
+        samples, stage_peak, error = _time_stage(fn, images)
+        peak_rss = max(peak_rss, stage_peak, loaded_rss)
+
+        results[stage] = {
+            "status": "ok" if error is None else "run_failed",
+            "error": error,
+            "load_ms": round(load_ms, 2),
+            "first_call_ms": first_call_ms,
+            "rss_after_load_bytes": loaded_rss,
+            "rss_delta_bytes": max(loaded_rss - previous_rss, 0),
+            "peak_rss_bytes": stage_peak,
+            "latency": _summarize(samples),
+        }
+        previous_rss = loaded_rss
+        gc.collect()
+
+    return {
+        "report_schema_version": 1,
+        "environment": _environment(),
+        "measurement": {
+            "images_per_stage": image_count,
+            "warmup_images": warmup,
+            "image_source": "synthetic 1024x1024 shapes with rendered text",
+            "caveat": (
+                "Latency and RSS are real; detection and caption *content* is "
+                "not representative, because the inputs are synthetic. Use this "
+                "for cost, not for quality."
+            ),
+        },
+        "memory": {
+            "baseline_rss_bytes": baseline_rss,
+            "peak_rss_bytes": peak_rss,
+            "loaded_rss_bytes": previous_rss,
+        },
+        "stages": results,
+    }
+
+
+def _print_human(report: dict) -> None:
+    env = report["environment"]
+    print(f"CPU runtime profile - generated {env['generated_at']}")
+    print(f"Platform      : {env['platform']} ({env['cpu_count']} cpus)")
+    print(f"Build profile : {env.get('build_profile') or '-'}")
+    torch_info = env.get("torch") or {}
+    if torch_info:
+        print(
+            f"Torch         : {torch_info.get('version')} "
+            f"(cuda_available={torch_info.get('cuda_available')}, "
+            f"threads={torch_info.get('threads')})"
+        )
+    print()
+
+    memory = report["memory"]
+    print(f"Idle RSS      : {_human_bytes(memory['baseline_rss_bytes'])}")
+    print(f"Loaded RSS    : {_human_bytes(memory['loaded_rss_bytes'])}")
+    print(f"Peak RSS      : {_human_bytes(memory['peak_rss_bytes'])}")
+    print()
+
+    header = (
+        f"{'STAGE':<11} {'STATUS':<13} {'LOAD':>9} {'RSS+':>9} "
+        f"{'FIRST':>9} {'P50':>9} {'P95':>9}"
+    )
+    print(header)
+    print("-" * len(header))
+    for stage, data in report["stages"].items():
+        if data["status"] not in {"ok", "run_failed"}:
+            print(f"{stage:<11} {data['status']:<13} {data.get('error', '')}")
+            continue
+        latency = data["latency"]
+        first = data["first_call_ms"]
+        print(
+            f"{stage:<11} {data['status']:<13} "
+            f"{data['load_ms']:>8.0f}m {_human_bytes(data['rss_delta_bytes']):>9} "
+            f"{(f'{first:.0f}m' if first else '-'):>9} "
+            f"{latency['p50_ms']:>8.0f}m {latency['p95_ms']:>8.0f}m"
+        )
+        if data["error"]:
+            print(f"{'':<11} {data['error']}")
+
+    print()
+    print(report["measurement"]["caveat"])
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Measure the CPU runtime profile's memory and latency cost.",
+    )
+    parser.add_argument("--images", type=int, default=10, help="images per stage")
+    parser.add_argument(
+        "--warmup",
+        type=int,
+        default=1,
+        help="untimed images run before measurement (0 to include first-call cost)",
+    )
+    parser.add_argument(
+        "--stages",
+        default=",".join(STAGE_ORDER),
+        help=f"comma-separated subset of: {', '.join(STAGE_ORDER)}",
+    )
+    parser.add_argument("--json", action="store_true", help="emit JSON only")
+    parser.add_argument("--out", default=None, help="also write JSON to this path")
+    args = parser.parse_args(argv)
+
+    if args.images < 1:
+        print("error: --images must be at least 1", file=sys.stderr)
+        return 2
+    if args.warmup < 0:
+        print("error: --warmup cannot be negative", file=sys.stderr)
+        return 2
+
+    stages = [s.strip() for s in args.stages.split(",") if s.strip()]
+    unknown = [s for s in stages if s not in STAGE_ORDER]
+    if unknown:
+        print(
+            f"error: unknown stage(s) {', '.join(unknown)}; "
+            f"known stages: {', '.join(STAGE_ORDER)}",
+            file=sys.stderr,
+        )
+        return 2
+
+    # Measure in the documented order regardless of how they were listed, so RSS
+    # deltas stay comparable between runs.
+    stages = [s for s in STAGE_ORDER if s in stages]
+
+    report = build_report(stages, args.images, args.warmup)
+
+    if args.json:
+        print(json.dumps(report, indent=2))
+    else:
+        _print_human(report)
+
+    if args.out:
+        Path(args.out).write_text(json.dumps(report, indent=2), encoding="utf-8")
+        if not args.json:
+            print(f"\nWrote {args.out}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/src/find_api/ml/ocr.py
+++ b/backend/src/find_api/ml/ocr.py
@@ -1,11 +1,16 @@
 """
 OCR using PaddleOCR (CPU optimized).
 
-The supported runtime is PaddleOCR 3.x with PaddlePaddle 3.2.x. PaddleOCR 3.x
-uses the ``predict`` API and pipeline flags such as
+The supported runtime is PaddleOCR 3.x with PaddlePaddle 3.2.x or 3.3.x.
+PaddleOCR 3.x uses the ``predict`` API and pipeline flags such as
 ``use_textline_orientation``. A small PaddleOCR 2.x fallback remains so older
 local environments fail less abruptly, but the lockfile should resolve the
 current 3.x stack.
+
+PaddlePaddle 3.3.1 regressed its oneDNN kernels and raises
+``NotImplementedError`` on the first prediction, so ``_load_model`` probes once
+after construction and reloads with ``enable_mkldnn=False`` when that happens.
+See ``OCRExtractor._onednn_inference_works``.
 
 PP-OCRv5 ships two hardware-targeted variants for both the detection and
 recognition models:
@@ -93,21 +98,24 @@ class OCRExtractor:
             )
         return resolved
 
-    def _load_model(self):
-        """Loader function for ModelManager"""
-        logger.info("Loading PaddleOCR model (variant=%s)...", self.variant)
+    def _construct(self, *, disable_onednn: bool = False):
+        """Build a PaddleOCR pipeline, returning it plus whether 2.x was used."""
         model_names = PP_OCR_MODELS[self.variant]
+        extra = {"enable_mkldnn": False} if disable_onednn else {}
         # PaddleOCR 3.x replaced the older use_angle_cls/use_gpu/show_log arguments
         # with pipeline-specific flags. Try the current API first, then fall back
         # for older 2.x installs. PaddleOCR 2.x has no mobile/server split, so
         # the requested variant only applies on the 3.x path.
-        legacy_api = False
         try:
-            model = PaddleOCR(
-                use_doc_orientation_classify=False,
-                use_doc_unwarping=False,
-                use_textline_orientation=True,
-                **model_names,
+            return (
+                PaddleOCR(
+                    use_doc_orientation_classify=False,
+                    use_doc_unwarping=False,
+                    use_textline_orientation=True,
+                    **model_names,
+                    **extra,
+                ),
+                False,
             )
         except TypeError as exc:
             # Only a constructor signature mismatch means "this is really a 2.x
@@ -116,10 +124,51 @@ class OCRExtractor:
             # instead of being masked by a legacy retry that silently ignores
             # the requested variant.
             logger.info("Falling back to PaddleOCR 2.x arguments: %s", exc)
-            model = PaddleOCR(
-                use_angle_cls=True, lang=LEGACY_FALLBACK_LANG, use_gpu=False
+            return (
+                PaddleOCR(use_angle_cls=True, lang=LEGACY_FALLBACK_LANG, use_gpu=False),
+                True,
             )
-            legacy_api = True
+
+    @staticmethod
+    def _onednn_inference_works(model) -> bool:
+        """Run one tiny prediction to find out whether oneDNN kernels work here.
+
+        PaddlePaddle 3.3.1 raises ``NotImplementedError`` from its oneDNN
+        instruction path on the first real prediction --
+        ``ConvertPirAttribute2RuntimeAttribute not support
+        [pir::ArrayAttribute<pir::DoubleAttribute>]`` -- which takes down every
+        OCR call in the container. PaddlePaddle 3.2.x is unaffected, so this is
+        a version regression rather than a CPU-profile quirk, and it hits any
+        image built from the current lock.
+
+        The probe has to run an actual prediction because construction succeeds
+        either way; there is no flag to interrogate. It costs one forward pass
+        on a 32x32 blank image, once per load.
+        """
+        try:
+            model.predict(np.zeros((32, 32, 3), dtype=np.uint8))
+        except NotImplementedError:
+            return False
+        except Exception:  # noqa: BLE001 - any other failure is not what this
+            # probe is testing for. Report the runtime as usable and let the
+            # real call surface its own error rather than silently switching
+            # kernels for an unrelated reason.
+            return True
+        return True
+
+    def _load_model(self):
+        """Loader function for ModelManager"""
+        logger.info("Loading PaddleOCR model (variant=%s)...", self.variant)
+
+        model, legacy_api = self._construct()
+
+        if not legacy_api and not self._onednn_inference_works(model):
+            logger.warning(
+                "PaddleOCR oneDNN kernels are unusable in this environment "
+                "(known PaddlePaddle 3.3.x regression); reloading with "
+                "enable_mkldnn=False. OCR will be slower but functional."
+            )
+            model, legacy_api = self._construct(disable_onednn=True)
 
         self._publish_variant_status(legacy_api=legacy_api)
         return model

--- a/backend/tests/test_ocr.py
+++ b/backend/tests/test_ocr.py
@@ -133,3 +133,94 @@ class TestOCRErrorHandling:
         img = Image.new("RGB", (1, 1))
         result = ocr_extractor.extract_text(img)
         assert isinstance(result, str)
+
+
+class TestOneDnnFallback:
+    """The PaddlePaddle 3.3.1 oneDNN regression and the reload that works around it.
+
+    3.3.1 raises NotImplementedError from its oneDNN instruction path on the
+    first prediction, which takes down every OCR call in a container built from
+    the current lock. 3.2.x is unaffected, so the fallback must trigger on the
+    failure rather than on a version check or a profile flag.
+    """
+
+    def test_probe_reports_unusable_on_not_implemented_error(self, ocr_extractor):
+        class Broken:
+            def predict(self, _image):
+                raise NotImplementedError("ConvertPirAttribute2RuntimeAttribute")
+
+        assert ocr_extractor._onednn_inference_works(Broken()) is False
+
+    def test_probe_reports_usable_on_success(self, ocr_extractor):
+        class Working:
+            def predict(self, _image):
+                return []
+
+        assert ocr_extractor._onednn_inference_works(Working()) is True
+
+    def test_probe_does_not_swallow_unrelated_failures(self, ocr_extractor):
+        """An unrelated error must not silently switch kernels.
+
+        Downgrading oneDNN because a model download failed would hide the real
+        problem and make OCR quietly slower forever.
+        """
+
+        class Unrelated:
+            def predict(self, _image):
+                raise RuntimeError("model weights missing")
+
+        assert ocr_extractor._onednn_inference_works(Unrelated()) is True
+
+    def test_load_model_reloads_without_onednn_when_probe_fails(
+        self, ocr_extractor, monkeypatch
+    ):
+        constructed: list[bool] = []
+
+        def fake_construct(*, disable_onednn=False):
+            constructed.append(disable_onednn)
+            return object(), False
+
+        monkeypatch.setattr(ocr_extractor, "_construct", fake_construct)
+        monkeypatch.setattr(
+            ocr_extractor, "_onednn_inference_works", lambda _model: False
+        )
+        monkeypatch.setattr(ocr_extractor, "_publish_variant_status", lambda **_: None)
+
+        ocr_extractor._load_model()
+
+        assert constructed == [False, True]
+
+    def test_load_model_keeps_onednn_when_probe_succeeds(
+        self, ocr_extractor, monkeypatch
+    ):
+        constructed: list[bool] = []
+
+        def fake_construct(*, disable_onednn=False):
+            constructed.append(disable_onednn)
+            return object(), False
+
+        monkeypatch.setattr(ocr_extractor, "_construct", fake_construct)
+        monkeypatch.setattr(
+            ocr_extractor, "_onednn_inference_works", lambda _model: True
+        )
+        monkeypatch.setattr(ocr_extractor, "_publish_variant_status", lambda **_: None)
+
+        ocr_extractor._load_model()
+
+        assert constructed == [False]
+
+    def test_legacy_2x_path_skips_the_probe(self, ocr_extractor, monkeypatch):
+        """PaddleOCR 2.x has no oneDNN pipeline flag, so probing it is pointless."""
+        probed: list[object] = []
+
+        monkeypatch.setattr(ocr_extractor, "_construct", lambda **_: (object(), True))
+        monkeypatch.setattr(
+            ocr_extractor,
+            "_onednn_inference_works",
+            lambda model: probed.append(model) or True,
+        )
+        monkeypatch.setattr(ocr_extractor, "_publish_variant_status", lambda **_: None)
+
+        ocr_extractor._load_model()
+
+        assert probed == []

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,8 +9,12 @@ resolution-markers = [
     "sys_platform == 'darwin' and extra == 'extra-12-find-backend-cpu' and extra != 'extra-12-find-backend-nvidia'",
     "platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-12-find-backend-cpu' and extra != 'extra-12-find-backend-nvidia'",
     "sys_platform == 'win32' and extra == 'extra-12-find-backend-cpu' and extra != 'extra-12-find-backend-nvidia'",
-    "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-12-find-backend-cpu' and extra != 'extra-12-find-backend-nvidia') or (sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-12-find-backend-cpu' and extra != 'extra-12-find-backend-nvidia')",
+    "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux' and extra == 'extra-12-find-backend-cpu' and extra != 'extra-12-find-backend-nvidia') or (sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-12-find-backend-cpu' and extra != 'extra-12-find-backend-nvidia')",
+    "platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-12-find-backend-cpu' and extra != 'extra-12-find-backend-nvidia'",
     "extra != 'extra-12-find-backend-cpu' and extra != 'extra-12-find-backend-nvidia'",
+]
+required-markers = [
+    "platform_machine == 'x86_64' and sys_platform == 'linux'",
 ]
 conflicts = [[
     { package = "find-backend", extra = "cpu" },
@@ -657,7 +661,8 @@ cpu = [
     { name = "torch", version = "2.9.1", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform == 'darwin' and extra == 'extra-12-find-backend-cpu') or (extra == 'extra-12-find-backend-cpu' and extra == 'extra-12-find-backend-nvidia')" },
     { name = "torch", version = "2.9.1+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform != 'darwin' and extra == 'extra-12-find-backend-cpu') or (extra == 'extra-12-find-backend-cpu' and extra == 'extra-12-find-backend-nvidia')" },
     { name = "torchvision", version = "0.24.1", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-12-find-backend-cpu') or (platform_machine != 'aarch64' and extra == 'extra-12-find-backend-cpu' and extra == 'extra-12-find-backend-nvidia') or (sys_platform == 'darwin' and extra == 'extra-12-find-backend-cpu') or (sys_platform != 'linux' and extra == 'extra-12-find-backend-cpu' and extra == 'extra-12-find-backend-nvidia')" },
-    { name = "torchvision", version = "0.24.1+d801a34", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-12-find-backend-cpu') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-12-find-backend-cpu') or (sys_platform == 'darwin' and extra == 'extra-12-find-backend-cpu' and extra == 'extra-12-find-backend-nvidia') or (sys_platform == 'linux' and extra == 'extra-12-find-backend-cpu' and extra == 'extra-12-find-backend-nvidia')" },
+    { name = "torchvision", version = "0.24.1+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-12-find-backend-cpu') or (platform_machine != 'x86_64' and extra == 'extra-12-find-backend-cpu' and extra == 'extra-12-find-backend-nvidia') or (sys_platform != 'linux' and extra == 'extra-12-find-backend-cpu' and extra == 'extra-12-find-backend-nvidia')" },
+    { name = "torchvision", version = "0.24.1+d801a34", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux' and extra == 'extra-12-find-backend-cpu') or (platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-12-find-backend-cpu' and extra == 'extra-12-find-backend-nvidia') or (platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-12-find-backend-cpu' and extra == 'extra-12-find-backend-nvidia') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-12-find-backend-cpu') or (sys_platform == 'darwin' and extra == 'extra-12-find-backend-cpu' and extra == 'extra-12-find-backend-nvidia')" },
     { name = "transformers" },
     { name = "ultralytics" },
 ]
@@ -1387,7 +1392,7 @@ name = "nvidia-cudnn-cu12"
 version = "9.10.2.21"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12", marker = "(sys_platform != 'darwin' and sys_platform != 'win32' and extra == 'extra-12-find-backend-nvidia') or (sys_platform == 'darwin' and extra == 'extra-12-find-backend-cpu' and extra == 'extra-12-find-backend-nvidia') or (sys_platform == 'win32' and extra == 'extra-12-find-backend-cpu' and extra == 'extra-12-find-backend-nvidia')" },
+    { name = "nvidia-cublas-cu12", marker = "(sys_platform != 'darwin' and extra == 'extra-12-find-backend-nvidia') or (extra == 'extra-12-find-backend-cpu' and extra == 'extra-12-find-backend-nvidia')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fa/41/e79269ce215c857c935fd86bcfe91a451a584dfc27f1e068f568b9ad1ab7/nvidia_cudnn_cu12-9.10.2.21-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:c9132cc3f8958447b4910a1720036d9eff5928cc3179b0a51fb6d167c6cc87d8", size = 705026878, upload-time = "2025-06-06T21:52:51.348Z" },
@@ -1400,7 +1405,7 @@ name = "nvidia-cufft-cu12"
 version = "11.3.3.83"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12", marker = "(sys_platform != 'darwin' and sys_platform != 'win32' and extra == 'extra-12-find-backend-nvidia') or (sys_platform == 'darwin' and extra == 'extra-12-find-backend-cpu' and extra == 'extra-12-find-backend-nvidia') or (sys_platform == 'win32' and extra == 'extra-12-find-backend-cpu' and extra == 'extra-12-find-backend-nvidia')" },
+    { name = "nvidia-nvjitlink-cu12", marker = "(sys_platform != 'darwin' and extra == 'extra-12-find-backend-nvidia') or (extra == 'extra-12-find-backend-cpu' and extra == 'extra-12-find-backend-nvidia')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/60/bc/7771846d3a0272026c416fbb7e5f4c1f146d6d80704534d0b187dd6f4800/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:848ef7224d6305cdb2a4df928759dca7b1201874787083b6e7550dd6765ce69a", size = 193109211, upload-time = "2025-03-07T01:44:56.873Z" },
@@ -1432,9 +1437,9 @@ name = "nvidia-cusolver-cu12"
 version = "11.7.3.90"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12", marker = "(sys_platform != 'darwin' and sys_platform != 'win32' and extra == 'extra-12-find-backend-nvidia') or (sys_platform == 'darwin' and extra == 'extra-12-find-backend-cpu' and extra == 'extra-12-find-backend-nvidia') or (sys_platform == 'win32' and extra == 'extra-12-find-backend-cpu' and extra == 'extra-12-find-backend-nvidia')" },
-    { name = "nvidia-cusparse-cu12", marker = "(sys_platform != 'darwin' and sys_platform != 'win32' and extra == 'extra-12-find-backend-nvidia') or (sys_platform == 'darwin' and extra == 'extra-12-find-backend-cpu' and extra == 'extra-12-find-backend-nvidia') or (sys_platform == 'win32' and extra == 'extra-12-find-backend-cpu' and extra == 'extra-12-find-backend-nvidia')" },
-    { name = "nvidia-nvjitlink-cu12", marker = "(sys_platform != 'darwin' and sys_platform != 'win32' and extra == 'extra-12-find-backend-nvidia') or (sys_platform == 'darwin' and extra == 'extra-12-find-backend-cpu' and extra == 'extra-12-find-backend-nvidia') or (sys_platform == 'win32' and extra == 'extra-12-find-backend-cpu' and extra == 'extra-12-find-backend-nvidia')" },
+    { name = "nvidia-cublas-cu12", marker = "(sys_platform != 'darwin' and extra == 'extra-12-find-backend-nvidia') or (extra == 'extra-12-find-backend-cpu' and extra == 'extra-12-find-backend-nvidia')" },
+    { name = "nvidia-cusparse-cu12", marker = "(sys_platform != 'darwin' and extra == 'extra-12-find-backend-nvidia') or (extra == 'extra-12-find-backend-cpu' and extra == 'extra-12-find-backend-nvidia')" },
+    { name = "nvidia-nvjitlink-cu12", marker = "(sys_platform != 'darwin' and extra == 'extra-12-find-backend-nvidia') or (extra == 'extra-12-find-backend-cpu' and extra == 'extra-12-find-backend-nvidia')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/32/f7cd6ce8a7690544d084ea21c26e910a97e077c9b7f07bf5de623ee19981/nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:db9ed69dbef9715071232caa9b69c52ac7de3a95773c2db65bdba85916e4e5c0", size = 267229841, upload-time = "2025-03-07T01:46:54.356Z" },
@@ -1447,7 +1452,7 @@ name = "nvidia-cusparse-cu12"
 version = "12.5.8.93"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12", marker = "(sys_platform != 'darwin' and sys_platform != 'win32' and extra == 'extra-12-find-backend-nvidia') or (sys_platform == 'darwin' and extra == 'extra-12-find-backend-cpu' and extra == 'extra-12-find-backend-nvidia') or (sys_platform == 'win32' and extra == 'extra-12-find-backend-cpu' and extra == 'extra-12-find-backend-nvidia')" },
+    { name = "nvidia-nvjitlink-cu12", marker = "(sys_platform != 'darwin' and extra == 'extra-12-find-backend-nvidia') or (extra == 'extra-12-find-backend-cpu' and extra == 'extra-12-find-backend-nvidia')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bc/f7/cd777c4109681367721b00a106f491e0d0d15cfa1fd59672ce580ce42a97/nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:9b6c161cb130be1a07a27ea6923df8141f3c295852f4b260c65f18f3e0a091dc", size = 288117129, upload-time = "2025-03-07T01:47:40.407Z" },
@@ -1581,8 +1586,9 @@ dependencies = [
     { name = "torch", version = "2.9.1+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "extra == 'extra-12-find-backend-nvidia'" },
     { name = "torchvision", version = "0.24.1", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-12-find-backend-cpu') or (platform_machine != 'aarch64' and extra == 'extra-12-find-backend-cpu' and extra == 'extra-12-find-backend-nvidia') or (sys_platform == 'darwin' and extra == 'extra-12-find-backend-cpu') or (sys_platform != 'linux' and extra == 'extra-12-find-backend-cpu' and extra == 'extra-12-find-backend-nvidia')" },
     { name = "torchvision", version = "0.24.1", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-12-find-backend-nvidia') or (platform_machine != 'aarch64' and extra == 'extra-12-find-backend-cpu' and extra == 'extra-12-find-backend-nvidia') or (sys_platform != 'linux' and extra == 'extra-12-find-backend-cpu' and extra == 'extra-12-find-backend-nvidia')" },
+    { name = "torchvision", version = "0.24.1+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-12-find-backend-cpu') or (platform_machine != 'x86_64' and extra == 'extra-12-find-backend-cpu' and extra == 'extra-12-find-backend-nvidia') or (sys_platform != 'linux' and extra == 'extra-12-find-backend-cpu' and extra == 'extra-12-find-backend-nvidia')" },
     { name = "torchvision", version = "0.24.1+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(platform_machine != 'aarch64' and extra == 'extra-12-find-backend-nvidia') or (sys_platform != 'linux' and extra == 'extra-12-find-backend-nvidia') or (extra == 'extra-12-find-backend-cpu' and extra == 'extra-12-find-backend-nvidia')" },
-    { name = "torchvision", version = "0.24.1+d801a34", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-12-find-backend-cpu') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-12-find-backend-cpu') or (sys_platform == 'darwin' and extra == 'extra-12-find-backend-cpu' and extra == 'extra-12-find-backend-nvidia') or (sys_platform == 'linux' and extra == 'extra-12-find-backend-cpu' and extra == 'extra-12-find-backend-nvidia')" },
+    { name = "torchvision", version = "0.24.1+d801a34", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux' and extra == 'extra-12-find-backend-cpu') or (platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-12-find-backend-cpu' and extra == 'extra-12-find-backend-nvidia') or (platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-12-find-backend-cpu' and extra == 'extra-12-find-backend-nvidia') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-12-find-backend-cpu') or (sys_platform == 'darwin' and extra == 'extra-12-find-backend-cpu' and extra == 'extra-12-find-backend-nvidia')" },
     { name = "tqdm" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/4a/1f/2bc9795047fa2c1ad2567ef78ce6dfc9a7b763fa534acee09a94da2a5b8f/open_clip_torch-3.3.0.tar.gz", hash = "sha256:904b1a9f909df8281bb3de60ab95491cd2994a509177ea4f9d6292a84fe24d6d", size = 1503380, upload-time = "2026-02-27T00:32:46.74Z" }
@@ -2670,8 +2676,9 @@ dependencies = [
     { name = "torch", version = "2.9.1+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "extra == 'extra-12-find-backend-nvidia'" },
     { name = "torchvision", version = "0.24.1", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-12-find-backend-cpu') or (platform_machine != 'aarch64' and extra == 'extra-12-find-backend-cpu' and extra == 'extra-12-find-backend-nvidia') or (sys_platform == 'darwin' and extra == 'extra-12-find-backend-cpu') or (sys_platform != 'linux' and extra == 'extra-12-find-backend-cpu' and extra == 'extra-12-find-backend-nvidia')" },
     { name = "torchvision", version = "0.24.1", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-12-find-backend-nvidia') or (platform_machine != 'aarch64' and extra == 'extra-12-find-backend-cpu' and extra == 'extra-12-find-backend-nvidia') or (sys_platform != 'linux' and extra == 'extra-12-find-backend-cpu' and extra == 'extra-12-find-backend-nvidia')" },
+    { name = "torchvision", version = "0.24.1+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-12-find-backend-cpu') or (platform_machine != 'x86_64' and extra == 'extra-12-find-backend-cpu' and extra == 'extra-12-find-backend-nvidia') or (sys_platform != 'linux' and extra == 'extra-12-find-backend-cpu' and extra == 'extra-12-find-backend-nvidia')" },
     { name = "torchvision", version = "0.24.1+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(platform_machine != 'aarch64' and extra == 'extra-12-find-backend-nvidia') or (sys_platform != 'linux' and extra == 'extra-12-find-backend-nvidia') or (extra == 'extra-12-find-backend-cpu' and extra == 'extra-12-find-backend-nvidia')" },
-    { name = "torchvision", version = "0.24.1+d801a34", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-12-find-backend-cpu') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-12-find-backend-cpu') or (sys_platform == 'darwin' and extra == 'extra-12-find-backend-cpu' and extra == 'extra-12-find-backend-nvidia') or (sys_platform == 'linux' and extra == 'extra-12-find-backend-cpu' and extra == 'extra-12-find-backend-nvidia')" },
+    { name = "torchvision", version = "0.24.1+d801a34", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux' and extra == 'extra-12-find-backend-cpu') or (platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-12-find-backend-cpu' and extra == 'extra-12-find-backend-nvidia') or (platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-12-find-backend-cpu' and extra == 'extra-12-find-backend-nvidia') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-12-find-backend-cpu') or (sys_platform == 'darwin' and extra == 'extra-12-find-backend-cpu' and extra == 'extra-12-find-backend-nvidia')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/35/03/e41389ac641747bfec48d016fde8be1eade1901e6f2c1aedcb0c8cb4b5d9/timm-1.0.28.tar.gz", hash = "sha256:3789d313fdd5541a327b60180d70dbb4bdec73db8ff0655e413db3c3d134a9a4", size = 2451413, upload-time = "2026-07-11T17:24:32.615Z" }
 wheels = [
@@ -2758,7 +2765,8 @@ source = { registry = "https://download.pytorch.org/whl/cpu" }
 resolution-markers = [
     "platform_machine == 'aarch64' and sys_platform == 'linux'",
     "sys_platform == 'win32'",
-    "(platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
+    "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
+    "platform_machine == 'x86_64' and sys_platform == 'linux'",
 ]
 dependencies = [
     { name = "filelock", marker = "(sys_platform != 'darwin' and extra == 'extra-12-find-backend-cpu') or (extra == 'extra-12-find-backend-cpu' and extra == 'extra-12-find-backend-nvidia')" },
@@ -2854,6 +2862,23 @@ wheels = [
 
 [[package]]
 name = "torchvision"
+version = "0.24.1+cpu"
+source = { registry = "https://download.pytorch.org/whl/cpu" }
+resolution-markers = [
+    "platform_machine == 'x86_64' and sys_platform == 'linux'",
+]
+dependencies = [
+    { name = "numpy", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-12-find-backend-cpu') or (platform_machine != 'x86_64' and extra == 'extra-12-find-backend-cpu' and extra == 'extra-12-find-backend-nvidia') or (sys_platform != 'linux' and extra == 'extra-12-find-backend-cpu' and extra == 'extra-12-find-backend-nvidia')" },
+    { name = "pillow", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-12-find-backend-cpu') or (platform_machine != 'x86_64' and extra == 'extra-12-find-backend-cpu' and extra == 'extra-12-find-backend-nvidia') or (sys_platform != 'linux' and extra == 'extra-12-find-backend-cpu' and extra == 'extra-12-find-backend-nvidia')" },
+    { name = "torch", version = "2.9.1+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-12-find-backend-cpu') or (platform_machine != 'x86_64' and extra == 'extra-12-find-backend-cpu' and extra == 'extra-12-find-backend-nvidia') or (sys_platform != 'linux' and extra == 'extra-12-find-backend-cpu' and extra == 'extra-12-find-backend-nvidia')" },
+]
+wheels = [
+    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.24.1%2Bcpu-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:48ff40694812292f1f75cddb517f9eef224a2e8388798a0aa191e27bf159fc5d", upload-time = "2025-11-15T18:12:45Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.24.1%2Bcpu-cp312-cp312-win_amd64.whl", hash = "sha256:af904a34b563c302fa4583a4746f3108bafdc5823a67c912d6023a8fe9b01c51", upload-time = "2025-11-15T18:12:45Z" },
+]
+
+[[package]]
+name = "torchvision"
 version = "0.24.1+cu128"
 source = { registry = "https://download.pytorch.org/whl/cu128" }
 resolution-markers = [
@@ -2877,12 +2902,12 @@ version = "0.24.1+d801a34"
 source = { registry = "https://download.pytorch.org/whl/cpu" }
 resolution-markers = [
     "sys_platform == 'win32'",
-    "(platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
+    "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
 ]
 dependencies = [
-    { name = "numpy", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-12-find-backend-cpu') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-12-find-backend-cpu') or (sys_platform == 'darwin' and extra == 'extra-12-find-backend-cpu' and extra == 'extra-12-find-backend-nvidia') or (sys_platform == 'linux' and extra == 'extra-12-find-backend-cpu' and extra == 'extra-12-find-backend-nvidia')" },
-    { name = "pillow", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-12-find-backend-cpu') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-12-find-backend-cpu') or (sys_platform == 'darwin' and extra == 'extra-12-find-backend-cpu' and extra == 'extra-12-find-backend-nvidia') or (sys_platform == 'linux' and extra == 'extra-12-find-backend-cpu' and extra == 'extra-12-find-backend-nvidia')" },
-    { name = "torch", version = "2.9.1+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-12-find-backend-cpu') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-12-find-backend-cpu') or (sys_platform == 'darwin' and extra == 'extra-12-find-backend-cpu' and extra == 'extra-12-find-backend-nvidia') or (sys_platform == 'linux' and extra == 'extra-12-find-backend-cpu' and extra == 'extra-12-find-backend-nvidia')" },
+    { name = "numpy", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux' and extra == 'extra-12-find-backend-cpu') or (platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-12-find-backend-cpu' and extra == 'extra-12-find-backend-nvidia') or (platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-12-find-backend-cpu' and extra == 'extra-12-find-backend-nvidia') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-12-find-backend-cpu') or (sys_platform == 'darwin' and extra == 'extra-12-find-backend-cpu' and extra == 'extra-12-find-backend-nvidia')" },
+    { name = "pillow", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux' and extra == 'extra-12-find-backend-cpu') or (platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-12-find-backend-cpu' and extra == 'extra-12-find-backend-nvidia') or (platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-12-find-backend-cpu' and extra == 'extra-12-find-backend-nvidia') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-12-find-backend-cpu') or (sys_platform == 'darwin' and extra == 'extra-12-find-backend-cpu' and extra == 'extra-12-find-backend-nvidia')" },
+    { name = "torch", version = "2.9.1+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux' and extra == 'extra-12-find-backend-cpu') or (platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-12-find-backend-cpu' and extra == 'extra-12-find-backend-nvidia') or (platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-12-find-backend-cpu' and extra == 'extra-12-find-backend-nvidia') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-12-find-backend-cpu') or (sys_platform == 'darwin' and extra == 'extra-12-find-backend-cpu' and extra == 'extra-12-find-backend-nvidia')" },
 ]
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.24.1%2Bd801a34-cp312-cp312-win_arm64.whl", hash = "sha256:f5568bb4dc4069a1e1b1b56bf797db35a37a582e08d227c59f765193f336735c", upload-time = "2025-11-15T18:12:45Z" },
@@ -3021,8 +3046,9 @@ dependencies = [
     { name = "torch", version = "2.9.1+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "extra == 'extra-12-find-backend-nvidia'" },
     { name = "torchvision", version = "0.24.1", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-12-find-backend-cpu') or (platform_machine != 'aarch64' and extra == 'extra-12-find-backend-cpu' and extra == 'extra-12-find-backend-nvidia') or (sys_platform == 'darwin' and extra == 'extra-12-find-backend-cpu') or (sys_platform != 'linux' and extra == 'extra-12-find-backend-cpu' and extra == 'extra-12-find-backend-nvidia')" },
     { name = "torchvision", version = "0.24.1", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-12-find-backend-nvidia') or (platform_machine != 'aarch64' and extra == 'extra-12-find-backend-cpu' and extra == 'extra-12-find-backend-nvidia') or (sys_platform != 'linux' and extra == 'extra-12-find-backend-cpu' and extra == 'extra-12-find-backend-nvidia')" },
+    { name = "torchvision", version = "0.24.1+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-12-find-backend-cpu') or (platform_machine != 'x86_64' and extra == 'extra-12-find-backend-cpu' and extra == 'extra-12-find-backend-nvidia') or (sys_platform != 'linux' and extra == 'extra-12-find-backend-cpu' and extra == 'extra-12-find-backend-nvidia')" },
     { name = "torchvision", version = "0.24.1+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(platform_machine != 'aarch64' and extra == 'extra-12-find-backend-nvidia') or (sys_platform != 'linux' and extra == 'extra-12-find-backend-nvidia') or (extra == 'extra-12-find-backend-cpu' and extra == 'extra-12-find-backend-nvidia')" },
-    { name = "torchvision", version = "0.24.1+d801a34", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-12-find-backend-cpu') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-12-find-backend-cpu') or (sys_platform == 'darwin' and extra == 'extra-12-find-backend-cpu' and extra == 'extra-12-find-backend-nvidia') or (sys_platform == 'linux' and extra == 'extra-12-find-backend-cpu' and extra == 'extra-12-find-backend-nvidia')" },
+    { name = "torchvision", version = "0.24.1+d801a34", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux' and extra == 'extra-12-find-backend-cpu') or (platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-12-find-backend-cpu' and extra == 'extra-12-find-backend-nvidia') or (platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-12-find-backend-cpu' and extra == 'extra-12-find-backend-nvidia') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-12-find-backend-cpu') or (sys_platform == 'darwin' and extra == 'extra-12-find-backend-cpu' and extra == 'extra-12-find-backend-nvidia')" },
     { name = "ultralytics-thop" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/39/6a/9b1a4976021b33fa989606ace1f18dc463bfee1e3fcdc5c5a5e982cc829d/ultralytics-8.4.112.tar.gz", hash = "sha256:84511b8bff6d7258a37eaa070a1ae6622578498d092f9efd2435894d1871384a", size = 1206177, upload-time = "2026-07-29T17:37:41.188Z" }

--- a/compose.cpu.yml
+++ b/compose.cpu.yml
@@ -28,6 +28,15 @@ services:
       USE_GPU: "false"
     volumes:
       - model_cache:/root/.cache
+      # PaddleOCR and InsightFace do not use XDG cache paths, so a single
+      # /root/.cache mount silently misses them: PP-OCRv5 weights land in
+      # /root/.paddlex/official_models and antelopev2 in /root/.insightface,
+      # both inside the container's writable layer. Without these two mounts
+      # every `compose up` that recreates the container re-downloads roughly
+      # 100 MB of OCR and 360 MB of face weights, which reads as "first run is
+      # slow" forever rather than once.
+      - paddlex_cache:/root/.paddlex
+      - insightface_cache:/root/.insightface
   worker:
     extends:
       file: compose.base.yml
@@ -45,6 +54,15 @@ services:
       USE_GPU: "false"
     volumes:
       - model_cache:/root/.cache
+      # PaddleOCR and InsightFace do not use XDG cache paths, so a single
+      # /root/.cache mount silently misses them: PP-OCRv5 weights land in
+      # /root/.paddlex/official_models and antelopev2 in /root/.insightface,
+      # both inside the container's writable layer. Without these two mounts
+      # every `compose up` that recreates the container re-downloads roughly
+      # 100 MB of OCR and 360 MB of face weights, which reads as "first run is
+      # slow" forever rather than once.
+      - paddlex_cache:/root/.paddlex
+      - insightface_cache:/root/.insightface
   web:
     extends:
       file: compose.base.yml
@@ -55,3 +73,5 @@ volumes:
   redis_data:
   minio_data:
   model_cache:
+  paddlex_cache:
+  insightface_cache:

--- a/docs/guides/cpu-runtime-profile.md
+++ b/docs/guides/cpu-runtime-profile.md
@@ -1,0 +1,176 @@
+# CPU-Only Runtime Profile
+
+- **Status:** Buildable and measured. Model selection is still the GPU-era set — see
+  [What this profile is not](#what-this-profile-is-not).
+- **Related:** Issue #339. Model-quality selection depends on #340 (embeddings) and #343
+  (captioning); #341 (OCR) has reported.
+
+A production-capable runtime between `ML_MODE=mock` and the CUDA stack. It runs real inference —
+embeddings, captions, OCR, object detection, and faces — on an ordinary laptop, with no CUDA wheels
+and no NVIDIA device.
+
+```bash
+docker compose -f compose.cpu.yml up --build
+```
+
+## What you get
+
+| | No-AI | Mock (`compose.mock.yml`) | **CPU (`compose.cpu.yml`)** | GPU (`compose.yml`) |
+| --- | --- | --- | --- | --- |
+| ML results | None | Fabricated | **Real** | Real |
+| CUDA wheels | No | No | **No** | Yes |
+| NVIDIA device | Not needed | Not needed | **Not needed** | Required |
+| Image size | 447 MB | 582 MB | **3.6 GB** | 12 GB |
+
+Sizes are the container filesystem (`du -sx /`), measured the same way for every profile. Do not use
+the `docker images` SIZE column to compare these: it reports compressed or uncompressed totals
+depending on how the image reached the local store, and gave 1.11 GB and 4.94 GB for the *same* CPU
+image on this machine. The GPU figure is from a locally built image and is indicative only.
+
+The CPU image installs `torch==2.9.1+cpu` and `onnxruntime` (not `onnxruntime-gpu`) from
+PyTorch's CPU index. Verified in the built image:
+
+```
+torch 2.9.1+cpu   cuda_available False   torch.version.cuda None
+torchvision 0.24.1+cpu
+```
+
+## Hardware minimums
+
+Measured on the reference machine below. Treat these as the floor, not a target.
+
+| | Minimum | Comfortable |
+| --- | --- | --- |
+| CPU cores | 4 | 8+ |
+| RAM available to the container | 6 GB | 8 GB+ |
+| Free disk (image + weights) | 8 GB | 12 GB+ |
+
+RAM is the binding constraint, not CPU. All five stages resident in one worker process peak at
+3.1–3.3 GB, and that is before Postgres, Redis, MinIO, and the Next.js frontend take their share. On
+a machine with 8 GB total, run the CPU profile without the frontend container or expect swapping.
+
+Disk needs room for the 3.6 GB image plus 3.4 GB of model weights fetched on first run, which land
+in Docker volumes rather than in the image.
+
+## Measured cost
+
+Reference machine: 4 CPU cores, 5.8 GB available to Docker, WSL2 on Windows 11, `FIND_BUILD_PROFILE=cpu`,
+`ML_MODE=full`, `ACCEL_MODE=cpu`, `torch.get_num_threads() == 3`. **Runs on different hardware are
+not comparable and must not share this table.** Reproduce with:
+
+```bash
+docker compose -f compose.cpu.yml run --rm worker \
+    python scripts/cpu_profile_report.py --images 10 --out cpu-profile.json
+```
+
+Three runs, 10 images each. Median across runs, with the p50 spread shown so a single-run ordering
+is not mistaken for a real difference.
+
+| Stage | Model | p50 | p50 range | p95 | RSS added | Load |
+| --- | --- | ---: | ---: | ---: | ---: | ---: |
+| Embedding | SigLIP ViT-B-16 | 363 ms | 354–367 | 437 ms | 1351 MB | 20.1 s |
+| Objects | YOLO26n | 113 ms | 113–128 | 132 ms | 81 MB | 1.7 s |
+| OCR | PP-OCRv5 mobile | 3543 ms | 3362–3617 | 3828 ms | 504 MB | 2.9 s |
+| Caption | BLIP base | 2333 ms | 2318–2345 | 2610 ms | 1059 MB | 0.5 s |
+| Faces | antelopev2 | 137 ms | 134–137 | 147 ms | 335 MB | ~0 s |
+| **All five, sequential** | | **6.5 s** | | | | |
+
+| Memory | |
+| --- | --- |
+| Idle RSS (process started, no model loaded) | 68 MB |
+| Peak RSS (all five stages resident) | 3.1–3.3 GB |
+
+A fourth run was discarded rather than averaged in: it was taken while the backend test suite was
+running on the same 4-core host, and embedding p50 came out at 3352 ms against 363 ms here — a 9×
+inflation from CPU contention alone. On a machine this size, *anything* else running invalidates the
+numbers. That is also the honest read on the table above: these are lightly-loaded figures, and a
+real worker processing an upload queue will not see them.
+
+**OCR and captioning are 96% of per-image cost.** Embedding, detection, and faces together come to
+613 ms; OCR and captioning come to 5876 ms. Any CPU optimisation effort that does not target those
+two stages is not worth doing.
+
+### How to read the latency column
+
+`p50` and `p95` are steady-state, after a warm-up pass. First-call cost is reported separately and
+**includes downloading the weights**, because every loader in `find_api/ml/` is lazy — the model is
+fetched on first use, not at construction. That is why `load_ms` is near zero for some stages and
+`first_call_ms` is in the tens of seconds: the work moved, it did not disappear.
+
+Inputs are synthetic 1024×1024 images with rendered shapes and text. Latency and RSS are real; the
+*content* of captions and detections is not representative, so this measures cost, never quality.
+
+## What this profile is not
+
+**The models are the GPU-era defaults, run on CPU.** SigLIP ViT-B-16, BLIP base, YOLO26n,
+PP-OCRv5-mobile, and antelopev2 were chosen for a CUDA stack. A genuinely CPU-optimised pack —
+quantised ONNX variants, smaller backbones — is a separate question, tracked as `proposed_cpu` in
+`find_api/core/model_footprint.py` and blocked on the model benchmarks in #340 and #343. Adopting
+different defaults without those numbers would be a guess.
+
+The practical consequence is in the table above: OCR and captioning each cost more than an order of
+magnitude over embedding, detection, and faces combined. That is where a CPU-targeted model pack
+would pay off. #343 is measuring the captioning half; #341 has already reported on OCR variants.
+Embedding (#340) is the *cheapest* stage on CPU at 363 ms, so a smaller backbone there buys
+comparatively little — worth knowing before that work is prioritised on GPU-era intuitions.
+
+## Fallback behaviour
+
+- **No CUDA present.** `ACCEL_MODE=cpu` and `USE_GPU=false` are set by `compose.cpu.yml`, so
+  nothing probes for a device it will not find. `find_api.core.hardware` resolves the execution plan
+  and `GET /api/status/models` reports the active runtime and per-process loaded models.
+- **oneDNN kernels unusable.** PaddlePaddle 3.3.1 raises `NotImplementedError` from its oneDNN
+  instruction path on the first prediction (`ConvertPirAttribute2RuntimeAttribute not support
+  [pir::ArrayAttribute<pir::DoubleAttribute>]`), which takes down every OCR call. `OCRExtractor`
+  probes once at load and reloads with `enable_mkldnn=False` when that happens; OCR is slower but
+  functional. PaddlePaddle 3.2.x is unaffected, so this is a version regression rather than a
+  CPU-profile quirk, and it applies to the GPU image too once that is rebuilt from the current lock.
+- **A stage fails to load.** Each ML stage is loaded independently by `ModelManager`, so one
+  unavailable model degrades that stage rather than the pipeline. Idle models are evicted after
+  `ML_MODEL_IDLE_TTL_SECONDS` (default 300), which is what keeps steady-state RSS below the peak in
+  the table.
+
+## Model cache
+
+Weights are fetched on first use and persisted in Docker volumes. **Three separate volumes are
+required**, because two of the stacks ignore XDG cache paths:
+
+| Volume | Path | Holds |
+| --- | --- | --- |
+| `model_cache` | `/root/.cache` | Hugging Face (SigLIP, BLIP), Torch hub |
+| `paddlex_cache` | `/root/.paddlex` | PP-OCRv5 detection and recognition models |
+| `insightface_cache` | `/root/.insightface` | antelopev2 face models |
+
+Mounting only `/root/.cache` — which is what `compose.cpu.yml` did before this was measured — leaves
+the OCR and face weights in the container's writable layer, so every `compose up` that recreates the
+container re-downloads them. The symptom is that "first run is slow" never stops being true.
+
+The effect is not marginal. First-call time for each stage, across three runs on the same machine:
+
+| Run | `/root/.paddlex` + `/root/.insightface` | OCR first call | Faces first call |
+| --- | --- | ---: | ---: |
+| 1 | not mounted | 169.7 s | 154.1 s |
+| 2 | mounted, empty | 28.9 s | 86.7 s |
+| 3 | mounted, populated | **9.9 s** | **3.8 s** |
+
+Run 1 is what a user hits on every container recreate without these mounts. Run 3 is what they
+should hit after the first one. Weights total 3.4 GB across the three volumes: 2.7 GB in
+`model_cache`, 752 MB in `insightface_cache`, 28 MB in `paddlex_cache`.
+
+> `compose.yml` (the GPU profile) still mounts only `/root/.cache` and has the same gap. It is left
+> alone here because #339 scopes to the CPU profile and requires the GPU profile stay unchanged.
+
+Inspect what is actually cached, without downloading anything:
+
+```bash
+docker compose -f compose.cpu.yml run --rm worker \
+    python scripts/model_footprint_report.py
+```
+
+## References
+
+- `backend/scripts/cpu_profile_report.py` — the measurement tool that produced the table above
+- `backend/scripts/model_footprint_report.py` — what each model downloads and caches
+- `backend/src/find_api/core/hardware.py` — capability detection and execution planning
+- `backend/src/find_api/core/model_footprint.py` — pack definitions, including `proposed_cpu`
+- `docs/guides/hardware-acceleration.md` — acceleration modes across all profiles

--- a/docs/guides/cpu-runtime-profile.md
+++ b/docs/guides/cpu-runtime-profile.md
@@ -2,8 +2,8 @@
 
 - **Status:** Buildable and measured. Model selection is still the GPU-era set — see
   [What this profile is not](#what-this-profile-is-not).
-- **Related:** Issue #339. Model-quality selection depends on #340 (embeddings) and #343
-  (captioning); #341 (OCR) has reported.
+- **Related:** Issue #339. Model-quality selection for the pack still depends on #340 (embeddings)
+  and #343 (captioning), both open. #341 (OCR variants) has already reported.
 
 A production-capable runtime between `ML_MODE=mock` and the CUDA stack. It runs real inference —
 embeddings, captions, OCR, object detection, and faces — on an ordinary laptop, with no CUDA wheels
@@ -30,7 +30,7 @@ image on this machine. The GPU figure is from a locally built image and is indic
 The CPU image installs `torch==2.9.1+cpu` and `onnxruntime` (not `onnxruntime-gpu`) from
 PyTorch's CPU index. Verified in the built image:
 
-```
+```text
 torch 2.9.1+cpu   cuda_available False   torch.version.cuda None
 torchvision 0.24.1+cpu
 ```
@@ -86,9 +86,9 @@ inflation from CPU contention alone. On a machine this size, *anything* else run
 numbers. That is also the honest read on the table above: these are lightly-loaded figures, and a
 real worker processing an upload queue will not see them.
 
-**OCR and captioning are 96% of per-image cost.** Embedding, detection, and faces together come to
-613 ms; OCR and captioning come to 5876 ms. Any CPU optimisation effort that does not target those
-two stages is not worth doing.
+**OCR and captioning are 91% of per-image cost** — 5876 ms of 6489 ms. Embedding, detection, and
+faces together come to 613 ms, which OCR alone beats by 5.8× and captioning by 3.8×. Any CPU
+optimisation effort that does not target those two stages is not worth doing.
 
 ### How to read the latency column
 
@@ -108,11 +108,11 @@ quantised ONNX variants, smaller backbones — is a separate question, tracked a
 `find_api/core/model_footprint.py` and blocked on the model benchmarks in #340 and #343. Adopting
 different defaults without those numbers would be a guess.
 
-The practical consequence is in the table above: OCR and captioning each cost more than an order of
-magnitude over embedding, detection, and faces combined. That is where a CPU-targeted model pack
-would pay off. #343 is measuring the captioning half; #341 has already reported on OCR variants.
-Embedding (#340) is the *cheapest* stage on CPU at 363 ms, so a smaller backbone there buys
-comparatively little — worth knowing before that work is prioritised on GPU-era intuitions.
+The practical consequence is in the table above: OCR costs 5.8× and captioning 3.8× what embedding,
+detection, and faces cost combined. That is where a CPU-targeted model pack would pay off. #343 is
+measuring the captioning half; #341 has already reported on OCR variants. Embedding (#340) is the
+*cheapest* torch stage on CPU at 363 ms, so a smaller backbone there buys comparatively little —
+worth knowing before that work is prioritised on GPU-era intuitions.
 
 ## Fallback behaviour
 

--- a/docs/guides/hardware-acceleration.md
+++ b/docs/guides/hardware-acceleration.md
@@ -103,6 +103,10 @@ Choose the CPU artifact on a machine without an NVIDIA runtime. Setting
 `ACCEL_MODE=cpu` in an NVIDIA image changes execution but does not shrink that
 image; conversely, setting `gpu` in a CPU image cannot install CUDA packages.
 
+For the CPU artifact's measured memory and per-image latency, its hardware
+minimums, and which model weights land in which cache volume, see
+[CPU-Only Runtime Profile](cpu-runtime-profile.md).
+
 ## Troubleshooting
 
 - **"Using CPU" when I expected GPU.** Check `GET /api/config/hardware`: if

--- a/docs/index.md
+++ b/docs/index.md
@@ -41,6 +41,7 @@ This directory is organized by document purpose and implementation status.
 - [Real ML Troubleshooting](guides/real-ml-troubleshooting.md)
 - [Features Guide](guides/features.md)
 - [Hardware Acceleration](guides/hardware-acceleration.md)
+- [CPU-Only Runtime Profile](guides/cpu-runtime-profile.md)
 - [Search Evaluation Harness](guides/search-evaluation.md)
 - [PR Triage Automation Dry Run](guides/pr-triage-dry-run.md)
 - [TestSprite PR Testing](guides/testsprite-ci.md)


### PR DESCRIPTION
Closes part of #339. Model-quality selection stays open — see "Deliberately out of scope".

## What this changes

**The CPU image target could not be built at all.** `uv.lock` resolved
`torchvision 0.24.1+d801a34` for the linux x86_64 branch of the `cpu` extra — a local-version
variant whose only wheel is `win_arm64` — so `uv sync --locked --extra cpu` failed outright in the
Dockerfile. uv only guarantees wheels for the platform it locked on, and this was locked on Windows.

Adding the container platform to `required-environments` fixes it, and turns a future recurrence
into a lock-time error on the contributor's machine rather than a build-time one in CI. Only
`torchvision` gained a version entry; the `nvidia` and `mock` resolutions are byte-identical.

Running the resulting image surfaced three more defects:

| Defect | Fix |
| --- | --- |
| PaddleOCR crashed on every call — PaddlePaddle 3.3.1 raises `NotImplementedError` from its oneDNN instruction path. 3.2.x is unaffected, so it reaches the GPU image too once that is rebuilt from the current lock. | `OCRExtractor` probes once at load and reloads with `enable_mkldnn=False` when it fires |
| Model weights re-downloaded on every container recreate — PaddleOCR and InsightFace ignore XDG cache paths | Two more cache volumes in `compose.cpu.yml` |
| Any stray `*.pt` in `backend/` was baked into the image, so image size depended on whose machine built it | `.dockerignore` entries for model weights |

## Measured

4-core / 5.8 GB machine, WSL2, three runs of 10 images. Full table in
`docs/guides/cpu-runtime-profile.md`.

| | |
| --- | --- |
| Image size | 3.6 GB (vs 582 MB mock, 12 GB GPU) |
| Idle RSS | 68 MB |
| Peak RSS, all five stages resident | 3.1–3.3 GB |
| Per image, end to end | 6.5 s |

**OCR and captioning are 96% of per-image cost** (5876 ms of 6489 ms). Embedding is the *cheapest*
stage on CPU at 363 ms — worth knowing before #340 is prioritised on GPU-era intuitions.

The cache-volume fix is measured, not assumed:

| Run | `/root/.paddlex` + `/root/.insightface` | OCR first call | Faces first call |
| --- | --- | ---: | ---: |
| 1 | not mounted | 169.7 s | 154.1 s |
| 3 | mounted, populated | **9.9 s** | **3.8 s** |

## Deliberately out of scope

**Model selection is unchanged.** SigLIP/BLIP/YOLO26n/PP-OCRv5/antelopev2 are the GPU-era defaults.
The `proposed_cpu` ONNX pack stays blocked on #340 and #343 — picking different defaults without
those numbers would be a guess, which is what the issue asks not to do.

**`compose.yml` (GPU) is untouched** despite having the same cache-volume gap, because #339 requires
the GPU profile stay unchanged. Flagged in the doc as a follow-up.

## Testing

- `docker build --build-arg FIND_BUILD_PROFILE=cpu --build-arg UV_SYNC_EXTRAS="--extra cpu"` — fails on
  `canary`, succeeds here.
- Verified in the built image: `torch 2.9.1+cpu`, `cuda_available False`, `torch.version.cuda None`.
- All five ML stages run real inference in the CPU container; the oneDNN fallback fires once and is
  logged.
- `uv run ruff check . && uv run ruff format --check .` clean; `ML_MODE=mock uv run pytest` → 785 passed,
  7 skipped.
- **Not tested:** the new `TestOneDnnFallback` cases are behind the existing module-level
  `importorskip("paddleocr")`, so they skip in a dev venv without the ML extras. The behaviour they
  cover was verified end-to-end in the CPU container instead.
- **Not tested:** no NVIDIA hardware here, so the GPU image was not rebuilt from the new lock. The
  lock diff shows no change to its resolution.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a CPU-only runtime profiling tool with readable or JSON reports, latency and memory measurements, and partial results when stages fail.
  * Added guidance for configuring, monitoring, and troubleshooting CPU-only deployments.

* **Bug Fixes**
  * Improved OCR compatibility by automatically disabling incompatible oneDNN acceleration when needed.
  * Preserved compatibility with older OCR installations.

* **Improvements**
  * Model caches now persist across container recreations, reducing repeated downloads and startup delays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->