### PR TITLE
chore(deps): update uvicorn[standard] requirement to >=0.52.3,<0.53

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -6,7 +6,7 @@ license = "AGPL-3.0-only"
 requires-python = ">=3.12,<3.13"
 dependencies = [
   "fastapi>=0.141.1,<0.142",
-  "uvicorn[standard]>=0.52.1,<0.53",
+  "uvicorn[standard]>=0.52.3,<0.53",
   "python-multipart>=0.0.32,<0.1",
   "pydantic>=2.13.4,<3",
   "pydantic-settings>=2.15.0,<3",

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -751,7 +751,7 @@ requires-dist = [
     { name = "transformers", marker = "extra == 'nvidia'", specifier = ">=5.15.0,<6" },
     { name = "ultralytics", marker = "extra == 'cpu'", specifier = ">=8.4.120" },
     { name = "ultralytics", marker = "extra == 'nvidia'", specifier = ">=8.4.120" },
-    { name = "uvicorn", extras = ["standard"], specifier = ">=0.52.1,<0.53" },
+    { name = "uvicorn", extras = ["standard"], specifier = ">=0.52.3,<0.53" },
 ]
 provides-extras = ["mock", "cpu", "nvidia"]
 
@@ -3095,15 +3095,15 @@ wheels = [
 
 [[package]]
 name = "uvicorn"
-version = "0.52.1"
+version = "0.52.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
     { name = "h11" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/03/18/ccce41535dee1be77735592bd19965f3972c82e07ee703d324709496b716/uvicorn-0.52.1.tar.gz", hash = "sha256:112ec661814189acbccd3f7b86460147cc065fc92c0821afa78918780e4354dd", size = 100571, upload-time = "2026-08-01T18:19:30.732Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f2/0f/3f86e61397dd33bf2ccf28188c40db6a740658aeebbbf6e7dbc101a1f487/uvicorn-0.52.4.tar.gz", hash = "sha256:73acfee47a0b133c5de13d219492d62d8a31e935f4fe6e41a232451a15379f86", size = 100627, upload-time = "2026-08-19T06:27:41.821Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/d5/68e6e9bca63c0badf67002890a46d3784c958de45b65e1275ec583ca1f06/uvicorn-0.52.1-py3-none-any.whl", hash = "sha256:e4403f9d93188cf9d1088e9f40e3acd12630e2df8675316704379a7fc20fff6a", size = 79859, upload-time = "2026-08-01T18:19:29.294Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/79/4a20b54ab0491485ccd8c077db2d39187c7f12b3e15485d38a7be37c81b4/uvicorn-0.52.4-py3-none-any.whl", hash = "sha256:f86e41a149d7d05a9969337e3946a9c171c06a5d42680896daaba624aeac8da1", size = 79871, upload-time = "2026-08-19T06:27:40.36Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## What

Restores the change from #457. Dependabot opened that PR, then closed it itself with *"Looks like uvicorn[standard] is no longer updatable"* once the other backend dependency PRs (#454, #455, #456) landed and its branch went stale — and it deleted the branch, so it cannot be reopened.

The floor never actually moved on canary: `backend/pyproject.toml` still said `>=0.52.1,<0.53` and `backend/uv.lock` was still pinned to uvicorn 0.52.1.

## Change

- `uvicorn[standard]` requirement: `>=0.52.1,<0.53` → `>=0.52.3,<0.53` (exactly what #457 proposed)
- Relocked; uv resolves **0.52.4**, the current release inside the unchanged `<0.53` ceiling.

## Testing

- `uv lock` — resolves 201 packages, only uvicorn moves
- Full `uv run pytest tests/` was run against this same lock state on the sibling branch for #462 (795 passed, 7 skipped); CI re-runs it here.