### PR TITLE
fix(deps): raise pnpm overrides past the open nanoid, postcss, and undici advisories

### DIFF
--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -6,9 +6,10 @@ settings:
 
 overrides:
   form-data: 4.0.6
-  postcss: ^8.5.20
+  postcss: ^8.5.26
+  nanoid: ^3.3.18
   sharp: ^0.35.3
-  undici: 7.28.0
+  undici: 7.29.0
   vite: 8.0.16
 
 importers:
@@ -95,8 +96,8 @@ importers:
         specifier: ^30.0.1
         version: 30.0.1
       postcss:
-        specifier: ^8.5.20
-        version: 8.5.20
+        specifier: ^8.5.26
+        version: 8.5.26
       tailwindcss:
         specifier: ^4.3.3
         version: 4.3.3
@@ -1515,11 +1516,6 @@ packages:
   murmurhash-js@1.0.0:
     resolution: {integrity: sha512-TvmkNhkv8yct0SVBSy+o8wYzXjE4Zz3PCesbfs8HiCXXdcTuocApFv11UWlNFWKYsP2okqrhb7JNlSm9InBhIw==}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
-    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
-    hasBin: true
-
   nanoid@3.3.18:
     resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -1584,14 +1580,6 @@ packages:
     resolution: {integrity: sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==}
     engines: {node: '>=20'}
     hasBin: true
-
-  postcss@8.5.20:
-    resolution: {integrity: sha512-lW616l85ucIQL+FocMmL7pQFPqBmwejrCMg+iPxyImlrANNJG9NHq/RkyCZopDhd8C3LA03PHRJDjkbGu8vvug==}
-    engines: {node: ^10 || ^12 || >=14}
-
-  postcss@8.5.23:
-    resolution: {integrity: sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==}
-    engines: {node: ^10 || ^12 || >=14}
 
   postcss@8.5.26:
     resolution: {integrity: sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==}
@@ -1781,8 +1769,8 @@ packages:
   undici-types@8.3.0:
     resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
 
-  undici@7.28.0:
-    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
+  undici@7.29.0:
+    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
     engines: {node: '>=20.18.1'}
 
   vite@8.0.16:
@@ -2374,7 +2362,7 @@ snapshots:
       '@alloc/quick-lru': 5.2.0
       '@tailwindcss/node': 4.3.3
       '@tailwindcss/oxide': 4.3.3
-      postcss: 8.5.23
+      postcss: 8.5.26
       tailwindcss: 4.3.3
 
   '@tanstack/query-core@5.101.4': {}
@@ -2840,7 +2828,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.2
-      undici: 7.28.0
+      undici: 7.29.0
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -3003,8 +2991,6 @@ snapshots:
 
   murmurhash-js@1.0.0: {}
 
-  nanoid@3.3.16: {}
-
   nanoid@3.3.18: {}
 
   next@16.2.12(@playwright/test@1.62.1)(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
@@ -3013,7 +2999,7 @@ snapshots:
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.11.11
       caniuse-lite: 1.0.30001806
-      postcss: 8.5.20
+      postcss: 8.5.26
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
       styled-jsx: 5.1.6(react@19.2.8)
@@ -3062,18 +3048,6 @@ snapshots:
       playwright-core: 1.62.1
     optionalDependencies:
       fsevents: 2.3.2
-
-  postcss@8.5.20:
-    dependencies:
-      nanoid: 3.3.16
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
-
-  postcss@8.5.23:
-    dependencies:
-      nanoid: 3.3.16
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
 
   postcss@8.5.26:
     dependencies:
@@ -3281,7 +3255,7 @@ snapshots:
 
   undici-types@8.3.0: {}
 
-  undici@7.28.0: {}
+  undici@7.29.0: {}
 
   vite@8.0.16(@types/node@26.2.0)(jiti@2.7.0):
     dependencies:

--- a/frontend/pnpm-workspace.yaml
+++ b/frontend/pnpm-workspace.yaml
@@ -3,20 +3,30 @@ minimumReleaseAgeExclude:
   - baseline-browser-mapping
   # Security patches must not wait for the normal seven-day release-age gate.
   - form-data
+  - nanoid
+  - postcss
   - undici
   - vite
 allowBuilds:
   sharp: true
 overrides:
   form-data: 4.0.6
-  # postcss <=8.5.17 is a high advisory (GHSA-r28c-9q8g-f849). The Tailwind v3
-  # PostCSS toolchain resolved against 8.5.14 and stayed there because the old
-  # floor still satisfied it; raise the floor so every consumer collapses onto
-  # one patched copy.
-  postcss: ^8.5.20
+  # postcss <=8.5.22 is a medium advisory (GHSA-fxqj-rqcc-2cmp, the incomplete
+  # fix for GHSA-6g55-p6wh-862q). The Tailwind PostCSS toolchain resolved
+  # against an older patch and stayed there because the old floor still
+  # satisfied it; raise the floor so every consumer collapses onto one patched
+  # copy. 8.5.26 is also the first release whose own nanoid floor is patched,
+  # so it clears the nanoid advisory below in one go.
+  postcss: ^8.5.26
+  # nanoid <3.3.18 is a high advisory (GHSA-2v37-7h3g-55p8). It reaches the tree
+  # only through postcss, but older postcss patches still pin 3.3.16, so pin the
+  # floor here too rather than relying on a transitive bump.
+  nanoid: ^3.3.18
   # sharp <0.35.0 is vulnerable (GHSA high); Next pulls it in transitively for
   # image optimisation, so pin the whole tree forward rather than waiting for
   # Next to bump its own floor.
   sharp: ^0.35.3
-  undici: 7.28.0
+  # undici <7.29.0 carries GHSA-4cwx-7wf7-3272 (high) plus four medium cache /
+  # cookie / CRLF advisories; pinned exactly so every consumer shares one copy.
+  undici: 7.29.0
   vite: 8.0.16


### PR DESCRIPTION
## What

Closes the seven open Dependabot advisories against `frontend/pnpm-lock.yaml`. All of them are transitive packages already governed by the `overrides` block in `frontend/pnpm-workspace.yaml`, so the fix is a floor bump rather than a direct dependency change.

| Package | Advisory | Severity | Was | Now |
| --- | --- | --- | --- | --- |
| nanoid | GHSA-2v37-7h3g-55p8 | high | 3.3.16 | 3.3.18 |
| postcss | GHSA-fxqj-rqcc-2cmp | medium | 8.5.20 | 8.5.26 |
| undici | GHSA-4cwx-7wf7-3272 + 4 mediums | high | 7.28.0 | 7.29.0 |

## Why these versions

- `postcss@8.5.26` is the first release whose own `nanoid` floor is patched, so it clears the nanoid advisory as a side effect. `nanoid` is still pinned to `^3.3.18` directly so no stale postcss patch can drag it back to 3.3.16.
- The old `postcss: ^8.5.20` floor was still satisfied by the Tailwind PostCSS toolchain, which is why nothing moved on its own.
- `undici` was pinned exactly at 7.28.0, so the five advisories against it could not resolve without editing the pin.
- `nanoid` and `postcss` are added to `minimumReleaseAgeExclude` for the same reason `form-data`, `undici`, and `vite` are already there: security patches must not wait out the seven-day release-age gate.

## Testing

- `pnpm install` - lockfile resolves a single copy each of `nanoid@3.3.18`, `postcss@8.5.26`, `undici@7.29.0`
- `pnpm check` - pass (23 pre-existing warnings, unchanged)
- `pnpm build` - pass
- `pnpm test` - 41 files, 311 tests pass

Not tested: `pnpm test:e2e` (Playwright) and the Tauri desktop build.

## Scope

No app code touched - only `frontend/pnpm-workspace.yaml` and `frontend/pnpm-lock.yaml`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Updated underlying components to include patched versions and address known security advisories.
  * Strengthened release safeguards to help ensure approved, secure versions are used.

* **Maintenance**
  * Refreshed supported component versions for improved reliability and ongoing maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->