### PR TITLE
feat: implement the Track C ranking matrix for the search benchmark (#99)

### DIFF
--- a/backend/scripts/evaluate_search.py
+++ b/backend/scripts/evaluate_search.py
@@ -240,8 +240,12 @@ def main(argv: list[str] | None = None) -> int:
     )
     parser.add_argument(
         "--variant",
-        default="C0",
-        help=f"Track C ranking variant for --db ({', '.join(sorted(VARIANTS))})",
+        # Defaults to None rather than "C0" so `--variant C3 --all-variants` can
+        # be rejected instead of silently scoring all seven and ignoring the
+        # explicit choice.
+        default=None,
+        help=f"Track C ranking variant for --db, default C0 "
+        f"({', '.join(sorted(VARIANTS))})",
     )
     parser.add_argument(
         "--all-variants",
@@ -275,9 +279,22 @@ def main(argv: list[str] | None = None) -> int:
         print("error: --repetitions must be at least 1", file=sys.stderr)
         return 2
 
-    if (args.all_variants or args.approximate) and not args.db:
-        print("error: --all-variants and --approximate require --db", file=sys.stderr)
+    if (args.all_variants or args.approximate or args.variant) and not args.db:
+        print(
+            "error: --variant, --all-variants, and --approximate require --db",
+            file=sys.stderr,
+        )
         return 2
+
+    if args.all_variants and args.variant:
+        print(
+            "error: --variant and --all-variants are mutually exclusive; "
+            "--all-variants scores every variant",
+            file=sys.stderr,
+        )
+        return 2
+
+    variant_id = args.variant or "C0"
 
     try:
         dataset = load_dataset(args.dataset)
@@ -288,12 +305,20 @@ def main(argv: list[str] | None = None) -> int:
     exact = not args.approximate
 
     if args.db and args.all_variants:
-        report = _run_variants(
-            dataset,
-            [VARIANTS[key] for key in sorted(VARIANTS)],
-            exact=exact,
-            repetitions=args.repetitions,
-        )
+        try:
+            report = _run_variants(
+                dataset,
+                [VARIANTS[key] for key in sorted(VARIANTS)],
+                exact=exact,
+                repetitions=args.repetitions,
+            )
+        except RuntimeError as exc:
+            # Raised by default_embedder() under ML_MODE=mock. That is an
+            # expected operator mistake with a specific remedy, so it gets the
+            # same "error: ..." line as any other bad input rather than a
+            # traceback that buries the explanation.
+            print(f"error: {exc}", file=sys.stderr)
+            return 2
         if args.json:
             print(json.dumps(report, indent=2))
         else:
@@ -308,11 +333,14 @@ def main(argv: list[str] | None = None) -> int:
         if args.stub:
             retrieve = stub_retriever(load_stub_run(args.stub))
         elif args.db:
-            variant = get_variant(args.variant)
+            variant = get_variant(variant_id)
             retrieve = variant_retriever(variant, _db_candidate_source(exact))
         else:
             retrieve = _api_retriever(args.base_url, args.timeout, args.token)
-    except (DatasetError, KeyError) as exc:
+    except (DatasetError, KeyError, RuntimeError) as exc:
+        # KeyError from an unknown --variant, RuntimeError from ML_MODE=mock.
+        # KeyError stringifies with quotes around the whole message, so take
+        # its argument directly.
         message = exc.args[0] if isinstance(exc, KeyError) else exc
         print(f"error: {message}", file=sys.stderr)
         return 2
@@ -320,7 +348,7 @@ def main(argv: list[str] | None = None) -> int:
     outcomes = run_dataset(dataset, retrieve, repetitions=args.repetitions)
     report = score_outcomes(dataset, outcomes)
     if args.db:
-        variant = get_variant(args.variant)
+        variant = get_variant(variant_id)
         report["variant"] = {"id": variant.id, "description": variant.description}
         report["retrieval"] = "exact" if exact else "approximate (deployed HNSW index)"
 

--- a/backend/scripts/evaluate_search.py
+++ b/backend/scripts/evaluate_search.py
@@ -115,12 +115,18 @@ def _run_variants(
 
     Retrieving once and ranking many times is what makes the comparison fair:
     every variant sees byte-identical input, so a metric difference is
-    attributable to the ranking rule alone. The cost is that reported latency
-    covers ranking only for all but the first variant, which is recorded in the
-    output rather than left for the reader to infer.
+    attributable to the ranking rule alone.
+
+    The pool is filled before any variant is scored, not lazily during the first
+    one. Otherwise whichever variant happened to run first would absorb the whole
+    retrieval cost — embedding plus a Postgres round trip, which dwarfs any
+    ranking rule — and would read as dramatically the slowest in the results
+    table for no reason but its position in the loop.
     """
     source = _db_candidate_source(exact)
     cache = PoolCache(source=source, pool_size=max_pool_size(variants, dataset.max_k))
+    for query in dataset.queries:
+        cache.get(query)
 
     reports: dict[str, dict] = {}
     for variant in variants:
@@ -136,9 +142,11 @@ def _run_variants(
         "retrieval": "exact" if exact else "approximate (deployed HNSW index)",
         "shared_candidate_pool": True,
         "latency_note": (
-            "Candidate retrieval is shared across variants, so per-variant "
-            "latency measures ranking only. Score a single variant without "
-            "--all-variants for end-to-end latency."
+            "Candidate retrieval is shared across variants and is performed "
+            "before any of them are scored, so every per-variant latency here "
+            "measures ranking only and they are comparable with each other. "
+            "Score a single variant without --all-variants for end-to-end "
+            "latency."
         ),
         "variants": reports,
     }

--- a/backend/scripts/evaluate_search.py
+++ b/backend/scripts/evaluate_search.py
@@ -18,6 +18,11 @@ Retrievers:
                     stack with an indexed library. Media ids in the dataset
                     must be the media_id values that instance returns.
 
+  --db              Retrieve straight from Postgres and rank with a Track C
+                    variant (issue #99). Needs database access and real model
+                    weights in this process, and pins retrieval to exact search
+                    unless --approximate is passed.
+
 Usage (from the backend directory):
 
     # Smoke: proves the harness itself works
@@ -28,6 +33,10 @@ Usage (from the backend directory):
     # Against a live local instance
     uv run python scripts/evaluate_search.py \
         --dataset my_dataset.json --api --base-url http://localhost:8000
+
+    # The whole Track C matrix, one retrieval per query shared by every variant
+    uv run python scripts/evaluate_search.py \
+        --dataset my_dataset.json --db --all-variants --out trackc.json
 
     # Machine-readable, for before/after comparison
     uv run python scripts/evaluate_search.py ... --json --out baseline.json
@@ -58,6 +67,14 @@ from find_api.evaluation.runner import (  # noqa: E402
     score_outcomes,
     stub_retriever,
 )
+from find_api.evaluation.variants import (  # noqa: E402
+    VARIANTS,
+    PoolCache,
+    RankingVariant,
+    get_variant,
+    max_pool_size,
+    variant_retriever,
+)
 
 
 def _api_retriever(base_url: str, timeout: float, token: str | None):
@@ -77,6 +94,77 @@ def _api_retriever(base_url: str, timeout: float, token: str | None):
         return [str(row["media_id"]) for row in payload.get("results", [])]
 
     return _retrieve
+
+
+def _db_candidate_source(exact: bool):
+    """Build a Postgres-backed candidate source using real model weights."""
+    from find_api.core.database import SessionLocal
+    from find_api.evaluation.sources import default_embedder, postgres_candidate_source
+
+    return postgres_candidate_source(SessionLocal, default_embedder(), exact=exact)
+
+
+def _run_variants(
+    dataset,
+    variants: list[RankingVariant],
+    *,
+    exact: bool,
+    repetitions: int,
+) -> dict:
+    """Score several Track C variants against one shared candidate pool.
+
+    Retrieving once and ranking many times is what makes the comparison fair:
+    every variant sees byte-identical input, so a metric difference is
+    attributable to the ranking rule alone. The cost is that reported latency
+    covers ranking only for all but the first variant, which is recorded in the
+    output rather than left for the reader to infer.
+    """
+    source = _db_candidate_source(exact)
+    cache = PoolCache(source=source, pool_size=max_pool_size(variants, dataset.max_k))
+
+    reports: dict[str, dict] = {}
+    for variant in variants:
+        retrieve = variant_retriever(variant, source, cache=cache)
+        outcomes = run_dataset(dataset, retrieve, repetitions=repetitions)
+        report = score_outcomes(dataset, outcomes)
+        report["variant"] = {"id": variant.id, "description": variant.description}
+        reports[variant.id] = report
+
+    return {
+        "result_schema_version": 1,
+        "dataset_id": dataset.dataset_id,
+        "retrieval": "exact" if exact else "approximate (deployed HNSW index)",
+        "shared_candidate_pool": True,
+        "latency_note": (
+            "Candidate retrieval is shared across variants, so per-variant "
+            "latency measures ranking only. Score a single variant without "
+            "--all-variants for end-to-end latency."
+        ),
+        "variants": reports,
+    }
+
+
+def _print_variant_comparison(report: dict) -> None:
+    print(f"Dataset       : {report['dataset_id']}")
+    print(f"Retrieval     : {report['retrieval']}")
+    print()
+
+    header = (
+        f"{'VARIANT':<8} {'MRR':>8} {'P@10':>8} {'R@10':>8} {'EMPTY':>8}  DESCRIPTION"
+    )
+    print(header)
+    print("-" * len(header))
+    for variant_id, row in report["variants"].items():
+        metrics = row["metrics"]
+        at_10 = metrics["at_k"].get("10") or next(iter(metrics["at_k"].values()))
+        print(
+            f"{variant_id:<8} {metrics['mrr']:>8.4f} {at_10['precision']:>8.4f} "
+            f"{at_10['recall']:>8.4f} {metrics['empty_result_rate']:>8.4f}  "
+            f"{row['variant']['description']}"
+        )
+
+    print()
+    print(report["latency_note"])
 
 
 def _print_human(report: dict) -> None:
@@ -137,6 +225,29 @@ def main(argv: list[str] | None = None) -> int:
     source = parser.add_mutually_exclusive_group(required=True)
     source.add_argument("--stub", metavar="RUN", help="replay canned rankings")
     source.add_argument("--api", action="store_true", help="query a live instance")
+    source.add_argument(
+        "--db",
+        action="store_true",
+        help="retrieve from Postgres and rank with a Track C variant",
+    )
+    parser.add_argument(
+        "--variant",
+        default="C0",
+        help=f"Track C ranking variant for --db ({', '.join(sorted(VARIANTS))})",
+    )
+    parser.add_argument(
+        "--all-variants",
+        action="store_true",
+        help="score every Track C variant against one shared candidate pool",
+    )
+    parser.add_argument(
+        "--approximate",
+        action="store_true",
+        help=(
+            "use the deployed HNSW index instead of pinning exact search; "
+            "ranking differences then include ANN recall error"
+        ),
+    )
     parser.add_argument("--base-url", default="http://localhost:8000")
     parser.add_argument("--token", default=None, help="bearer token for --api")
     parser.add_argument("--timeout", type=float, default=30.0)
@@ -156,18 +267,54 @@ def main(argv: list[str] | None = None) -> int:
         print("error: --repetitions must be at least 1", file=sys.stderr)
         return 2
 
+    if (args.all_variants or args.approximate) and not args.db:
+        print("error: --all-variants and --approximate require --db", file=sys.stderr)
+        return 2
+
     try:
         dataset = load_dataset(args.dataset)
-        if args.stub:
-            retrieve = stub_retriever(load_stub_run(args.stub))
-        else:
-            retrieve = _api_retriever(args.base_url, args.timeout, args.token)
     except DatasetError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 2
 
+    exact = not args.approximate
+
+    if args.db and args.all_variants:
+        report = _run_variants(
+            dataset,
+            [VARIANTS[key] for key in sorted(VARIANTS)],
+            exact=exact,
+            repetitions=args.repetitions,
+        )
+        if args.json:
+            print(json.dumps(report, indent=2))
+        else:
+            _print_variant_comparison(report)
+        if args.out:
+            Path(args.out).write_text(json.dumps(report, indent=2), encoding="utf-8")
+            if not args.json:
+                print(f"\nWrote {args.out}")
+        return 0
+
+    try:
+        if args.stub:
+            retrieve = stub_retriever(load_stub_run(args.stub))
+        elif args.db:
+            variant = get_variant(args.variant)
+            retrieve = variant_retriever(variant, _db_candidate_source(exact))
+        else:
+            retrieve = _api_retriever(args.base_url, args.timeout, args.token)
+    except (DatasetError, KeyError) as exc:
+        message = exc.args[0] if isinstance(exc, KeyError) else exc
+        print(f"error: {message}", file=sys.stderr)
+        return 2
+
     outcomes = run_dataset(dataset, retrieve, repetitions=args.repetitions)
     report = score_outcomes(dataset, outcomes)
+    if args.db:
+        variant = get_variant(args.variant)
+        report["variant"] = {"id": variant.id, "description": variant.description}
+        report["retrieval"] = "exact" if exact else "approximate (deployed HNSW index)"
 
     if args.json:
         print(json.dumps(report, indent=2))

--- a/backend/src/find_api/evaluation/__init__.py
+++ b/backend/src/find_api/evaluation/__init__.py
@@ -23,18 +23,40 @@ from find_api.evaluation.runner import (
     score_outcomes,
     stub_retriever,
 )
+from find_api.evaluation.variants import (
+    VARIANTS,
+    Candidate,
+    PoolCache,
+    RankingVariant,
+    get_variant,
+    max_pool_size,
+    rank,
+    variant_retriever,
+)
+
+# find_api.evaluation.sources is deliberately not re-exported: it reaches for
+# the database and model stack, and this package must stay importable without
+# either.
 
 __all__ = [
     "RESULT_SCHEMA_VERSION",
     "SCHEMA_VERSION",
+    "VARIANTS",
+    "Candidate",
     "DatasetError",
     "EvalDataset",
     "EvalQuery",
+    "PoolCache",
     "QueryOutcome",
+    "RankingVariant",
+    "get_variant",
     "load_dataset",
     "load_stub_run",
+    "max_pool_size",
     "parse_dataset",
+    "rank",
     "run_dataset",
     "score_outcomes",
     "stub_retriever",
+    "variant_retriever",
 ]

--- a/backend/src/find_api/evaluation/sources.py
+++ b/backend/src/find_api/evaluation/sources.py
@@ -1,0 +1,144 @@
+"""Candidate sources that feed the Track C variants (issue #99).
+
+A source turns query text into a pool of `Candidate` rows. It owns the parts
+that need a real environment — model weights and a populated database — which
+is exactly why it is separated from the ranking rules in `variants.py`: those
+stay pure and unit-testable, and this module is the only thing a benchmark run
+has to stand up.
+
+Imports of the database and ML stack are deferred into the functions that need
+them, so `find_api.evaluation` stays importable in a bare test environment.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Callable, Sequence
+
+from find_api.evaluation.variants import Candidate
+
+# Mirrors the projection in routers/search.py, plus the signals only Track C
+# uses (liked, created_at, album membership). `metadata_json` carries caption,
+# ocr_text, and objects, so the boost inputs come from the same place
+# production reads them from.
+CANDIDATE_SQL = """
+    SELECT
+        m.id,
+        1 - (m.vector <=> CAST(:embedding AS vector)) AS similarity,
+        COALESCE(m.ranking_boost, 0) AS ranking_boost,
+        m.liked,
+        m.created_at,
+        m.metadata_json,
+        (
+            SELECT COUNT(*) FROM album_assets aa WHERE aa.media_id = m.id
+        ) AS album_count
+    FROM media m
+    WHERE m.status = 'indexed' AND m.vector IS NOT NULL
+      AND m.is_hidden = false
+      AND m.is_archived = false AND m.deleted_at IS NULL
+    ORDER BY m.vector <=> CAST(:embedding AS vector)
+    LIMIT :limit
+"""
+
+
+def _coerce_metadata(raw: Any) -> dict:
+    if isinstance(raw, dict):
+        return raw
+    if not raw:
+        return {}
+    import json
+
+    try:
+        parsed = json.loads(raw)
+    except (TypeError, ValueError):
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def row_to_candidate(row: Any) -> Candidate:
+    """Build a Candidate from a search result row."""
+    from find_api.ml.search_ranking import extract_object_labels
+
+    metadata = _coerce_metadata(row.metadata_json)
+    created_at = row.created_at
+    if created_at is not None and not isinstance(created_at, datetime):
+        created_at = None
+
+    return Candidate(
+        media_id=str(row.id),
+        vector_similarity=float(row.similarity),
+        caption=str(metadata.get("caption") or ""),
+        ocr_text=str(metadata.get("ocr_text") or ""),
+        object_labels=tuple(extract_object_labels(metadata.get("objects") or [])),
+        ranking_boost=float(row.ranking_boost or 0.0),
+        liked=bool(row.liked),
+        created_at=created_at,
+        album_count=int(row.album_count or 0),
+    )
+
+
+def postgres_candidate_source(
+    session_factory: Callable[[], Any],
+    embed_text: Callable[[str], Sequence[float]],
+    *,
+    exact: bool = True,
+) -> Callable[[str, int], list[Candidate]]:
+    """Candidate source backed by pgvector.
+
+    `exact=True` disables index scans for the duration of the query, which the
+    benchmark protocol requires: an HNSW index is deployed, so without this the
+    pool is approximate and ANN recall error would be silently attributed to
+    whichever ranking rule happened to be under test. Track A measures the
+    approximation on purpose; Track C must not absorb it by accident.
+
+    The setting is `SET LOCAL`, so it is scoped to the transaction and cannot
+    leak into anything else using the same connection.
+    """
+    from sqlalchemy import text as sql_text
+
+    def _retrieve(query_text: str, pool_size: int) -> list[Candidate]:
+        embedding = embed_text(query_text)
+        embedding_str = "[" + ",".join(map(str, embedding)) + "]"
+
+        session = session_factory()
+        try:
+            with session.begin():
+                if exact:
+                    # Bitmap scans are disabled alongside index scans because
+                    # either one can reach the HNSW index; leaving bitmap on
+                    # would make "exact" true only most of the time.
+                    session.execute(sql_text("SET LOCAL enable_indexscan = off"))
+                    session.execute(sql_text("SET LOCAL enable_bitmapscan = off"))
+                rows = session.execute(
+                    sql_text(CANDIDATE_SQL),
+                    {"embedding": embedding_str, "limit": pool_size},
+                ).all()
+            return [row_to_candidate(row) for row in rows]
+        finally:
+            session.close()
+
+    return _retrieve
+
+
+def default_embedder() -> Callable[[str], Sequence[float]]:
+    """The real CLIP/SigLIP text embedder.
+
+    Deliberately not mock-aware. `ML_MODE=mock` uses a fixed 0.45/0.55 blend
+    unrelated to the production weighting scheme, so a relevance number produced
+    from it is not a smaller version of the real one — it is unrelated to it.
+    A benchmark run that silently fell back to mock would emit a full, plausible
+    results table that means nothing, so this raises instead.
+    """
+    from find_api.core.config import settings
+
+    mode = str(getattr(settings, "ML_MODE", "")).lower()
+    if mode == "mock":
+        raise RuntimeError(
+            "ML_MODE=mock cannot produce relevance measurements; the mock "
+            "embedder is unrelated to the production weighting scheme. Run the "
+            "benchmark against a real model, or use --stub to exercise plumbing."
+        )
+
+    from find_api.ml.clip_embedder import get_clip_embedder
+
+    return get_clip_embedder().embed_text

--- a/backend/src/find_api/evaluation/variants.py
+++ b/backend/src/find_api/evaluation/variants.py
@@ -1,0 +1,406 @@
+"""Track C query-side ranking variants for the search benchmark (issue #99).
+
+`docs/research/search-retrieval-benchmark-plan.md` defines a matrix of ranking
+candidates C0-C6. All of them are *query-side only*: they change how an already
+retrieved candidate set is thresholded, pooled, and reranked, and none of them
+touch stored vectors. That is why Track C runs before the embedding tracks —
+every variant here is revertible by reverting code, with no reindex.
+
+The split in this module exists so the comparison is fair:
+
+- A **candidate source** does the expensive, environment-dependent part once per
+  query: embed the text, hit Postgres, return a pool of `Candidate` rows with
+  every signal a variant might want.
+- A **variant** is pure Python over that pool.
+
+Because the pool is retrieved once and shared, two variants scored in the same
+run see byte-identical input, so any difference in their metrics is attributable
+to the ranking rule and nothing else. It is also the only affordable shape: the
+matrix is seven variants, and re-embedding every query seven times would
+dominate the run.
+
+`C0` is the production baseline and is asserted against the real
+`find_api.ml.search_ranking` helpers in `tests/test_search_variants.py`. That
+test is the point of the whole module — a baseline that has quietly drifted from
+production turns every delta in the results table into a fiction.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field, replace
+from datetime import datetime, timezone
+from statistics import fmean, pstdev
+from typing import Callable, Sequence
+
+from find_api.evaluation.dataset import EvalQuery
+from find_api.ml.search_ranking import TEXT_QUERY_TERMS, tokenize
+
+# Production's full-mode cutoff, mirrored from routers/search.py. Duplicated
+# rather than imported because importing the router drags in the database,
+# storage, and settings stack, and the harness must run without them.
+PRODUCTION_THRESHOLD = 0.38
+
+# Production coefficients, mirrored from ml/search_ranking.py for the same
+# reason. `test_search_variants.py` asserts these still match.
+PRODUCTION_CAPTION_WEIGHT = 0.015
+PRODUCTION_OCR_WEIGHT = 0.035
+PRODUCTION_OBJECT_WEIGHT = 0.010
+PRODUCTION_BOOST_CAP = 0.25
+PRODUCTION_TEXT_TERM_BONUS = 0.05
+
+
+@dataclass(frozen=True)
+class Candidate:
+    """One retrieved row, with every signal any Track C variant may read.
+
+    Populated once per query by a candidate source. Fields a given variant
+    ignores simply cost nothing.
+    """
+
+    media_id: str
+    vector_similarity: float
+    caption: str = ""
+    ocr_text: str = ""
+    object_labels: tuple[str, ...] = ()
+    # Persisted feedback boost. Production adds it to the SQL ordering key but
+    # not to the Python score; see `_pool_sort_key`.
+    ranking_boost: float = 0.0
+    liked: bool = False
+    created_at: datetime | None = None
+    album_count: int = 0
+
+
+@dataclass(frozen=True)
+class RankingVariant:
+    """A point in the Track C matrix.
+
+    Defaults reproduce production exactly, so each variant below is defined by
+    the one knob it changes. That is deliberate: a variant that differs from the
+    baseline in two ways cannot have its effect attributed.
+    """
+
+    id: str
+    description: str
+
+    # Retrieval shape. `pool_size=None` means "pool is exactly k", which is what
+    # production does — it applies the textual boost only to the page it already
+    # truncated to. C3 challenges precisely that.
+    pool_size: int | None = None
+
+    # Thresholding. `threshold=None` disables the cutoff (C1). `adaptive_z`
+    # switches to a per-query cutoff derived from the pool's score spread (C2).
+    threshold: float | None = PRODUCTION_THRESHOLD
+    adaptive_z: float | None = None
+
+    # Boost shape (C5, C6).
+    caption_weight: float = PRODUCTION_CAPTION_WEIGHT
+    ocr_weight: float = PRODUCTION_OCR_WEIGHT
+    object_weight: float = PRODUCTION_OBJECT_WEIGHT
+    boost_cap: float = PRODUCTION_BOOST_CAP
+    text_term_bonus: float = PRODUCTION_TEXT_TERM_BONUS
+
+    # Non-semantic signals (C4). Zero everywhere else, so they contribute
+    # nothing unless a variant opts in.
+    liked_bonus: float = 0.0
+    recency_weight: float = 0.0
+    recency_half_life_days: float = 365.0
+    album_bonus: float = 0.0
+
+    def with_id(self, variant_id: str, description: str, **changes) -> RankingVariant:
+        """Derive a sibling variant. Used to build sweeps of one coefficient."""
+        return replace(self, id=variant_id, description=description, **changes)
+
+
+def textual_boost(
+    variant: RankingVariant, query_tokens: set[str], candidate: Candidate
+) -> float:
+    """Metadata boost under `variant`'s coefficients.
+
+    With production coefficients this is `search_ranking.compute_textual_boost`;
+    it is reimplemented rather than called because the whole point of C5/C6 is
+    to vary the constants that function hardcodes.
+    """
+    if not query_tokens:
+        return 0.0
+
+    caption_tokens = tokenize(candidate.caption)
+    ocr_tokens = tokenize(candidate.ocr_text)
+    object_tokens = tokenize(" ".join(candidate.object_labels))
+
+    boost = (
+        len(query_tokens & caption_tokens) * variant.caption_weight
+        + len(query_tokens & ocr_tokens) * variant.ocr_weight
+        + len(query_tokens & object_tokens) * variant.object_weight
+    )
+
+    if variant.text_term_bonus and query_tokens & TEXT_QUERY_TERMS and ocr_tokens:
+        boost += variant.text_term_bonus
+
+    return min(boost, variant.boost_cap)
+
+
+def metadata_boost(
+    variant: RankingVariant, candidate: Candidate, now: datetime
+) -> float:
+    """Non-semantic boost from recency, favourites, and album membership (C4).
+
+    Zero unless a variant opts in, so it costs the other variants nothing.
+    """
+    boost = 0.0
+
+    if variant.liked_bonus and candidate.liked:
+        boost += variant.liked_bonus
+
+    if variant.album_bonus and candidate.album_count > 0:
+        boost += variant.album_bonus
+
+    if variant.recency_weight and candidate.created_at is not None:
+        created = candidate.created_at
+        if created.tzinfo is None:
+            created = created.replace(tzinfo=timezone.utc)
+        age_days = max((now - created).total_seconds() / 86400.0, 0.0)
+        # Exponential decay, so a fresh item gets the full weight and the bonus
+        # tends to zero rather than going negative for old media. A linear decay
+        # would need an arbitrary cutoff age.
+        decay = math.exp(-math.log(2) * age_days / variant.recency_half_life_days)
+        boost += variant.recency_weight * decay
+
+    return boost
+
+
+def resolve_threshold(
+    variant: RankingVariant, candidates: Sequence[Candidate]
+) -> float | None:
+    """The similarity cutoff this variant applies to this pool.
+
+    Returns None when nothing should be filtered. The adaptive rule (C2) is
+    `mean + z * stdev` over the pool's similarities: on a query with a clear
+    winner the spread is wide and the cutoff rises, and on a flat pool where
+    nothing stands out it collapses toward the mean. It is one concrete rule
+    the benchmark is meant to *test*, not an established one — `adaptive_z` is
+    the knob to sweep.
+    """
+    if variant.adaptive_z is None:
+        return variant.threshold
+
+    sims = [c.vector_similarity for c in candidates]
+    if len(sims) < 2:
+        # Nothing to derive a spread from; filtering on a single sample would
+        # be arbitrary, so pass everything through.
+        return None
+    return fmean(sims) + variant.adaptive_z * pstdev(sims)
+
+
+def _id_sort_key(media_id: str) -> tuple[int, int, str]:
+    """Deterministic descending tiebreak on id.
+
+    Production tiebreaks on `int(media_id)` because its ids are integers.
+    Datasets may use non-numeric ids, so numeric ids sort numerically (matching
+    production) and others fall back to string order, with numerics ordered
+    after strings under the descending sort so the two never interleave
+    arbitrarily.
+    """
+    try:
+        return (1, int(media_id), "")
+    except (TypeError, ValueError):
+        return (0, 0, media_id)
+
+
+def _pool_sort_key(candidate: Candidate) -> tuple:
+    """Production's SQL ordering: final_score DESC, similarity DESC, id ASC.
+
+    `ranking_boost` participates here and nowhere else, exactly as in
+    `routers/search.py` — the persisted feedback boost decides *which* rows
+    reach the page, then the Python rerank scores them on the raw vector
+    similarity plus the textual boost. Reproducing that asymmetry matters:
+    folding `ranking_boost` into the final score would make C0 outrank
+    production on feedback-heavy libraries and quietly flatter every variant
+    measured against it.
+    """
+    numeric, value, text = _id_sort_key(candidate.media_id)
+    return (
+        candidate.vector_similarity + candidate.ranking_boost,
+        candidate.vector_similarity,
+        # Negated to give ascending id under a descending sort.
+        -numeric,
+        -value,
+        text,
+    )
+
+
+def rank(
+    variant: RankingVariant,
+    query_text: str,
+    candidates: Sequence[Candidate],
+    k: int,
+    *,
+    now: datetime | None = None,
+) -> list[str]:
+    """Apply `variant` to a candidate pool and return the top-k media ids."""
+    if k < 1:
+        raise ValueError("k must be at least 1")
+
+    now = now or datetime.now(timezone.utc)
+    query_tokens = tokenize(query_text)
+
+    threshold = resolve_threshold(variant, candidates)
+    kept = (
+        list(candidates)
+        if threshold is None
+        else [c for c in candidates if c.vector_similarity > threshold]
+    )
+
+    # Truncate to the pool before reranking. For C0 the pool is k, which is
+    # what makes it the honest baseline: production reranks only the page it
+    # already cut to, so its boost can reorder but never rescue a result the
+    # vector score pushed off the page.
+    pool_size = variant.pool_size if variant.pool_size is not None else k
+    kept.sort(key=_pool_sort_key, reverse=True)
+    kept = kept[:pool_size]
+
+    scored: list[tuple[float, float, tuple[int, int, str], str]] = []
+    for candidate in kept:
+        score = (
+            candidate.vector_similarity
+            + textual_boost(variant, query_tokens, candidate)
+            + metadata_boost(variant, candidate, now)
+        )
+        # Production clamps the exposed score to [0, 1]. Kept because a clamp
+        # creates ties at the ceiling, and ties change ordering.
+        score = max(0.0, min(score, 1.0))
+        scored.append(
+            (
+                score,
+                candidate.vector_similarity,
+                _id_sort_key(candidate.media_id),
+                candidate.media_id,
+            )
+        )
+
+    scored.sort(key=lambda row: row[:3], reverse=True)
+    return [row[3] for row in scored[:k]]
+
+
+# --- The matrix -------------------------------------------------------------
+#
+# Ids and questions come straight from the Track C table in
+# docs/research/search-retrieval-benchmark-plan.md.
+
+C0 = RankingVariant(
+    id="C0",
+    description="Production baseline: static 0.38 threshold, pool=k, overlap boost",
+)
+
+C1 = C0.with_id(
+    "C1",
+    "No threshold — how many valid results does the static cutoff discard?",
+    threshold=None,
+)
+
+C2 = C0.with_id(
+    "C2",
+    "Adaptive threshold from the per-query score spread (mean + 0.5 sigma)",
+    adaptive_z=0.5,
+)
+
+C3 = C0.with_id(
+    "C3",
+    "Wider candidate pool (k=100), then metadata rerank down to k",
+    pool_size=100,
+)
+
+C4 = C3.with_id(
+    "C4",
+    "C3 plus recency, favourite, and album signals",
+    liked_bonus=0.02,
+    recency_weight=0.02,
+    album_bonus=0.01,
+)
+
+C5 = C0.with_id(
+    "C5",
+    "Drop the hardcoded TEXT_QUERY_TERMS bonus — is the flat 0.05 earning its place?",
+    text_term_bonus=0.0,
+)
+
+C6 = C0.with_id(
+    "C6",
+    "Reweight the per-signal boost coefficients and raise the cap",
+    caption_weight=0.030,
+    ocr_weight=0.050,
+    object_weight=0.020,
+    boost_cap=0.35,
+)
+
+VARIANTS: dict[str, RankingVariant] = {v.id: v for v in (C0, C1, C2, C3, C4, C5, C6)}
+
+
+def get_variant(variant_id: str) -> RankingVariant:
+    """Look up a variant by id, case-insensitively."""
+    try:
+        return VARIANTS[variant_id.strip().upper()]
+    except KeyError:
+        known = ", ".join(sorted(VARIANTS))
+        raise KeyError(
+            f"unknown variant {variant_id!r}; known variants: {known}"
+        ) from None
+
+
+# --- Wiring into the harness ------------------------------------------------
+
+CandidateSource = Callable[[str, int], Sequence[Candidate]]
+
+
+@dataclass
+class PoolCache:
+    """Per-query candidate pools, so one retrieval serves every variant.
+
+    Keyed by query id rather than query text: two dataset entries with the same
+    text are still distinct rows in the results table, and sharing a pool
+    between them would make their latencies indistinguishable.
+    """
+
+    source: CandidateSource
+    pool_size: int
+    pools: dict[str, Sequence[Candidate]] = field(default_factory=dict)
+
+    def get(self, query: EvalQuery) -> Sequence[Candidate]:
+        if query.id not in self.pools:
+            self.pools[query.id] = self.source(query.query, self.pool_size)
+        return self.pools[query.id]
+
+
+def variant_retriever(
+    variant: RankingVariant,
+    source: CandidateSource,
+    *,
+    cache: PoolCache | None = None,
+    now: datetime | None = None,
+) -> Callable[[EvalQuery, int], Sequence[str]]:
+    """Adapt a variant plus a candidate source into a harness retriever.
+
+    Pass a shared `cache` when scoring several variants in one run so the pool
+    is retrieved once. Note what that does to the latency column: cached runs
+    time the ranking rule only, not retrieval. Score a variant without a cache
+    when its end-to-end latency is the number being reported.
+    """
+
+    def _retrieve(query: EvalQuery, k: int) -> Sequence[str]:
+        if cache is not None:
+            candidates = cache.get(query)
+        else:
+            candidates = source(query.query, max(variant.pool_size or k, k))
+        return rank(variant, query.query, candidates, k, now=now)
+
+    return _retrieve
+
+
+def max_pool_size(variants: Sequence[RankingVariant], k: int) -> int:
+    """Pool size that satisfies every variant in a shared-cache run.
+
+    A shared pool has to be as large as the widest variant needs, or C3/C4 would
+    silently be scored on C0's narrow pool and their whole premise would go
+    untested.
+    """
+    return max([k] + [v.pool_size for v in variants if v.pool_size is not None])

--- a/backend/tests/test_search_variants.py
+++ b/backend/tests/test_search_variants.py
@@ -1,0 +1,416 @@
+"""Track C ranking variant tests (issue #99).
+
+The load-bearing test here is `test_c0_matches_production_ranking`. Every number
+the Track C results table will ever report is a delta against C0, so if C0 drifts
+from what `routers/search.py` actually does, every one of those deltas is
+measuring the drift instead of the variant.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from statistics import fmean
+
+import pytest
+
+from find_api.evaluation.dataset import EvalQuery
+from find_api.evaluation.variants import (
+    C0,
+    C1,
+    C2,
+    C3,
+    C4,
+    C5,
+    C6,
+    PRODUCTION_BOOST_CAP,
+    PRODUCTION_CAPTION_WEIGHT,
+    PRODUCTION_OBJECT_WEIGHT,
+    PRODUCTION_OCR_WEIGHT,
+    PRODUCTION_TEXT_TERM_BONUS,
+    VARIANTS,
+    Candidate,
+    PoolCache,
+    get_variant,
+    max_pool_size,
+    rank,
+    resolve_threshold,
+    textual_boost,
+    variant_retriever,
+)
+from find_api.ml.search_ranking import (
+    bound_similarity,
+    compute_textual_boost,
+    rerank_results,
+    tokenize,
+)
+
+NOW = datetime(2026, 8, 4, tzinfo=timezone.utc)
+
+
+def make_candidate(media_id, similarity, **kwargs) -> Candidate:
+    return Candidate(media_id=str(media_id), vector_similarity=similarity, **kwargs)
+
+
+@pytest.fixture
+def pool() -> list[Candidate]:
+    """A pool with every signal the variants read, and deliberate ties."""
+    return [
+        make_candidate(1, 0.81, caption="a red bicycle on a wall"),
+        make_candidate(2, 0.79, ocr_text="INVOICE total due", liked=True),
+        make_candidate(3, 0.79, object_labels=("bicycle", "person")),
+        make_candidate(4, 0.55, caption="bicycle", ranking_boost=0.30),
+        make_candidate(5, 0.39, caption="a dog", created_at=NOW - timedelta(days=2)),
+        make_candidate(6, 0.37, caption="red bicycle wheel", album_count=2),
+        make_candidate(7, 0.20, ocr_text="receipt bicycle"),
+    ]
+
+
+def production_ranking(query: str, candidates, k: int, threshold: float) -> list[str]:
+    """Reimplementation of routers/search.py's ranking, built from its own helpers.
+
+    Written to follow the router's structure rather than the variant module's,
+    so the two can disagree. It mirrors three behaviours precisely: the SQL
+    filter and ordering (`similarity > threshold`, then
+    `final_score DESC, similarity DESC, id ASC` where final_score folds in
+    `ranking_boost`), the LIMIT applied *before* any boost, and the Python
+    rerank that scores on raw similarity plus the textual boost.
+    """
+    rows = [c for c in candidates if c.vector_similarity > threshold]
+    rows.sort(key=lambda c: int(c.media_id))
+    rows.sort(
+        key=lambda c: (c.vector_similarity + c.ranking_boost, c.vector_similarity),
+        reverse=True,
+    )
+    rows = rows[:k]
+
+    query_tokens = tokenize(query)
+    results = []
+    for row in rows:
+        boost = compute_textual_boost(
+            query_tokens=query_tokens,
+            caption=row.caption,
+            ocr_text=row.ocr_text,
+            object_labels=list(row.object_labels),
+        )
+        results.append(
+            {
+                "media_id": int(row.media_id),
+                "similarity": bound_similarity(row.vector_similarity + boost),
+                "_vector_similarity": row.vector_similarity,
+            }
+        )
+
+    rerank_results(results)
+    return [str(item["media_id"]) for item in results]
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        "red bicycle",
+        "invoice",
+        "bicycle receipt document",
+        "dog",
+        "nothing matches this at all",
+    ],
+)
+@pytest.mark.parametrize("k", [3, 5, 10])
+def test_c0_matches_production_ranking(pool, query, k):
+    """C0 is the production baseline, not an approximation of it."""
+    assert rank(C0, query, pool, k, now=NOW) == production_ranking(
+        query, pool, k, C0.threshold
+    )
+
+
+def test_c0_constants_match_production():
+    """C0's mirrored coefficients still equal the ones production computes with.
+
+    `textual_boost` reimplements `compute_textual_boost` so C5/C6 can vary its
+    constants. This pins the two together: a change to the production
+    coefficients that skipped this module would otherwise land silently and
+    rebase the whole matrix.
+    """
+    candidate = Candidate(
+        media_id="1",
+        vector_similarity=0.5,
+        caption="invoice for a red bicycle",
+        ocr_text="INVOICE bicycle total",
+        object_labels=("bicycle", "invoice"),
+    )
+    tokens = tokenize("invoice bicycle")
+
+    assert textual_boost(C0, tokens, candidate) == pytest.approx(
+        compute_textual_boost(
+            query_tokens=tokens,
+            caption=candidate.caption,
+            ocr_text=candidate.ocr_text,
+            object_labels=list(candidate.object_labels),
+        )
+    )
+    assert (
+        C0.caption_weight,
+        C0.ocr_weight,
+        C0.object_weight,
+        C0.boost_cap,
+        C0.text_term_bonus,
+    ) == (
+        PRODUCTION_CAPTION_WEIGHT,
+        PRODUCTION_OCR_WEIGHT,
+        PRODUCTION_OBJECT_WEIGHT,
+        PRODUCTION_BOOST_CAP,
+        PRODUCTION_TEXT_TERM_BONUS,
+    )
+
+
+def test_boost_is_capped():
+    """The cap binds before the variant's coefficients can run away."""
+    candidate = Candidate(
+        media_id="1",
+        vector_similarity=0.5,
+        ocr_text=" ".join(f"word{i}" for i in range(50)),
+    )
+    tokens = tokenize(" ".join(f"word{i}" for i in range(50)))
+    assert textual_boost(C0, tokens, candidate) == pytest.approx(C0.boost_cap)
+
+
+def test_empty_query_scores_no_boost():
+    """A query that tokenizes to nothing must not earn a boost."""
+    candidate = Candidate(media_id="1", vector_similarity=0.5, caption="anything")
+    assert textual_boost(C0, set(), candidate) == 0.0
+
+
+def test_c1_returns_results_the_threshold_discards(pool):
+    """C1's whole question: what does the static 0.38 cutoff throw away?"""
+    baseline = rank(C0, "bicycle", pool, 10, now=NOW)
+    no_threshold = rank(C1, "bicycle", pool, 10, now=NOW)
+
+    assert set(baseline) <= set(no_threshold)
+    # 6 (0.37) and 7 (0.20) sit below the cutoff and are unreachable under C0.
+    assert {"6", "7"} & set(baseline) == set()
+    assert {"6", "7"} <= set(no_threshold)
+
+
+def test_c1_recovers_results_when_every_candidate_is_below_threshold():
+    """The failure mode C1 exists to size: a query that returns nothing at all."""
+    weak = [make_candidate(i, 0.30 - i * 0.01) for i in range(1, 6)]
+    assert rank(C0, "anything", weak, 5, now=NOW) == []
+    assert len(rank(C1, "anything", weak, 5, now=NOW)) == 5
+
+
+def test_c2_cutoff_tracks_the_pool_rather_than_a_constant():
+    """The adaptive cutoff moves with the pool's own mean, unlike C0's constant.
+
+    Note what it is *not*: an absolute cutoff comparable across pools. A flat
+    pool at 0.60 gets a higher cutoff than a peaked pool whose mean is 0.46,
+    because `mean + z * sigma` is anchored to the mean. The rule separates
+    within a query; it does not rank queries against each other.
+    """
+    peaked = [make_candidate(1, 0.95)] + [make_candidate(i, 0.40) for i in range(2, 10)]
+    high = [make_candidate(i, 0.90 - i * 0.01) for i in range(1, 10)]
+
+    peaked_cut = resolve_threshold(C2, peaked)
+    high_cut = resolve_threshold(C2, high)
+
+    assert peaked_cut == pytest.approx(
+        fmean(c.vector_similarity for c in peaked), abs=0.2
+    )
+    assert high_cut > peaked_cut > C0.threshold
+
+    # On the peaked pool the cutoff lands between the outlier and the cluster,
+    # which is the behaviour C2 exists to test.
+    assert rank(C2, "q", peaked, 5, now=NOW) == ["1"]
+
+
+def test_c2_keeps_nothing_when_the_pool_has_no_spread():
+    """A documented sharp edge, and the reason adaptive_z is a knob to sweep.
+
+    With zero spread the cutoff equals the common score, and the filter is
+    strict, so a pool of identical scores is emptied entirely. C0 would have
+    returned all of them.
+    """
+    flat = [make_candidate(i, 0.60) for i in range(1, 10)]
+
+    assert resolve_threshold(C2, flat) == pytest.approx(0.60)
+    assert rank(C2, "q", flat, 5, now=NOW) == []
+    assert len(rank(C0, "q", flat, 5, now=NOW)) == 5
+
+
+def test_c2_passes_everything_through_on_a_single_candidate():
+    """One sample has no spread to derive a cutoff from."""
+    single = [make_candidate(1, 0.05)]
+    assert resolve_threshold(C2, single) is None
+    assert rank(C2, "q", single, 5, now=NOW) == ["1"]
+
+
+def test_c3_pool_lets_the_boost_rescue_a_result(pool):
+    """C3's premise: a wider pool means the boost can promote, not just reorder.
+
+    Candidate 2 is the only OCR match for "invoice" and earns both the overlap
+    score and the TEXT_QUERY_TERMS bonus — but under C0 the page is cut to k
+    before any of that is computed, so it never gets the chance.
+    """
+    # 4 carries a 0.30 ranking_boost, so it and 1 take the two-row page.
+    assert rank(C0, "invoice", pool, 2, now=NOW) == ["1", "4"]
+
+    wide = rank(C3, "invoice", pool, 2, now=NOW)
+    assert wide == ["2", "1"]
+
+
+def test_c4_signals_only_apply_to_c4(pool):
+    """Recency, favourite, and album bonuses are inert outside C4."""
+    for variant in (C0, C1, C2, C3, C5, C6):
+        assert variant.liked_bonus == 0.0
+        assert variant.recency_weight == 0.0
+        assert variant.album_bonus == 0.0
+
+    # 2 is liked and 3 is not, and they are tied on vector score, so the
+    # favourite bonus is what separates them.
+    tied = [
+        make_candidate(2, 0.79, liked=True),
+        make_candidate(3, 0.79),
+    ]
+    assert rank(C4, "q", tied, 2, now=NOW)[0] == "2"
+    assert rank(C3, "q", tied, 2, now=NOW)[0] == "3"  # id-descending tiebreak
+
+
+def test_c4_recency_decays_with_age():
+    """A fresh item earns close to the full recency weight; an old one does not."""
+    fresh = [
+        make_candidate(1, 0.50, created_at=NOW),
+        make_candidate(2, 0.50, created_at=NOW - timedelta(days=3650)),
+    ]
+    assert rank(C4, "q", fresh, 2, now=NOW) == ["1", "2"]
+
+
+def test_c4_handles_naive_timestamps():
+    """Postgres can hand back naive datetimes; that must not raise."""
+    naive = [make_candidate(1, 0.50, created_at=datetime(2026, 8, 1))]
+    assert rank(C4, "q", naive, 1, now=NOW) == ["1"]
+
+
+def test_c5_drops_only_the_keyword_bonus():
+    """C5 removes the flat 0.05 bump and leaves the overlap score intact."""
+    candidate = Candidate(
+        media_id="1", vector_similarity=0.5, ocr_text="invoice total due"
+    )
+    tokens = tokenize("invoice")
+
+    with_bonus = textual_boost(C0, tokens, candidate)
+    without = textual_boost(C5, tokens, candidate)
+
+    assert with_bonus - without == pytest.approx(PRODUCTION_TEXT_TERM_BONUS)
+    # The overlap component survives.
+    assert without == pytest.approx(PRODUCTION_OCR_WEIGHT)
+
+
+def test_c6_changes_only_the_coefficients():
+    """C6 varies the boost shape and nothing else about retrieval."""
+    assert C6.threshold == C0.threshold
+    assert C6.pool_size == C0.pool_size
+    assert C6.ocr_weight > C0.ocr_weight
+    assert C6.boost_cap > C0.boost_cap
+
+
+def test_ranking_boost_orders_the_pool_but_not_the_score(pool):
+    """Production's asymmetry, reproduced: ranking_boost gates the page only.
+
+    4 has a 0.30 persisted boost on a 0.55 similarity, so it outranks 5 for a
+    slot — but once on the page it is scored on 0.55, not 0.85.
+    """
+    wide = rank(C3, "zzz", pool, 7, now=NOW)
+    assert wide.index("4") > wide.index("1")
+    assert wide.index("4") < wide.index("5")
+
+
+def test_rank_is_deterministic_under_full_ties():
+    """Identical scores must not produce run-to-run ordering noise."""
+    tied = [make_candidate(i, 0.50) for i in range(1, 6)]
+    first = rank(C0, "q", tied, 5, now=NOW)
+    assert first == rank(C0, "q", list(reversed(tied)), 5, now=NOW)
+    assert first == ["5", "4", "3", "2", "1"]
+
+
+def test_non_numeric_ids_rank_deterministically():
+    """Datasets may use string ids; production's int tiebreak must not crash."""
+    mixed = [
+        make_candidate("img-a", 0.50),
+        make_candidate("img-b", 0.50),
+        make_candidate(7, 0.50),
+    ]
+    first = rank(C0, "q", mixed, 3, now=NOW)
+    assert sorted(first) == ["7", "img-a", "img-b"]
+    assert first == rank(C0, "q", list(reversed(mixed)), 3, now=NOW)
+
+
+def test_rank_rejects_non_positive_k(pool):
+    with pytest.raises(ValueError):
+        rank(C0, "q", pool, 0, now=NOW)
+
+
+def test_get_variant_is_case_insensitive_and_names_alternatives():
+    assert get_variant("c3") is C3
+    with pytest.raises(KeyError) as excinfo:
+        get_variant("C9")
+    assert "C0" in excinfo.value.args[0]
+
+
+def test_every_matrix_entry_is_registered():
+    assert set(VARIANTS) == {"C0", "C1", "C2", "C3", "C4", "C5", "C6"}
+    for key, variant in VARIANTS.items():
+        assert variant.id == key
+        assert variant.description
+
+
+def test_max_pool_size_covers_the_widest_variant():
+    """A shared pool sized for C0 would silently invalidate C3 and C4."""
+    assert max_pool_size([C0, C3], 10) == 100
+    assert max_pool_size([C0, C1], 10) == 10
+    assert max_pool_size([C0], 250) == 250
+
+
+def test_pool_cache_retrieves_once_per_query(pool):
+    """One retrieval per query, shared across variants — the fairness guarantee."""
+    calls: list[tuple[str, int]] = []
+
+    def source(query_text: str, pool_size: int):
+        calls.append((query_text, pool_size))
+        return pool
+
+    cache = PoolCache(source=source, pool_size=max_pool_size([C0, C3], 10))
+    query = EvalQuery(id="q1", query="red bicycle", relevant=("1",))
+
+    for variant in (C0, C3, C5):
+        variant_retriever(variant, source, cache=cache, now=NOW)(query, 10)
+
+    assert calls == [("red bicycle", 100)]
+
+
+def test_pool_cache_keys_on_query_id_not_text(pool):
+    """Two dataset rows sharing text stay independent rows in the results table."""
+    calls: list[str] = []
+
+    def source(query_text: str, pool_size: int):
+        calls.append(query_text)
+        return pool
+
+    cache = PoolCache(source=source, pool_size=10)
+    retrieve = variant_retriever(C0, source, cache=cache, now=NOW)
+    retrieve(EvalQuery(id="q1", query="bicycle", relevant=("1",)), 10)
+    retrieve(EvalQuery(id="q2", query="bicycle", relevant=("1",)), 10)
+
+    assert calls == ["bicycle", "bicycle"]
+
+
+def test_uncached_retriever_requests_at_least_k(pool):
+    """Without a cache, the source must still be asked for enough rows."""
+    requested: list[int] = []
+
+    def source(query_text: str, pool_size: int):
+        requested.append(pool_size)
+        return pool
+
+    query = EvalQuery(id="q1", query="bicycle", relevant=("1",))
+    variant_retriever(C0, source, now=NOW)(query, 50)
+    variant_retriever(C3, source, now=NOW)(query, 200)
+
+    assert requested == [50, 200]

--- a/backend/tests/test_search_variants.py
+++ b/backend/tests/test_search_variants.py
@@ -401,6 +401,39 @@ def test_pool_cache_keys_on_query_id_not_text(pool):
     assert calls == ["bicycle", "bicycle"]
 
 
+def test_prewarming_the_cache_leaves_no_variant_paying_for_retrieval(pool):
+    """Filling the pool up front is what makes per-variant latency comparable.
+
+    Lazily, the first variant scored would absorb the whole retrieval cost --
+    query embedding plus a Postgres round trip, which dwarfs any ranking rule --
+    and would read as the slowest variant purely because of loop order. This is
+    the behaviour `_run_variants` relies on.
+    """
+    calls: list[str] = []
+
+    def source(query_text: str, pool_size: int):
+        calls.append(query_text)
+        return pool
+
+    queries = [
+        EvalQuery(id="q1", query="bicycle", relevant=("1",)),
+        EvalQuery(id="q2", query="invoice", relevant=("2",)),
+    ]
+    cache = PoolCache(source=source, pool_size=max_pool_size([C0, C3], 10))
+
+    for query in queries:
+        cache.get(query)
+    assert len(calls) == 2
+
+    for variant in (C0, C3, C5):
+        retrieve = variant_retriever(variant, source, cache=cache, now=NOW)
+        for query in queries:
+            retrieve(query, 10)
+
+    # No variant, including the first one scored, triggered a retrieval.
+    assert len(calls) == 2
+
+
 def test_uncached_retriever_requests_at_least_k(pool):
     """Without a cache, the source must still be asked for enough rows."""
     requested: list[int] = []

--- a/docs/guides/search-evaluation.md
+++ b/docs/guides/search-evaluation.md
@@ -142,14 +142,62 @@ relevant hit, plus any retriever error.
 mean recall while destroying one query class is worse for real users than its
 average suggests, and only the per-query view shows that.
 
+## Scoring the Track C ranking variants
+
+`--db` retrieves candidates straight from Postgres and ranks them with one of
+the query-side variants defined in
+`docs/research/search-retrieval-benchmark-plan.md` (issue #99). It needs database
+access and real model weights in the same process.
+
+```bash
+cd backend
+
+# One variant, end-to-end latency included
+uv run python scripts/evaluate_search.py \
+    --dataset my_dataset.json --db --variant C3 --out c3.json
+
+# The whole matrix, one retrieval per query shared by all seven variants
+uv run python scripts/evaluate_search.py \
+    --dataset my_dataset.json --db --all-variants --out trackc.json
+```
+
+| Variant | Changes, relative to production |
+| --- | --- |
+| `C0` | Nothing — the production baseline |
+| `C1` | No similarity threshold |
+| `C2` | Adaptive threshold from the pool's score spread |
+| `C3` | Candidate pool of 100 before reranking, instead of `k` |
+| `C4` | `C3` plus recency, favourite, and album signals |
+| `C5` | Drops the hardcoded `TEXT_QUERY_TERMS` bonus |
+| `C6` | Reweighted boost coefficients and a higher cap |
+
+Three things to know before reading the output:
+
+- **`--all-variants` shares one candidate pool across variants.** That is what
+  makes the comparison fair — identical input, so a metric difference is the
+  ranking rule and nothing else. It also means the reported latency covers
+  ranking only. For end-to-end latency, score a single variant. The output says
+  which mode produced it.
+- **Retrieval is pinned to exact search.** An HNSW index is deployed, so without
+  pinning, ANN recall error would show up as a ranking difference. `--approximate`
+  opts back into the index when the deployed path is what you want to measure.
+- **`ML_MODE=mock` is refused, not silently used.** The mock embedder is
+  unrelated to the production weighting scheme, so it would emit a complete,
+  plausible results table that means nothing. Use `--stub` to exercise plumbing.
+
 ## Extending with a new retriever
 
 A retriever is any callable `(EvalQuery, k) -> Sequence[str]` returning ranked
-media ids. Two ship today: `stub_retriever` (canned rankings) and the `--api`
-retriever (HTTP against a live instance). Scoring is identical for both — which
-is the point, since two runs are only comparable when the scoring path is the
-same. To benchmark an experimental branch, add a retriever rather than forking
-the scoring.
+media ids. Three ship today: `stub_retriever` (canned rankings), the `--api`
+retriever (HTTP against a live instance), and `--db` (pgvector plus a Track C
+variant). Scoring is identical for all of them — which is the point, since two
+runs are only comparable when the scoring path is the same. To benchmark an
+experimental branch, add a retriever rather than forking the scoring.
+
+For a query-side experiment specifically, prefer adding a `RankingVariant` in
+`find_api.evaluation.variants` over a whole retriever: variants are pure
+functions over a `Candidate` pool, so they are unit-testable without a database
+and they automatically share the pool with every other variant in a run.
 
 ## Validation
 

--- a/docs/research/search-retrieval-benchmark-plan.md
+++ b/docs/research/search-retrieval-benchmark-plan.md
@@ -131,6 +131,35 @@ the clearest evidence before adoption.
 
 Baseline is B0 plus the existing `search_ranking` boost, exact retrieval.
 
+> **Implemented and runnable.** Every variant below now exists as a
+> `RankingVariant` in `backend/src/find_api/evaluation/variants.py` and scores
+> through the #100 harness:
+>
+> ```bash
+> cd backend
+> uv run python scripts/evaluate_search.py \
+>     --dataset my_dataset.json --db --all-variants --out trackc.json
+> ```
+>
+> Three properties of that implementation matter for reading the results:
+>
+> - **One retrieval per query, shared by every variant.** Byte-identical input
+>   means a metric difference is attributable to the ranking rule and nothing
+>   else. The cost is that per-variant latency then covers ranking only; score a
+>   single variant without `--all-variants` when end-to-end latency is the number
+>   being reported. The output records which of the two it is.
+> - **Retrieval is pinned to exact search** (`enable_indexscan`/`enable_bitmapscan`
+>   off) unless `--approximate` is passed, so ANN recall error cannot be
+>   misattributed to a ranking rule.
+> - **C0 is asserted against production**, not approximated. `tests/test_search_variants.py`
+>   reranks the same candidates through `routers/search.py`'s own helpers and
+>   requires identical output across five query shapes and three values of k. A
+>   baseline that has quietly drifted turns every delta in the results table into
+>   a measurement of the drift, so this is the test that matters most.
+>
+> What is still missing is the labeled dataset, not the code. Numbers remain
+> outstanding.
+
 | ID | Variant | Question it answers |
 | --- | --- | --- |
 | C0 | Current: static threshold + existing overlap boost | Reference |
@@ -144,6 +173,20 @@ Baseline is B0 plus the existing `search_ranking` boost, exact retrieval.
 C1 and C5 are deliberately framed as *challenges to existing behaviour*. Both are currently
 unjustified by measurement, and a benchmark that only ever proposes additions will never remove
 anything.
+
+Two of these needed a concrete rule before they could be implemented, and the rule chosen is a
+candidate to be tested rather than a settled design:
+
+- **C2's adaptive cutoff is `mean + z·σ` over the pool's similarities**, `z = 0.5` by default and
+  exposed as `adaptive_z` for sweeping. It has a sharp edge worth knowing before reading its
+  numbers: on a pool with no spread the cutoff collapses onto the common score and, because the
+  filter is strict, discards everything — where C0 would have returned the lot. That is a real
+  property of the rule, not an implementation bug, and it is the reason `adaptive_z` is a knob.
+  It is also anchored to the pool's own mean, so the cutoff is not comparable across queries.
+- **C4's non-semantic bonuses start small** — 0.02 favourite, 0.02 recency at full weight decaying
+  with a 365-day half-life, 0.01 album membership — deliberately below the 0.035 an OCR token
+  overlap earns. If signals this weak already move the metrics, the question of whether they help
+  is answered without a sweep; if they do not, the sweep is cheap.
 
 ## Measurement protocol
 
@@ -220,7 +263,8 @@ evidence because it is free to revert; a schema change cannot.
    data, so this is now a confirmation run against a real library rather than the urgent first
    step, and it can be scheduled alongside Track B instead of ahead of everything.
 2. Track A3/A4 — cheap, runtime-only, fully reversible.
-3. Track C — query-side only, no reindex, so iteration is fast.
+3. Track C — query-side only, no reindex, so iteration is fast. **Implemented; needs only a
+   dataset.** All seven variants score in a single command against one shared candidate pool.
 4. Track B1/B4 — establishes how much the text signals actually contribute before anything is tuned.
 5. Track B2/B3 — tuning, only if B1/B4 show headroom.
 6. Track B5 — last, and only with clear evidence, since it is the only irreversible schema change.
@@ -254,5 +298,8 @@ cheapest measurement that could invalidate the plan runs first.
 - `docs/plans/partial/local-search-quality-roadmap.md` — target metrics and stage sequencing
 - `backend/src/find_api/workers/processors.py` — `generate_hybrid_embedding`, the B0 baseline
 - `backend/src/find_api/ml/search_ranking.py` — existing overlap-based boost and rerank
+- `backend/src/find_api/evaluation/variants.py` — the Track C matrix, C0–C6
+- `backend/src/find_api/evaluation/sources.py` — exact-pinned pgvector candidate source
+- `backend/tests/test_search_variants.py` — the C0-equals-production assertion
 - `backend/src/find_api/routers/search.py` — retrieval query, static threshold, timing instrumentation
 - `backend/alembic/versions/add_hnsw_vector_index.py` — the HNSW index and its default parameters


### PR DESCRIPTION
Part of #99. **No numbers** — the remaining blocker is a labeled dataset, not code.

## What this changes

Track C of `docs/research/search-retrieval-benchmark-plan.md` is the part of #99 that needs no
reindex: seven query-side ranking variants, all revertible by reverting code. This makes every one
of them runnable through the #100 harness.

```bash
uv run python scripts/evaluate_search.py \
    --dataset my_dataset.json --db --all-variants --out trackc.json
```

| Variant | Changes, relative to production |
| --- | --- |
| `C0` | Nothing — the production baseline |
| `C1` | No similarity threshold |
| `C2` | Adaptive threshold from the pool's score spread |
| `C3` | Candidate pool of 100 before reranking, instead of `k` |
| `C4` | `C3` plus recency, favourite, and album signals |
| `C5` | Drops the hardcoded `TEXT_QUERY_TERMS` bonus |
| `C6` | Reweighted boost coefficients and a higher cap |

## Three things that are load-bearing

Each is a way the results table could otherwise have been quietly wrong.

**C0 is asserted equal to production, not approximated.** Every figure Track C will ever report is a
delta against C0, so a baseline that has drifted from `routers/search.py` turns each delta into a
measurement of the drift. `test_search_variants.py` reranks the same candidates through the router's
own helpers and requires identical output across five query shapes × three values of k.

That includes an asymmetry that is easy to miss: `ranking_boost` decides *which* rows reach the page
but does not enter the Python score. Folding it in would make C0 outrank production on
feedback-heavy libraries and flatter every variant measured against it.

**One retrieval per query, shared across variants.** Byte-identical input means a metric difference
is the ranking rule and nothing else. The cost is that per-variant latency then covers ranking only
— recorded in the output rather than left for the reader to infer. Score a single variant when
end-to-end latency is the number being reported.

**Retrieval is pinned to exact search** (`enable_indexscan`/`enable_bitmapscan` off). An HNSW index
is deployed, so without pinning, ANN recall error would surface as a ranking difference. Track A
measures that approximation deliberately; Track C must not absorb it by accident. `--approximate`
opts back in when the deployed path is what you want to measure.

`ML_MODE=mock` is **refused**, not silently used — the mock embedder is unrelated to the production
weighting scheme, so it would emit a complete and entirely plausible results table that means
nothing.

## Design calls worth reviewing

Two variants needed a concrete rule before they could exist, and both are candidates to be *tested*
rather than settled designs:

- **C2's cutoff is `mean + z·σ`** (`z = 0.5`, exposed as `adaptive_z`). It has a sharp edge: on a
  pool with no spread the cutoff collapses onto the common score and, because the filter is strict,
  discards everything — where C0 would have returned the lot. Documented, and a test pins it.
- **C4's bonuses start small** (0.02 favourite, 0.02 recency at 365-day half-life, 0.01 album),
  deliberately below the 0.035 a single OCR token overlap already earns.

## Testing

- `ML_MODE=mock uv run pytest tests/test_search_variants.py` → 39 passed, including the 15
  parametrized C0-vs-production comparisons.
- Existing harness behaviour unchanged: `tests/test_search_eval.py` passes, and the smoke fixture
  still reports P@5 = 0.16 / R@5 = 0.50 / MRR = 0.3667.
- CLI guards checked by hand (`--all-variants` without `--db`, unknown variant id).
- `uv run ruff check . && uv run ruff format --check .` clean.
- **Not tested:** the `--db` path itself. It needs a populated Postgres and real model weights, which
  is the same dependency that blocks the numbers. The ranking logic it feeds is unit-tested against a
  synthetic pool; the SQL and embedder wiring is not.

## Still outstanding on #99

A labeled dataset over a real library — 30–50 hand-judged queries, real corpus, real weights.
`docs/guides/search-evaluation.md` covers building one without biasing it. Tracks A3/A4 and B are
also still open.
