### PR TITLE
fix(api): stop echoing identifier-resolution errors into the footprint report

### DIFF
--- a/backend/src/find_api/core/model_footprint.py
+++ b/backend/src/find_api/core/model_footprint.py
@@ -22,6 +22,7 @@ Design constraints (tracked by issue #339, the CPU-only runtime profile):
 
 from __future__ import annotations
 
+import logging
 import os
 import time
 from dataclasses import dataclass
@@ -36,6 +37,13 @@ from find_api.core.hardware import (
     resolve_execution,
 )
 from find_api.core.model_manager import get_model_manager
+
+logger = logging.getLogger(__name__)
+
+# Placeholder used when a model's configured identifier cannot be resolved.
+# Deliberately constant: the underlying exception text is logged server-side
+# instead of being echoed into the HTTP report.
+UNRESOLVED_IDENTIFIER = "<unresolved>"
 
 # --- Pack identifiers --------------------------------------------------------
 PACK_LIGHT = "light"
@@ -477,8 +485,15 @@ def build_report(include_paths: bool = False) -> dict:
     for spec in MODEL_SPECS:
         try:
             identifier = spec.identifier()
-        except Exception as exc:  # noqa: BLE001
-            identifier = f"<unresolved: {exc}>"
+        except Exception:  # noqa: BLE001
+            # The report is reachable over HTTP, so the exception text stays
+            # server-side: a settings/import failure here can name modules,
+            # env keys, or filesystem paths. Callers only need to know the
+            # identifier could not be resolved.
+            logger.warning(
+                "Could not resolve identifier for model %s", spec.key, exc_info=True
+            )
+            identifier = UNRESOLVED_IDENTIFIER
 
         try:
             cache_info = spec.cache_resolver()

--- a/backend/tests/test_model_footprint.py
+++ b/backend/tests/test_model_footprint.py
@@ -9,7 +9,9 @@ the test loudly instead of silently succeeding.
 
 from __future__ import annotations
 
+import dataclasses
 import json
+import logging
 import os
 
 import pytest
@@ -446,6 +448,41 @@ class TestBuildReport:
 
         yolo_entry = next(m for m in report["models"] if m["key"] == "yolo")
         assert yolo_entry["cache"]["path"] == str(tmp_path / "yolo26n.pt")
+
+    def test_unresolvable_identifier_does_not_leak_exception_text(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        """A failing identifier resolver must not echo its message to callers.
+
+        ``build_report(include_paths=False)`` is served by the admin
+        ``GET /status/models/footprint`` endpoint, so an exception raised
+        while resolving a configured identifier would put whatever that
+        exception says — module names, env keys, filesystem paths — into an
+        HTTP response body. The detail belongs in the server log only.
+        """
+        self._wire_all_caches(tmp_path, monkeypatch)
+
+        secret = f"cannot import backend module at {tmp_path / 'private' / 'x.py'}"
+
+        def _boom() -> str:
+            raise RuntimeError(secret)
+
+        broken = [
+            dataclasses.replace(spec, identifier=_boom) if spec.key == "yolo" else spec
+            for spec in mf.MODEL_SPECS
+        ]
+        monkeypatch.setattr(mf, "MODEL_SPECS", tuple(broken))
+
+        with caplog.at_level(logging.WARNING, logger=mf.__name__):
+            report = mf.build_report(include_paths=False)
+
+        yolo_entry = next(m for m in report["models"] if m["key"] == "yolo")
+        assert yolo_entry["identifier"] == mf.UNRESOLVED_IDENTIFIER
+        assert secret not in json.dumps(report)
+        assert "RuntimeError" not in json.dumps(report)
+
+        # The detail is still recoverable by the operator, just server-side.
+        assert secret in caplog.text
 
     def test_never_raises_when_everything_is_missing(self, tmp_path, monkeypatch):
         empty = tmp_path / "nothing-here"


### PR DESCRIPTION
## What

Fixes CodeQL alert **#14** — `py/stack-trace-exposure` (medium) on `backend/src/find_api/routers/status.py:33`.

The alert's real source is `build_report()` in `backend/src/find_api/core/model_footprint.py`:

```python
try:
    identifier = spec.identifier()
except Exception as exc:
    identifier = f"<unresolved: {exc}>"   # <- goes straight into the HTTP body
```

`GET /status/models/footprint` returns that report verbatim, so any failure inside an `identifier()` resolver put the exception's own text in front of an HTTP caller — module names, env keys, or filesystem paths, depending on what failed. In local mode `get_admin_user` is a no-op restriction, so that caller is anyone who can reach the instance.

This also contradicted the module docstring's own constraint: *"Never exposes credentials or private media metadata."*

## Change

- Log the exception with `exc_info=True` under `find_api.core.model_footprint` so the operator keeps the full detail server-side.
- Return a module-level constant `UNRESOLVED_IDENTIFIER = "<unresolved>"` in the report instead of the formatted exception.

Behaviour is otherwise unchanged: the report still never raises, and a broken resolver still degrades to a placeholder rather than a 500.

## Testing

- New regression test `test_unresolvable_identifier_does_not_leak_exception_text` — replaces one spec's resolver with one that raises a message containing a filesystem path, then asserts the message is absent from the serialized report, the entry reads `<unresolved>`, and the message *is* present in the captured log.
- `uv run pytest tests/` — 795 passed, 7 skipped
- `uv run ruff check .` — clean
- `uv run ruff format --check .` — clean

Not tested: live ML stack behaviour (the resolvers are patched in tests and never download weights, by design).