### PR TITLE
feat: PR Docker builds, desktop release path, PWA offline queue, and Instance UI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,14 +2,18 @@ name: CI
 
 # Trigger matrix (which paths wake which jobs):
 #
-#   Path pattern                    | frontend-check | backend-check | compose-check
-#   --------------------------------|----------------|---------------|--------------
-#   frontend/**                     |      yes       |      no       |      no
-#   backend/**, scripts/**          |      no        |      yes      |      no
-#   .github/workflows/**            |      yes       |      yes      |      yes
-#   compose*.yml                    |      yes       |      yes      |      yes
-#   root/shared non-doc config      |      yes       |      yes      |      no
-#   docs/**, *.md, ISSUE_TEMPLATE   |      no        |      no       |      no
+#   Path pattern                    | frontend-check | backend-check | compose-check | docker-check
+#   --------------------------------|----------------|---------------|---------------|-------------
+#   frontend/**                     |      yes       |      no       |      no       |  only if (*)
+#   backend/**, scripts/**          |      no        |      yes      |      no       |  only if (*)
+#   .github/workflows/**            |      yes       |      yes      |      yes      |  only ci.yml
+#   compose*.yml                    |      yes       |      yes      |      yes      |      no
+#   root/shared non-doc config      |      yes       |      yes      |      no       |      yes
+#   docs/**, *.md, ISSUE_TEMPLATE   |      no        |      no       |      no       |      no
+#
+# (*) docker-check is deliberately narrower than frontend/backend: it wakes only
+#     for the Dockerfiles themselves and the dependency manifests they COPY, not
+#     for every source edit. See the `docker` filter in detect-changes.
 
 on:
   workflow_dispatch:
@@ -100,6 +104,7 @@ jobs:
       frontend: ${{ steps.filter.outputs.frontend }}
       backend: ${{ steps.filter.outputs.backend }}
       shared: ${{ steps.filter.outputs.shared }}
+      docker: ${{ steps.filter.outputs.docker }}
       uncategorized: ${{ steps.uncategorized.outputs.uncategorized }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
@@ -118,6 +123,23 @@ jobs:
             shared:
               - '.github/workflows/**'
               - 'compose*.yml'
+            # Only the image inputs, not all of frontend/** and backend/**.
+            # An image build is expensive, and editing a React component or a
+            # router cannot break a Dockerfile that COPYs the whole tree
+            # anyway. What *can* break it is a change to the Dockerfile, to a
+            # dependency manifest it installs from, or to this file's version
+            # pins -- so those are the triggers.
+            docker:
+              - 'frontend/Dockerfile'
+              - 'frontend/.dockerignore'
+              - 'frontend/package.json'
+              - 'frontend/pnpm-lock.yaml'
+              - 'frontend/pnpm-workspace.yaml'
+              - 'backend/Dockerfile'
+              - 'backend/.dockerignore'
+              - 'backend/pyproject.toml'
+              - 'backend/uv.lock'
+              - '.github/workflows/ci.yml'
 
       - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d
         id: uncategorized
@@ -158,7 +180,10 @@ jobs:
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
         with:
-          node-version: 22
+          # Node 24 is Active LTS. Keep this in lockstep with the `FROM
+          # node:<major>-alpine` line in frontend/Dockerfile -- `docker-check`
+          # asserts the two agree, so changing one alone fails CI.
+          node-version: 24
           cache: "pnpm"
           cache-dependency-path: frontend/pnpm-lock.yaml
 
@@ -291,6 +316,99 @@ jobs:
 
       - name: Validate ${{ matrix.file }}
         run: docker compose --env-file .env.example -f "${{ matrix.file }}" config --quiet
+
+  # Build both Dockerfiles on pull requests.
+  #
+  # Before this job, `publish.yml` was the only workflow that built them and it
+  # runs on release -- so a broken Dockerfile stayed invisible until a release
+  # build, and the version pins in this file drifted from the ones in the
+  # images with nothing comparing them (#396).
+  #
+  # Build only: no push, no registry login, no QEMU/multi-arch. The backend
+  # builds its default `no-ai` profile; `cpu`/`nvidia` pull multi-gigabyte
+  # torch wheels and stay in the release path where they belong.
+  docker-check:
+    name: docker-check
+    needs: detect-changes
+    if: needs.detect-changes.outputs.docker == 'true' || needs.detect-changes.outputs.uncategorized == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
+
+      # The runtime versions live in two places each, and nothing used to
+      # compare them: `node-version` here vs `FROM node:<major>-alpine` in
+      # frontend/Dockerfile, and `python-version` here vs `ARG PYTHON_VERSION`
+      # / `ARG BASE_IMAGE` in backend/Dockerfile. They agreed by coincidence.
+      # Fail loudly on drift rather than discovering it at release time.
+      - name: Assert CI and Dockerfile runtime pins agree
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # Fail if a pin is missing (grep went stale) or ambiguous.
+          assert_single() {
+            local label="$1" values="$2"
+            if [ -z "${values}" ]; then
+              echo "No ${label} pin found -- the grep for it is stale." >&2
+              exit 1
+            fi
+            if [ "$(echo "${values}" | wc -l)" -ne 1 ]; then
+              echo "${label} is pinned to more than one value:" >&2
+              echo "${values}" >&2
+              exit 1
+            fi
+          }
+
+          ci_node="$(grep -oP 'node-version:\s*\K[0-9]+' .github/workflows/ci.yml | sort -u)"
+          dockerfile_node="$(grep -oP '^FROM node:\K[0-9]+' frontend/Dockerfile | sort -u)"
+          assert_single "ci.yml node-version" "${ci_node}"
+          assert_single "frontend/Dockerfile node major" "${dockerfile_node}"
+          if [ "${ci_node}" != "${dockerfile_node}" ]; then
+            echo "Node major drift: ci.yml=${ci_node}, frontend/Dockerfile=${dockerfile_node}." >&2
+            echo "Bump both in the same commit." >&2
+            exit 1
+          fi
+
+          ci_python="$(grep -oP 'python-version:\s*"\K[0-9]+\.[0-9]+' .github/workflows/ci.yml | sort -u)"
+          dockerfile_python="$(grep -oP '^ARG PYTHON_VERSION=\K[0-9]+\.[0-9]+' backend/Dockerfile | sort -u)"
+          dockerfile_base="$(grep -oP '^ARG BASE_IMAGE=python:\K[0-9]+\.[0-9]+' backend/Dockerfile | sort -u)"
+          assert_single "ci.yml python-version" "${ci_python}"
+          assert_single "backend/Dockerfile PYTHON_VERSION" "${dockerfile_python}"
+          assert_single "backend/Dockerfile BASE_IMAGE" "${dockerfile_base}"
+          if [ "${ci_python}" != "${dockerfile_python}" ] || [ "${ci_python}" != "${dockerfile_base}" ]; then
+            echo "Python drift: ci.yml=${ci_python}, PYTHON_VERSION=${dockerfile_python}, BASE_IMAGE=${dockerfile_base}." >&2
+            echo "Bump all three in the same commit." >&2
+            exit 1
+          fi
+
+          echo "Node ${ci_node} and Python ${ci_python} agree across CI and both Dockerfiles."
+
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c
+
+      # Default profile (no-ai). The ML profiles are a release-time concern.
+      - name: Build backend image
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a
+        with:
+          context: ./backend
+          file: ./backend/Dockerfile
+          push: false
+          cache-from: type=gha,scope=docker-check-backend
+          cache-to: type=gha,mode=max,scope=docker-check-backend
+
+      # `production` is the stage publish.yml ships, and it is the only one that
+      # exercises the full `pnpm build` + standalone-output copy chain.
+      - name: Build frontend image
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a
+        with:
+          context: ./frontend
+          file: ./frontend/Dockerfile
+          target: production
+          push: false
+          cache-from: type=gha,scope=docker-check-frontend
+          cache-to: type=gha,mode=max,scope=docker-check-frontend
 
   dependency-review:
     if: github.event_name == 'pull_request'

--- a/.github/workflows/desktop-installer.yml
+++ b/.github/workflows/desktop-installer.yml
@@ -56,8 +56,15 @@ jobs:
   #
   # The flag sits on the step, not the job: job-level continue-on-error still
   # reports the check itself as failed (it only spares the workflow run), which
-  # would leave a red X on every desktop PR. On the step, the job goes green
-  # while the step stays visibly red in the log.
+  # would leave a red X on every desktop PR.
+  #
+  # Note what that costs. A continue-on-error step reports `conclusion:
+  # success` and renders as a warning rather than a failure, so the build going
+  # wrong is NOT loud on its own. The "Report the known static-export break"
+  # step below is what makes it visible: it keys off `steps.build.outcome`,
+  # which preserves the true result, and emits a ::warning annotation onto the
+  # run summary. The listing and upload steps gate on the same value, so a
+  # failed build cannot produce an artifact.
   #
   # REMOVE IT when #465 lands, or the job quietly stops being a gate.
   unsigned-build:

--- a/.github/workflows/desktop-installer.yml
+++ b/.github/workflows/desktop-installer.yml
@@ -1,0 +1,251 @@
+name: Desktop installer
+
+# Windows installer pipeline for the Tauri desktop shell (issue #48).
+#
+# Two deliberately separate paths:
+#
+#   unsigned-build  - runs for contributors on pull requests. No secrets, no
+#                     environment, no signing. Proves the Tauri bundle still
+#                     builds, and uploads the artifact for manual inspection.
+#   signed-release  - maintainer-only, manual dispatch, gated behind the
+#                     protected `desktop-release` environment, which is where
+#                     the code-signing secrets live. Publishes a DRAFT release.
+#
+# The split is the point: a fork pull request must never be able to reach the
+# signing credentials. Because environment secrets are unavailable to
+# `pull_request` runs from forks, that is enforced by construction rather than
+# by convention.
+#
+# The signed path is inert until a certificate exists -- see
+# docs/plans/not-started/desktop-installer-release.md for provisioning,
+# rotation, verification, and the macOS/Linux extension points.
+
+on:
+  pull_request:
+    branches: ["canary", "main"]
+    paths:
+      - "frontend/src-tauri/**"
+      - "frontend/package.json"
+      - "frontend/pnpm-lock.yaml"
+      - "frontend/next.config.js"
+      - ".github/workflows/desktop-installer.yml"
+  workflow_dispatch:
+    inputs:
+      sign:
+        description: "Sign the installer (requires the desktop-release environment)"
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+concurrency:
+  group: desktop-installer-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # Contributor-facing validation. Runs with the default read-only token and
+  # cannot access any signing material.
+  unsigned-build:
+    name: Unsigned Windows build
+    if: inputs.sign != true
+    runs-on: windows-latest
+    timeout-minutes: 45
+    defaults:
+      run:
+        working-directory: ./frontend
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
+
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86
+        with:
+          version: 11.3.0
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+        with:
+          # Matches frontend-check in ci.yml and frontend/Dockerfile.
+          node-version: 24
+          cache: "pnpm"
+          cache-dependency-path: frontend/pnpm-lock.yaml
+
+      # windows-latest ships a stable Rust toolchain, so no toolchain action is
+      # needed. Cache the registry and target dir instead: a cold Tauri build
+      # spends nearly all of its time compiling dependencies, not our two
+      # source files.
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            frontend/src-tauri/target
+          key: tauri-windows-${{ hashFiles('frontend/src-tauri/Cargo.lock') }}
+          restore-keys: tauri-windows-
+
+      - run: pnpm install --frozen-lockfile
+
+      # `tauri build` runs `beforeBuildCommand` (pnpm build:static) itself, so
+      # the static export is produced as part of this step.
+      - name: Build unsigned installer
+        run: pnpm desktop:build
+
+      # Record what came out. `targets: "all"` on Windows produces both the NSIS
+      # .exe and the WiX .msi; listing them makes a bundle-target regression
+      # visible in the log rather than only as a missing upload.
+      - name: List bundle output
+        shell: bash
+        run: |
+          bundle_dir="src-tauri/target/release/bundle"
+          if [ ! -d "${bundle_dir}" ]; then
+            echo "No bundle directory produced at ${bundle_dir}." >&2
+            exit 1
+          fi
+          find "${bundle_dir}" -type f \( -name '*.msi' -o -name '*.exe' \) -print
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: find-desktop-windows-unsigned
+          path: |
+            frontend/src-tauri/target/release/bundle/msi/*.msi
+            frontend/src-tauri/target/release/bundle/nsis/*.exe
+          if-no-files-found: error
+          retention-days: 14
+
+  # Maintainer-only. `environment:` is what actually gates this: the signing
+  # secrets are scoped to `desktop-release`, which carries required reviewers
+  # and a tag restriction, so this job cannot start from a fork pull request.
+  signed-release:
+    name: Signed Windows release
+    if: github.event_name == 'workflow_dispatch' && inputs.sign == true
+    runs-on: windows-latest
+    timeout-minutes: 60
+    environment: desktop-release
+    permissions:
+      contents: write
+    defaults:
+      run:
+        working-directory: ./frontend
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
+
+      # Fail fast and legibly when the environment has not been provisioned,
+      # instead of producing a silently unsigned installer that would then be
+      # attached to a release as though it were signed.
+      - name: Preflight - require signing material
+        shell: bash
+        env:
+          CERT_BASE64: ${{ secrets.WINDOWS_CERTIFICATE }}
+          CERT_PASSWORD: ${{ secrets.WINDOWS_CERTIFICATE_PASSWORD }}
+        run: |
+          missing=0
+          if [ -z "${CERT_BASE64}" ]; then
+            echo "Secret WINDOWS_CERTIFICATE is not set on the desktop-release environment." >&2
+            missing=1
+          fi
+          if [ -z "${CERT_PASSWORD}" ]; then
+            echo "Secret WINDOWS_CERTIFICATE_PASSWORD is not set on the desktop-release environment." >&2
+            missing=1
+          fi
+          if [ "${missing}" -ne 0 ]; then
+            echo "Refusing to build an installer that would be published as signed but is not." >&2
+            exit 1
+          fi
+
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86
+        with:
+          version: 11.3.0
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+        with:
+          node-version: 24
+          cache: "pnpm"
+          cache-dependency-path: frontend/pnpm-lock.yaml
+
+      - run: pnpm install --frozen-lockfile
+
+      # The PFX is imported into the runner's per-job certificate store and the
+      # temporary file is removed immediately. Tauri signs through the store
+      # using the thumbprint in tauri.conf.json, so the key material never
+      # reaches a build argument, a command line, or a log.
+      - name: Import code-signing certificate
+        shell: pwsh
+        env:
+          CERT_BASE64: ${{ secrets.WINDOWS_CERTIFICATE }}
+          CERT_PASSWORD: ${{ secrets.WINDOWS_CERTIFICATE_PASSWORD }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $pfxPath = Join-Path $env:RUNNER_TEMP 'find-signing.pfx'
+          [IO.File]::WriteAllBytes($pfxPath, [Convert]::FromBase64String($env:CERT_BASE64))
+          $securePassword = ConvertTo-SecureString -String $env:CERT_PASSWORD -AsPlainText -Force
+          Import-PfxCertificate -FilePath $pfxPath -CertStoreLocation Cert:\CurrentUser\My -Password $securePassword | Out-Null
+          Remove-Item $pfxPath -Force
+
+      - name: Build signed installer
+        run: pnpm desktop:build
+
+      # Verification is not optional: an unsigned artifact must never leave this
+      # job wearing a release tag. signtool exits non-zero when the Authenticode
+      # signature is absent or does not chain to a trusted root, which is also
+      # what catches a missing `certificateThumbprint` in tauri.conf.json.
+      - name: Verify Authenticode signature
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $bundle = 'src-tauri/target/release/bundle'
+          $artifacts = Get-ChildItem -Path $bundle -Recurse -Include *.msi, *.exe
+          if (-not $artifacts) { throw "No installer artifacts found under $bundle" }
+          $signtool = Get-ChildItem 'C:\Program Files (x86)\Windows Kits\10\bin' -Recurse -Filter signtool.exe |
+            Where-Object { $_.FullName -like '*x64*' } |
+            Select-Object -First 1
+          if (-not $signtool) { throw 'signtool.exe was not found on the runner' }
+          foreach ($artifact in $artifacts) {
+            & $signtool.FullName verify /pa /v $artifact.FullName
+            if ($LASTEXITCODE -ne 0) { throw "Signature verification failed for $($artifact.Name)" }
+          }
+
+      - name: Write checksums
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $bundle = 'src-tauri/target/release/bundle'
+          Get-ChildItem -Path $bundle -Recurse -Include *.msi, *.exe |
+            ForEach-Object { "$((Get-FileHash $_.FullName -Algorithm SHA256).Hash)  $($_.Name)" } |
+            Set-Content -Encoding utf8 (Join-Path $bundle 'SHA256SUMS.txt')
+          Get-Content (Join-Path $bundle 'SHA256SUMS.txt')
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: find-desktop-windows-signed
+          path: |
+            frontend/src-tauri/target/release/bundle/msi/*.msi
+            frontend/src-tauri/target/release/bundle/nsis/*.exe
+            frontend/src-tauri/target/release/bundle/SHA256SUMS.txt
+          if-no-files-found: error
+          retention-days: 30
+
+      # Draft, never published automatically. A human opens the draft, checks
+      # the artifacts, and presses publish, so a bad build stays discardable
+      # instead of being something users have already downloaded. The tag comes
+      # from frontend/package.json, which `scripts/bump_version.py --check`
+      # already keeps in sync with the backend and the Tauri config.
+      - name: Attach artifacts to a draft release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          version="$(node -p "require('./package.json').version")"
+          tag="v${version}"
+          if ! gh release view "${tag}" >/dev/null 2>&1; then
+            gh release create "${tag}" --draft --title "Find ${version}" \
+              --notes "Draft release. Desktop installers attached by the desktop-installer workflow."
+          fi
+          gh release upload "${tag}" \
+            src-tauri/target/release/bundle/msi/*.msi \
+            src-tauri/target/release/bundle/nsis/*.exe \
+            src-tauri/target/release/bundle/SHA256SUMS.txt \
+            --clobber

--- a/.github/workflows/desktop-installer.yml
+++ b/.github/workflows/desktop-installer.yml
@@ -48,19 +48,22 @@ jobs:
   # Contributor-facing validation. Runs with the default read-only token and
   # cannot access any signing material.
   #
-  # continue-on-error until #465 is fixed: `pnpm build:static` currently fails
-  # on canary because three dynamic routes have no generateStaticParams(), so
-  # the Tauri bundle cannot be produced at all. That break is what this job
-  # found on its first run -- it is not caused by this job, and it must not
-  # gate unrelated desktop pull requests in the meantime. The build step still
-  # runs and still shows red in the log.
+  # The build step carries continue-on-error until #465 is fixed: `pnpm
+  # build:static` currently fails on canary because three dynamic routes have
+  # no generateStaticParams(), so the Tauri bundle cannot be produced at all.
+  # That break is what this job found on its first run -- it is not caused by
+  # this job, and it must not gate unrelated desktop pull requests meanwhile.
   #
-  # REMOVE THIS FLAG when #465 lands, or the job quietly stops being a gate.
+  # The flag sits on the step, not the job: job-level continue-on-error still
+  # reports the check itself as failed (it only spares the workflow run), which
+  # would leave a red X on every desktop PR. On the step, the job goes green
+  # while the step stays visibly red in the log.
+  #
+  # REMOVE IT when #465 lands, or the job quietly stops being a gate.
   unsigned-build:
     name: Unsigned Windows build
     if: inputs.sign != true
     runs-on: windows-latest
-    continue-on-error: true
     timeout-minutes: 45
     defaults:
       run:
@@ -100,6 +103,7 @@ jobs:
       # the static export is produced as part of this step.
       - name: Build unsigned installer
         id: build
+        continue-on-error: true
         run: pnpm desktop:build
 
       # Leave a legible marker so a contributor seeing a red step in an

--- a/.github/workflows/desktop-installer.yml
+++ b/.github/workflows/desktop-installer.yml
@@ -47,10 +47,20 @@ concurrency:
 jobs:
   # Contributor-facing validation. Runs with the default read-only token and
   # cannot access any signing material.
+  #
+  # continue-on-error until #465 is fixed: `pnpm build:static` currently fails
+  # on canary because three dynamic routes have no generateStaticParams(), so
+  # the Tauri bundle cannot be produced at all. That break is what this job
+  # found on its first run -- it is not caused by this job, and it must not
+  # gate unrelated desktop pull requests in the meantime. The build step still
+  # runs and still shows red in the log.
+  #
+  # REMOVE THIS FLAG when #465 lands, or the job quietly stops being a gate.
   unsigned-build:
     name: Unsigned Windows build
     if: inputs.sign != true
     runs-on: windows-latest
+    continue-on-error: true
     timeout-minutes: 45
     defaults:
       run:
@@ -89,12 +99,22 @@ jobs:
       # `tauri build` runs `beforeBuildCommand` (pnpm build:static) itself, so
       # the static export is produced as part of this step.
       - name: Build unsigned installer
+        id: build
         run: pnpm desktop:build
+
+      # Leave a legible marker so a contributor seeing a red step in an
+      # otherwise-green job knows it is the tracked break and not their change.
+      - name: Report the known static-export break
+        if: steps.build.outcome == 'failure'
+        shell: bash
+        run: |
+          echo "::warning title=Desktop bundle not produced::pnpm build:static failed. If this is the generateStaticParams error, it is the known break tracked in #465, not a regression in this pull request."
 
       # Record what came out. `targets: "all"` on Windows produces both the NSIS
       # .exe and the WiX .msi; listing them makes a bundle-target regression
       # visible in the log rather than only as a missing upload.
       - name: List bundle output
+        if: steps.build.outcome == 'success'
         shell: bash
         run: |
           bundle_dir="src-tauri/target/release/bundle"
@@ -105,6 +125,7 @@ jobs:
           find "${bundle_dir}" -type f \( -name '*.msi' -o -name '*.exe' \) -print
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        if: steps.build.outcome == 'success'
         with:
           name: find-desktop-windows-unsigned
           path: |

--- a/.github/workflows/desktop-installer.yml
+++ b/.github/workflows/desktop-installer.yml
@@ -223,6 +223,13 @@ jobs:
       # job wearing a release tag. signtool exits non-zero when the Authenticode
       # signature is absent or does not chain to a trusted root, which is also
       # what catches a missing `certificateThumbprint` in tauri.conf.json.
+      #
+      # `/tw` is what makes the timestamp mandatory. Without it, signtool treats
+      # an untimestamped-but-otherwise-valid signature as a pass and exits 0, so
+      # verification would wave through an installer that stops validating the
+      # day the certificate expires -- including copies users already
+      # downloaded. Under `/tw` that case is a warning, which is exit code 2,
+      # and the non-zero check below turns it into a failure.
       - name: Verify Authenticode signature
         shell: pwsh
         run: |
@@ -235,8 +242,10 @@ jobs:
             Select-Object -First 1
           if (-not $signtool) { throw 'signtool.exe was not found on the runner' }
           foreach ($artifact in $artifacts) {
-            & $signtool.FullName verify /pa /v $artifact.FullName
-            if ($LASTEXITCODE -ne 0) { throw "Signature verification failed for $($artifact.Name)" }
+            & $signtool.FullName verify /pa /tw /v $artifact.FullName
+            # Exit 2 is "completed with warnings", which under /tw means the
+            # signature carries no timestamp. That is a failure here.
+            if ($LASTEXITCODE -ne 0) { throw "Signature verification failed for $($artifact.Name) (signtool exit $LASTEXITCODE)" }
           }
 
       - name: Write checksums
@@ -272,7 +281,17 @@ jobs:
           set -euo pipefail
           version="$(node -p "require('./package.json').version")"
           tag="v${version}"
-          if ! gh release view "${tag}" >/dev/null 2>&1; then
+          if gh release view "${tag}" >/dev/null 2>&1; then
+            # `gh release view` succeeds for published releases too, so without
+            # this guard the `--clobber` below would replace assets on a release
+            # users can already download -- the opposite of "publication stays
+            # manual".
+            if [ "$(gh release view "${tag}" --json isDraft -q .isDraft)" != "true" ]; then
+              echo "Release ${tag} is already published; refusing to overwrite its assets." >&2
+              echo "Bump the version, or delete that release deliberately." >&2
+              exit 1
+            fi
+          else
             gh release create "${tag}" --draft --title "Find ${version}" \
               --notes "Draft release. Desktop installers attached by the desktop-installer workflow."
           fi

--- a/backend/src/find_api/routers/auth.py
+++ b/backend/src/find_api/routers/auth.py
@@ -402,6 +402,30 @@ def revoke_session(
     return {"revoked": session_id, "current": is_current}
 
 
+# --- Instance members ---
+
+
+@router.get("/auth/users")
+def list_users(
+    admin: Optional[User] = Depends(get_admin_user),
+    db: Session = Depends(get_db),
+):
+    """List the accounts on this instance. Admin only.
+
+    The Instance page needs to show who currently has access, which the join
+    request list cannot answer on its own: the first admin is created by
+    /auth/setup and never appears as a request, and an approved request stays
+    listed as `approved` whether or not that account still exists.
+
+    Returns the same safe projection as every other user-bearing response --
+    `_user_dict` never includes the password hash.
+    """
+    _ensure_admin_available(admin, db)
+
+    users = db.query(User).order_by(User.id.asc()).all()
+    return {"users": [_user_dict(user) for user in users]}
+
+
 # --- Invite tokens ---
 
 

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -534,3 +534,97 @@ class TestSecurityProperties:
             headers=_auth_header(member_token),
         )
         assert resp.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# Instance members
+# ---------------------------------------------------------------------------
+
+
+class TestUserListing:
+    """GET /auth/users backs the Instance page's member list (#263).
+
+    The join-request list cannot stand in for it: the first admin is created by
+    /auth/setup and never appears as a request.
+    """
+
+    def test_admin_sees_the_setup_admin(self, client):
+        token = _setup_admin(client)["token"]
+
+        resp = client.get("/api/auth/users", headers=_auth_header(token))
+
+        assert resp.status_code == 200
+        users = resp.json()["users"]
+        assert [user["username"] for user in users] == [ADMIN_USERNAME]
+        assert users[0]["role"] == "admin"
+
+    def test_approved_member_appears_in_the_list(self, client):
+        token = _setup_admin(client)["token"]
+        invite = _create_invite(client, token)
+        join = _join(client, invite["invite_token"])
+        client.post(
+            f"/api/auth/join-requests/{join['join_request_id']}/approve",
+            headers=_auth_header(token),
+        )
+
+        resp = client.get("/api/auth/users", headers=_auth_header(token))
+
+        assert resp.status_code == 200
+        users = {user["username"]: user for user in resp.json()["users"]}
+        assert set(users) == {ADMIN_USERNAME, "newuser"}
+        assert users["newuser"]["role"] == "member"
+
+    def test_rejected_request_creates_no_user(self, client):
+        token = _setup_admin(client)["token"]
+        invite = _create_invite(client, token)
+        join = _join(client, invite["invite_token"])
+        client.post(
+            f"/api/auth/join-requests/{join['join_request_id']}/reject",
+            headers=_auth_header(token),
+        )
+
+        resp = client.get("/api/auth/users", headers=_auth_header(token))
+
+        assert [user["username"] for user in resp.json()["users"]] == [ADMIN_USERNAME]
+
+    def test_never_exposes_the_password_hash(self, client):
+        token = _setup_admin(client)["token"]
+
+        resp = client.get("/api/auth/users", headers=_auth_header(token))
+
+        # Assert on the whole serialized body rather than per-key, so a future
+        # field carrying the hash cannot slip through.
+        assert "password_hash" not in resp.text
+        assert ADMIN_PASSWORD not in resp.text
+        assert set(resp.json()["users"][0]) == {
+            "id",
+            "username",
+            "display_name",
+            "role",
+        }
+
+    def test_member_cannot_list_users(self, client):
+        token = _setup_admin(client)["token"]
+        invite = _create_invite(client, token)
+        join = _join(client, invite["invite_token"])
+        client.post(
+            f"/api/auth/join-requests/{join['join_request_id']}/approve",
+            headers=_auth_header(token),
+        )
+        member_token = _login(client, username="newuser", password="newpass123").json()[
+            "token"
+        ]
+
+        resp = client.get("/api/auth/users", headers=_auth_header(member_token))
+
+        assert resp.status_code == 403
+
+    def test_anonymous_cannot_list_users(self, client):
+        _setup_admin(client)
+        # Setup leaves a session cookie on the shared client, so drop it --
+        # otherwise this asserts the admin path a second time.
+        client.cookies.clear()
+
+        resp = client.get("/api/auth/users")
+
+        assert resp.status_code in (401, 403)

--- a/docs/plans/not-started/byok-inference-plugin-boundary.md
+++ b/docs/plans/not-started/byok-inference-plugin-boundary.md
@@ -1,0 +1,331 @@
+# Privacy-Safe BYOK Inference Plugin Boundary
+
+**Status:** Design proposal — no implementation authorised by this document
+**Last reviewed:** 2026-08-22
+**Issue:** #353
+**Related:** #260 (self-hosted remote ML mode, shipped), #261 (remote acceleration UI), `docs/policies/agent-security.md`
+
+Find fails closed for remote inference today. This document designs the boundary
+that a future bring-your-own-key option would have to sit behind, so that adding
+one provider cannot quietly turn Find into a cloud upload path.
+
+Nothing here authorises a provider SDK, a hosted API call, a credential UI, or
+telemetry. The threat model and test strategy below are entry conditions for any
+adapter, not follow-up work.
+
+---
+
+## 1. What already exists, and why it is not BYOK
+
+`ML_MODE=remote` (#260) ships today:
+
+- One endpoint, `REMOTE_ML_URL`; one bearer token, `REMOTE_ML_API_KEY`.
+- Capability gating via `REMOTE_ML_FEATURES` (`embed,caption,detect,ocr,cluster`),
+  enforced in `workers/processors.py` — the enabled list is sent to the server so
+  switching `ocr` off actually stops the OCR, rather than only hiding the result.
+- `REMOTE_ML_STRIP_EXIF`, defaulting on, re-encoding to JPEG before transmission.
+- A validator requiring `https://` for any non-local host, because the request
+  carries both photo bytes and the token.
+
+That is a **self-hosted** path: the operator runs a Find ML server and is on both
+ends of the connection. The security question is "is the pipe safe" — which TLS
+plus a bearer token answers.
+
+BYOK is a different question. The operator is on one end and a third party is on
+the other, running software the operator did not build, under terms the operator
+did not write, and with retention behaviour the operator cannot inspect. "Is the
+pipe safe" is no longer the interesting part. The interesting part is **what
+leaves, to whom, under what consent, and what happens to it afterwards.**
+
+The distinction matters concretely:
+
+| | Self-hosted (`ML_MODE=remote`) | Third-party BYOK |
+|---|---|---|
+| Who runs the model | The operator | A vendor |
+| Trust basis | Operator controls both ends | Contractual, unverifiable at runtime |
+| Data retention | Operator's own policy | Vendor policy, may include training use |
+| Scope of a key leak | Operator's own server | Billable third-party account |
+| Consent granularity | One instance-wide switch | Must be per provider, per capability |
+| Correct default | Off | Off, and harder to turn on |
+
+**A BYOK provider must never be configurable through the `REMOTE_ML_*`
+settings.** Reusing them would collapse the two trust models into one switch,
+and an operator who enabled self-hosted acceleration once would silently satisfy
+the precondition for third-party upload.
+
+---
+
+## 2. Capability contract
+
+Core jobs must not know that providers exist. `workers/processors.py` already
+dispatches by stage; the boundary is a resolver returning something that
+satisfies a capability protocol, with the local implementation as the default.
+
+Capabilities are exactly the existing stages — BYOK adds no new ones:
+
+| Capability | Input | Output | Sensitivity |
+|---|---|---|---|
+| `embed_image` | Image bytes | Float vector | Whole image leaves |
+| `embed_text` | Query string | Float vector | **Every search the user types leaves** |
+| `caption` | Image bytes | Free text | Whole image leaves |
+| `ocr` | Image bytes | Text + boxes | Whole image; often the most sensitive text a library holds |
+| `detect` | Image bytes | Labels + boxes | Whole image leaves |
+| `cluster` | Vectors | Group assignments | No pixels, but face vectors are biometric |
+
+Two of these deserve to be called out rather than treated as line items:
+
+- **`embed_text` leaks intent, continuously.** Every query becomes a third-party
+  log line. It is the only capability whose traffic is proportional to *usage*
+  rather than to *library size*, and the only one that reveals what the user was
+  looking for rather than what they own. It must be independently consentable and
+  must default off even when image capabilities are on.
+- **`cluster` is biometric.** Face embeddings are personal data under GDPR
+  Article 9 and BIPA regardless of the absence of pixels. "No image leaves" is
+  not a sufficient argument for sending them.
+
+The protocol surface stays deliberately small — a manifest, a capability check, a
+per-capability invoke, and a health probe. Anything provider-specific (auth
+style, request shape, retries, response mapping) belongs inside the adapter.
+`processors.py` must remain readable without knowing which provider is active.
+
+---
+
+## 3. Provider manifest
+
+Declarative, versioned, reviewed in-tree. An adapter without a manifest does not
+load.
+
+```toml
+[provider]
+id = "example-vision"          # stable, lowercase, used as the settings key
+display_name = "Example Vision"
+adapter = "find_api.ml.providers.example_vision:ExampleVisionAdapter"
+manifest_version = 1
+
+[provider.endpoints]
+allowed_hosts = ["api.example-vision.com"]   # exact hosts; no wildcards
+require_tls = true
+
+[provider.capabilities]
+caption = { payload = "image", max_bytes = 4_194_304 }
+ocr     = { payload = "image", max_bytes = 4_194_304 }
+# embed_text absent => this provider cannot receive queries, and no runtime
+# consent can grant it.
+
+[provider.limits]
+requests_per_minute = 60
+timeout_seconds = 30
+max_retries = 2
+
+[provider.disclosure]
+terms_url = "https://example-vision.com/terms"
+retention = "documented"     # documented | unknown | trains-on-input
+region = "us"
+```
+
+Three properties do the work:
+
+1. **The manifest bounds the adapter.** `allowed_hosts` is enforced by the egress
+   layer, not by the adapter's own HTTP calls. An adapter that tries to reach an
+   undeclared host fails at the transport, so a compromised or careless adapter
+   cannot exfiltrate to an arbitrary destination.
+2. **Capabilities are allowlisted, not denylisted.** An absent capability cannot
+   be enabled at runtime by any configuration or consent record.
+3. **`retention = "trains-on-input"` is surfaced verbatim in the consent UI.** A
+   provider that trains on submitted images is a materially different decision
+   from one that does not, and the user makes it, not us.
+
+---
+
+## 4. Consent
+
+Consent is stored per `(provider_id, capability)`. There is no instance-wide
+"enable BYOK" switch, because such a switch is exactly the implicit upload path
+this issue exists to prevent.
+
+A consent record captures the provider, the capability, who granted it, when,
+the manifest version and hash it was granted against, and the disclosure text
+actually shown.
+
+Rules:
+
+1. **Deny by default.** No record means no call. An unreadable or corrupt consent
+   store means no call.
+2. **Consent is specific.** Granting `caption` grants nothing else. Granting for
+   one provider grants nothing for another.
+3. **Consent is invalidated by manifest change.** If the manifest hash changes —
+   a new host, a widened capability, a changed retention claim — every record for
+   that provider is void and must be re-granted. Otherwise a manifest edit
+   silently broadens what the user agreed to.
+4. **Consent is revocable, and revocation is immediate.** Revoking stops the next
+   job; it does not wait for a restart or a queue drain.
+5. **Consent does not survive a restore.** Backup restores and instance clones do
+   not carry consent records, because the person restoring may not be the person
+   who granted.
+
+---
+
+## 5. Secret handling
+
+BYOK keys are third-party billable credentials. Treated as at least as sensitive
+as the vault passphrase.
+
+- **At rest:** encrypted with AES-256-GCM. `core/crypto.py` already provides the
+  primitives used by the vault; the BYOK key set uses its own derived key with
+  its own associated data, so a vault compromise does not hand over provider
+  credentials, and vice versa.
+- **Alternative boundary:** a secret-file path or an OS keychain reference, for
+  operators who prefer credentials never enter the database. The manifest does
+  not care which is used.
+- **In memory:** decrypted only inside the adapter call, never cached on a
+  long-lived object, never attached to a job payload, and never carried into a
+  Redis/RQ queue entry — a queued job stores a provider id, never a key.
+- **Never returned.** No API response includes a key, in any form, including
+  masked or truncated. The API exposes only "configured" or "not configured"
+  plus a last-four suffix for disambiguation.
+- **Never logged.** Adapters are forbidden from logging request headers.
+  Structured errors are constructed from status codes and provider error codes,
+  never from raw responses — the same rule already applied in
+  `core/model_footprint.py`, which logs the exception server-side and returns a
+  constant placeholder.
+- **Rotation:** replacing a key does not clear consent (the grant is about the
+  provider and capability, not the credential). Rotation is logged. A key that
+  fails auth twice is marked stale and the provider is disabled until the
+  operator intervenes, so a revoked key does not produce an indefinite retry
+  loop against a third-party endpoint.
+
+---
+
+## 6. Egress control
+
+The egress layer is the single choke point through which any provider call
+passes.
+
+- **Host allowlist** from the manifest, checked against the resolved connection
+  target. Redirects are not followed — a 3xx from a provider is an error, since
+  following one would leave the allowlist behind.
+- **TLS required.** No `http://` exception for third-party providers; the
+  localhost carve-out in `validate_remote_ml_config` exists because a local
+  server is not a network hop, which cannot be true of a vendor.
+- **Timeouts** from the manifest, applied to connect and read separately.
+- **Rate limits** per provider, enforced locally so a runaway job cannot generate
+  an unbounded bill.
+- **Redaction before transmission.** EXIF stripped (as `REMOTE_ML_STRIP_EXIF`
+  already does), GPS removed, filenames and paths never sent — a filename alone
+  routinely carries a name, a date, or a location.
+- **Audit log,** append-only: timestamp, provider, capability, media id, byte
+  count, outcome, latency. It records *that* something left and *how much*, never
+  the content. Without it, "what did this provider receive?" is unanswerable, and
+  that question follows every third-party incident.
+
+---
+
+## 7. Fail closed
+
+The local implementation is the default for every capability. When a provider is
+unavailable, unconfigured, rate-limited, or returns an error, the job:
+
+1. Records the provider failure in the stage status.
+2. Falls back to the local implementation **only if the operator explicitly
+   enabled fallback for that capability.**
+3. Otherwise marks the stage failed and moves on.
+
+Fallback is opt-in rather than automatic on purpose. An operator who chose a
+provider for quality may prefer a visible failure to a silent downgrade — and an
+operator who chose it for speed may want the opposite. Guessing is worse than
+asking once.
+
+The inverse — falling back *to* a provider when local inference fails — is
+forbidden. That is precisely the implicit upload path this boundary prevents.
+
+---
+
+## 8. Threat model
+
+| # | Threat | Mitigation |
+|---|---|---|
+| T1 | Malicious/compromised adapter exfiltrates images | Manifest host allowlist enforced at egress, not in the adapter; no redirects |
+| T2 | Manifest widened in an update, silently broadening consent | Consent bound to manifest hash; change voids all records for that provider |
+| T3 | Key leaks via API response | Keys never serialised into any response; "configured" boolean plus last-four only |
+| T4 | Key leaks via logs or an error report | Header logging forbidden; errors built from codes; `diagnostics/bundle.py` scrubbers extended to the BYOK key space |
+| T5 | Search queries leak continuously | `embed_text` is a separate capability, defaults off, consented independently |
+| T6 | Face embeddings sent to a third party | `cluster` treated as biometric; separate consent; disclosure states this explicitly |
+| T7 | Runaway cost from a queue backlog | Per-provider local rate limit and max retries from the manifest |
+| T8 | Silent upload after a local failure | Provider-as-fallback forbidden by design |
+| T9 | Consent inherited by a restored backup or clone | Consent records excluded from backup/restore |
+| T10 | Provider returns a hostile payload (oversized, malformed, injected) | Response size cap; schema validation before use; provider text never interpolated into a prompt or a shell |
+| T11 | Operator cannot answer "what was sent?" after an incident | Append-only audit log of metadata for every call |
+| T12 | Downgrade to plaintext by a manifest edit | `require_tls` cannot be disabled for a non-local host; enforced at egress |
+
+---
+
+## 9. Test strategy
+
+Entry conditions. No adapter merges without all of these, and the first four are
+the ones that would actually catch a regression that matters.
+
+**Deny by default**
+- No consent record → no outbound request. Asserted by an egress spy, not by
+  inspecting a return value.
+- Corrupt or unreadable consent store → no outbound request.
+- Capability absent from the manifest → cannot be enabled by any config path.
+
+**Consent lifecycle**
+- Manifest hash change voids existing records; the next call is blocked until
+  re-grant.
+- Revocation takes effect on the next job with no restart.
+- Per-capability isolation: granting `caption` leaves `ocr` and `embed_text`
+  blocked.
+
+**Secret containment**
+- No API response contains the key. Asserted by serialising every BYOK-touching
+  response and searching for a sentinel value — the pattern already used by
+  `test_unresolvable_identifier_does_not_leak_exception_text`.
+- The sentinel does not appear in captured logs, in a diagnostics bundle, or in a
+  queued job payload.
+
+**Egress**
+- A request to an undeclared host fails at the transport, including when the
+  adapter is deliberately written to attempt it.
+- A 3xx redirect is an error, not a followed hop.
+- `http://` to a non-local host is rejected.
+- Timeout and rate limit are enforced from the manifest, not from adapter code.
+
+**Fail closed**
+- Provider down, unauthorised, and rate-limited each mark the stage failed
+  without local fallback unless fallback was explicitly enabled.
+- Local failure never escalates to a provider call.
+
+**Redaction**
+- EXIF and GPS absent from the transmitted payload.
+- Filenames and paths absent.
+
+**Audit**
+- Every outbound call produces exactly one audit entry.
+- The entry contains no image bytes and no key material.
+
+A mock provider fixture — declared in-tree, never reaching a network — carries
+this suite. Real provider calls do not belong in CI, for the same reason the OCR
+inference tests sit behind `importorskip`.
+
+---
+
+## 10. Non-goals
+
+No provider SDK, no hosted API call, no telemetry, no credential UI, and no
+adapter ships under this document. The deliverable is the boundary.
+
+## 11. Open questions for the maintainer
+
+1. **Is BYOK wanted at all?** A local-first, privacy-focused tool can reasonably
+   answer no. This design makes the option safe to build; it does not argue that
+   it should be built. Self-hosted remote (#260) already covers "my laptop is too
+   slow" without any third-party trust.
+2. **Multi-user instances (#263).** Whose consent counts when several people
+   share an instance? Per-user consent conflicts with a shared worker pool that
+   processes any user's media. The simplest defensible answer is admin-only
+   configuration plus a visible instance-wide disclosure — but it needs deciding
+   before any adapter, not after.
+3. **Where does the encryption key live?** Reusing the vault master key ties BYOK
+   availability to an unlocked vault. A separate key needs its own unlock story.
+4. **Does the audit log need retention limits?** It grows per processed image.

--- a/docs/plans/not-started/byok-inference-plugin-boundary.md
+++ b/docs/plans/not-started/byok-inference-plugin-boundary.md
@@ -72,6 +72,18 @@ Capabilities are exactly the existing stages — BYOK adds no new ones:
 | `detect` | Image bytes | Labels + boxes | Whole image leaves |
 | `cluster` | Vectors | Group assignments | No pixels, but face vectors are biometric |
 
+**Vectors need a declared shape, not just a type.** "Float vector" is not a
+contract: Find's pgvector columns are fixed at `EMBEDDING_DIM`, and a provider
+returning a different length either errors deep in persistence or, worse,
+silently corrupts a mixed-dimension index. The manifest must declare
+`embedding_dim` and the model identity behind it, the resolver must refuse a
+provider whose `embedding_dim` disagrees with the configured `EMBEDDING_DIM`,
+and any vector whose length does not match must be rejected before it reaches
+the database. The same applies to `cluster`, which consumes vectors rather than
+producing them. Changing a provider's embedding model is a reindex, exactly as
+it is for local models -- the manifest is what makes that visible instead of
+discovering it from corrupted search results.
+
 Two of these deserve to be called out rather than treated as line items:
 
 - **`embed_text` leaks intent, continuously.** Every query becomes a third-party
@@ -87,6 +99,18 @@ The protocol surface stays deliberately small — a manifest, a capability check
 per-capability invoke, and a health probe. Anything provider-specific (auth
 style, request shape, retries, response mapping) belongs inside the adapter.
 `processors.py` must remain readable without knowing which provider is active.
+
+**`invoke` receives an egress client; it does not get to make its own requests.**
+This is the load-bearing detail of the whole design. If an adapter can import
+`httpx` and open its own connection, then every control in §6 — host allowlist,
+TLS, timeouts, rate limits, redaction, audit — is advisory, enforced only by the
+adapter choosing to cooperate. The boundary has to be structural: the adapter is
+handed a capability-scoped client already bound to this provider's manifest, and
+that client is the only sanctioned path out. Review must reject an adapter that
+imports an HTTP library directly, and the test suite asserts it (see §9). A
+process- or network-level sandbox is stronger still and is the right answer if
+third-party adapter code is ever loaded from outside the repository — at which
+point code review is no longer a control at all.
 
 ---
 
@@ -116,6 +140,9 @@ ocr     = { payload = "image", max_bytes = 4_194_304 }
 requests_per_minute = 60
 timeout_seconds = 30
 max_retries = 2
+max_response_bytes = 1_048_576   # enforced while reading, before buffering
+idempotency = "key"              # key | none -- see retries below
+daily_budget_requests = 5_000    # cumulative ceiling, not just a rate
 
 [provider.disclosure]
 terms_url = "https://example-vision.com/terms"
@@ -134,6 +161,24 @@ Three properties do the work:
 3. **`retention = "trains-on-input"` is surfaced verbatim in the consent UI.** A
    provider that trains on submitted images is a materially different decision
    from one that does not, and the user makes it, not us.
+
+Three of the limits are less obvious than they look:
+
+- **`max_response_bytes` is enforced while reading, not after.** A cap checked
+  after buffering has already spent the memory it was meant to protect. A worker
+  handling a large library has no headroom to absorb a hostile or malfunctioning
+  provider's oversized response.
+- **`max_retries` alone is not retry safety.** A timeout can fire *after* the
+  provider accepted the request, so retrying resubmits the same image and is
+  billed twice. Retry automatically only for failures known to have occurred
+  before transmission (connection refused, DNS failure, TLS handshake). Anything
+  that could have been received needs a provider idempotency key; where the
+  provider offers none (`idempotency = "none"`), that class of failure is
+  surfaced rather than retried. The timeout-after-send case gets its own test.
+- **Rate limits bound throughput, not spend.** A large enough backlog runs at
+  `requests_per_minute` indefinitely and the bill grows with it.
+  `daily_budget_requests` is the cumulative ceiling; exhausting it disables the
+  provider and fails closed rather than continuing.
 
 ---
 
@@ -158,7 +203,13 @@ Rules:
    that provider is void and must be re-granted. Otherwise a manifest edit
    silently broadens what the user agreed to.
 4. **Consent is revocable, and revocation is immediate.** Revoking stops the next
-   job; it does not wait for a restart or a queue drain.
+   job; it does not wait for a restart or a queue drain. "Immediate" has to mean
+   *checked at the egress layer, immediately before each outbound request* --
+   not read once when the job was enqueued. A job that read consent an hour ago
+   and is only now reaching the network must be stopped, and a decision must
+   never be cached on the job or carried in its payload. The same gate applies
+   to health probes, which otherwise keep talking to a provider the user has
+   revoked.
 5. **Consent does not survive a restore.** Backup restores and instance clones do
    not carry consent records, because the person restoring may not be the person
    who granted.
@@ -170,10 +221,19 @@ Rules:
 BYOK keys are third-party billable credentials. Treated as at least as sensitive
 as the vault passphrase.
 
-- **At rest:** encrypted with AES-256-GCM. `core/crypto.py` already provides the
-  primitives used by the vault; the BYOK key set uses its own derived key with
-  its own associated data, so a vault compromise does not hand over provider
-  credentials, and vice versa.
+- **At rest:** encrypted with AES-256-GCM, using the primitives in
+  `core/crypto.py` that the vault already relies on.
+
+  **The isolation claim depends on the root, and the root is unresolved.** A
+  separately *derived* key does not isolate anything if it descends from the same
+  vault master — an attacker holding that master derives both. Independent
+  domain-separation strings buy defence against key reuse, not against a
+  compromised root. So one of these has to be chosen before implementation, not
+  after: an independent root secret with its own unlock path, an OS
+  keychain/KMS-held key that never enters the database, or an explicit narrowing
+  of the threat model to say that a vault compromise is assumed to take the BYOK
+  credentials with it. Shipping the first option's wording while implementing the
+  third is the failure to avoid. See the open question in §11.
 - **Alternative boundary:** a secret-file path or an OS keychain reference, for
   operators who prefer credentials never enter the database. The manifest does
   not care which is used.
@@ -204,15 +264,28 @@ passes.
 - **Host allowlist** from the manifest, checked against the resolved connection
   target. Redirects are not followed — a 3xx from a provider is an error, since
   following one would leave the allowlist behind.
+- **Resolve once, then connect to what was checked.** Validating a hostname and
+  then handing the name back to the HTTP client invites a second, different
+  resolution — the classic DNS-rebinding window. Resolve the host, reject the
+  result if it lands in loopback, private, link-local, or cloud-metadata space,
+  connect to *that address*, and still require full certificate and hostname
+  verification against the declared name. Without the address check, an
+  allowlisted host whose DNS the attacker controls becomes a path to
+  `169.254.169.254` and the instance's own credentials. Both the rebinding and
+  the private-address cases get tests.
 - **TLS required.** No `http://` exception for third-party providers; the
   localhost carve-out in `validate_remote_ml_config` exists because a local
   server is not a network hop, which cannot be true of a vendor.
 - **Timeouts** from the manifest, applied to connect and read separately.
 - **Rate limits** per provider, enforced locally so a runaway job cannot generate
   an unbounded bill.
-- **Redaction before transmission.** EXIF stripped (as `REMOTE_ML_STRIP_EXIF`
-  already does), GPS removed, filenames and paths never sent — a filename alone
-  routinely carries a name, a date, or a location.
+- **Redaction before transmission, and it fails closed.** EXIF stripped (as
+  `REMOTE_ML_STRIP_EXIF` already does), GPS removed, filenames and paths never
+  sent — a filename alone routinely carries a name, a date, or a location. If
+  re-encoding or metadata stripping raises, the original bytes are **not** sent
+  as a fallback: the stage is marked failed. A redaction step that degrades to
+  "send it anyway" is worse than no redaction, because the operator believes
+  location data was removed.
 - **Audit log,** append-only: timestamp, provider, capability, media id, byte
   count, outcome, latency. It records *that* something left and *how much*, never
   the content. Without it, "what did this provider receive?" is unanswerable, and
@@ -256,6 +329,13 @@ forbidden. That is precisely the implicit upload path this boundary prevents.
 | T10 | Provider returns a hostile payload (oversized, malformed, injected) | Response size cap; schema validation before use; provider text never interpolated into a prompt or a shell |
 | T11 | Operator cannot answer "what was sent?" after an incident | Append-only audit log of metadata for every call |
 | T12 | Downgrade to plaintext by a manifest edit | `require_tls` cannot be disabled for a non-local host; enforced at egress |
+| T13 | Adapter bypasses every egress control by opening its own socket | `invoke` is handed a capability-scoped client; direct HTTP imports rejected in review and asserted by test |
+| T14 | DNS rebinding or an allowlisted host resolving to link-local/metadata space | Resolve once, reject private/loopback/link-local/metadata addresses, connect to the checked address, verify certificate and hostname |
+| T15 | Revocation raced by an already-queued job | Consent re-checked at egress immediately before each request, never cached on the job |
+| T16 | Timeout after the provider received the request causes a duplicate billable submission | Auto-retry only for pre-transmission failures; anything else needs a provider idempotency key |
+| T17 | Backlog runs at the rate limit indefinitely and the bill grows without bound | `daily_budget_requests` ceiling; exhaustion disables the provider and fails closed |
+| T18 | Redaction fails and the original, GPS-bearing bytes are sent anyway | Redaction failure marks the stage failed; there is no send-anyway path |
+| T19 | Provider returns a vector of the wrong length and corrupts the index | `embedding_dim` declared in the manifest, matched against `EMBEDDING_DIM`, length checked before persistence |
 
 ---
 
@@ -287,9 +367,30 @@ the ones that would actually catch a regression that matters.
 **Egress**
 - A request to an undeclared host fails at the transport, including when the
   adapter is deliberately written to attempt it.
+- An adapter that imports an HTTP library directly is rejected — asserted by
+  scanning adapter modules, so the "structural, not advisory" claim in §2 is
+  actually enforced rather than merely stated.
+- A host resolving to loopback, private, link-local, or metadata space is
+  refused, and a second resolution cannot change the address connected to
+  (DNS-rebinding case).
 - A 3xx redirect is an error, not a followed hop.
 - `http://` to a non-local host is rejected.
 - Timeout and rate limit are enforced from the manifest, not from adapter code.
+- A response exceeding `max_response_bytes` is aborted while streaming, before
+  the bytes are buffered.
+- The cumulative `daily_budget_requests` ceiling disables the provider and fails
+  closed rather than continuing at the per-minute rate.
+
+**Retry safety**
+- A pre-transmission failure (connection refused, DNS failure) retries.
+- A timeout that could have been received does not silently retry when the
+  provider declares `idempotency = "none"`; with `idempotency = "key"` the retry
+  carries the same key.
+
+**Vector shape**
+- A provider whose manifest `embedding_dim` disagrees with `EMBEDDING_DIM` fails
+  to resolve at all.
+- A vector of unexpected length is rejected before persistence, not written.
 
 **Fail closed**
 - Provider down, unauthorised, and rate-limited each mark the stage failed
@@ -299,6 +400,8 @@ the ones that would actually catch a regression that matters.
 **Redaction**
 - EXIF and GPS absent from the transmitted payload.
 - Filenames and paths absent.
+- A redaction step that raises marks the stage failed and sends nothing — the
+  original bytes must never appear on the wire as a fallback.
 
 **Audit**
 - Every outbound call produces exactly one audit entry.
@@ -326,6 +429,11 @@ adapter ships under this document. The deliverable is the boundary.
    processes any user's media. The simplest defensible answer is admin-only
    configuration plus a visible instance-wide disclosure — but it needs deciding
    before any adapter, not after.
-3. **Where does the encryption key live?** Reusing the vault master key ties BYOK
-   availability to an unlocked vault. A separate key needs its own unlock story.
+3. **Where does the encryption key live?** This is a blocker, not a detail: §5's
+   isolation claim is only true if the BYOK root is independent of the vault
+   master. Reusing the vault master ties BYOK availability to an unlocked vault
+   *and* means one compromise takes both. A separate root needs its own unlock
+   story; an OS keychain or KMS avoids the question but adds a platform
+   dependency. Decide before an adapter, and make §5's wording match whichever is
+   chosen.
 4. **Does the audit log need retention limits?** It grows per processed image.

--- a/docs/plans/not-started/desktop-installer-release.md
+++ b/docs/plans/not-started/desktop-installer-release.md
@@ -49,6 +49,20 @@ that guarantee, because a fork controls the workflow file on its own branch.
 - **Deployment branch/tag rule** — restrict to `canary`, `main`, and `v*` tags so
   a signed build cannot be produced from an arbitrary branch.
 
+**These two are not automatic, and their absence is silent.** Referencing an
+environment that does not exist does not fail the job — GitHub creates the
+environment on first use, with no reviewers and no branch rule. So a signed run
+started before anyone configures `desktop-release` would face no approval gate
+at all.
+
+What that does *not* undermine is the fork boundary: environment secrets are
+unavailable to `pull_request` runs from forks whether or not the environment has
+protection rules, and the preflight refuses to build without the certificate. So
+the failure mode of an unconfigured environment is "no approval step", not "an
+unsigned artifact ships" or "a fork reaches the key". Configure it before the
+first signed run regardless — the approval gate is the only thing standing
+between a compromised maintainer token and a signed installer.
+
 ---
 
 ## Certificate storage and handling
@@ -128,6 +142,8 @@ verification step, and the draft-release behaviour are unchanged.
 | Thumbprint absent or wrong | `signtool verify` fails | Tauri emits an unsigned bundle rather than erroring, so verification is the only real detector |
 | Certificate expired | `signtool verify` fails | Same detector, before publication |
 | Timestamp server unreachable | Build fails | Signing without a timestamp produces an installer that expires with the certificate |
+| Signature present but untimestamped | `signtool verify /tw` exits 2, treated as failure | Plain `/pa` considers an untimestamped signature valid and exits 0, so without `/tw` this passes verification silently |
+| Tag already published | Upload step aborts | `gh release view` succeeds for published releases, so `--clobber` would otherwise overwrite assets users can already download |
 | Rust/Tauri build breaks | `unsigned-build` fails on the pull request | This is the coverage gap the issue is about |
 
 Nothing in the signed path is best-effort. Every step that could silently

--- a/docs/plans/not-started/desktop-installer-release.md
+++ b/docs/plans/not-started/desktop-installer-release.md
@@ -191,6 +191,24 @@ Tauri's gtk-rs 0.18 pin and is not fixable from this repository.
 
 ---
 
+## Known blocker: the static export does not build
+
+`unsigned-build` failed on its first run, and the cause is older than this
+pipeline: `pnpm build:static` aborts because `/albums/[id]`, `/image/[id]`, and
+`/public/shared/[key]` are client components with no `generateStaticParams()`,
+which `output: export` requires. No installer can be produced at all until that
+is resolved.
+
+Two things make it more than a one-line fix: a client component cannot export
+`generateStaticParams`, so each route needs a thin server wrapper; and an empty
+param list is still rejected, so every dynamic route has to pre-render at least
+one page. That forces a decision about what those routes even mean in a static
+bundle, where runtime ids cannot resolve.
+
+Tracked in #465. `unsigned-build` carries `continue-on-error` until it lands, so
+the known break does not gate unrelated desktop pull requests — remove that flag
+as part of the fix.
+
 ## Open questions
 
 - Should `unsigned-build` become a required status check? It is a Windows runner

--- a/docs/plans/not-started/desktop-installer-release.md
+++ b/docs/plans/not-started/desktop-installer-release.md
@@ -1,0 +1,203 @@
+# Signed Desktop Installer Release Pipeline
+
+**Status:** Design approved for the Windows path; signing is not yet provisioned
+**Last reviewed:** 2026-08-22
+**Issue:** #48
+**Implements:** `.github/workflows/desktop-installer.yml`
+
+This document defines how Find produces trustworthy desktop installers, and
+where the boundary sits between what a contributor can run and what only a
+maintainer can run. It covers Windows concretely. macOS and Linux are described
+as extension points only — nothing here claims either has been verified.
+
+---
+
+## Why a separate workflow
+
+`ci.yml` validates source. `publish.yml` builds and pushes container images on a
+tag. Neither touches the Tauri bundle, so today the only way to learn that
+`frontend/src-tauri/` no longer builds is for someone to run `pnpm desktop:build`
+by hand.
+
+The desktop path also has a property the container path does not: the artifact is
+a file a user downloads and executes on their own machine. That makes signing —
+and the custody of the key that does it — the central design problem rather than
+an afterthought.
+
+---
+
+## Trust boundary
+
+| | `unsigned-build` | `signed-release` |
+|---|---|---|
+| Trigger | `pull_request` on desktop paths | `workflow_dispatch` with `sign: true` |
+| Who can start it | Any contributor, including forks | Maintainers with access to the environment |
+| Token permissions | `contents: read` | `contents: write` |
+| Environment | none | `desktop-release` |
+| Secrets reachable | none | certificate + password |
+| Output | Build artifact, 14-day retention | Draft release + checksums, 30-day artifact |
+
+The enforcement is GitHub's environment model, not a conditional. Secrets scoped
+to an environment are not available to `pull_request` runs from forks at all, so
+the contributor path cannot reach the signing material even if the workflow file
+were edited in the pull request that runs it. A conditional alone would not give
+that guarantee, because a fork controls the workflow file on its own branch.
+
+`desktop-release` must be configured with:
+
+- **Required reviewers** — at least one maintainer approves each signed run.
+- **Deployment branch/tag rule** — restrict to `canary`, `main`, and `v*` tags so
+  a signed build cannot be produced from an arbitrary branch.
+
+---
+
+## Certificate storage and handling
+
+Two secrets on the `desktop-release` environment:
+
+| Secret | Contents |
+|---|---|
+| `WINDOWS_CERTIFICATE` | Base64 of the `.pfx` (certificate + private key) |
+| `WINDOWS_CERTIFICATE_PASSWORD` | Password protecting that `.pfx` |
+
+Handling rules the workflow already implements:
+
+1. The `.pfx` is materialised into `$RUNNER_TEMP`, imported into
+   `Cert:\CurrentUser\My`, and the file is deleted in the same step. It is never
+   written into the workspace, so it cannot be picked up by an artifact upload.
+2. Signing happens through the certificate store by thumbprint. The password
+   never appears on a command line, and therefore never in a log.
+3. Nothing echoes either secret. GitHub's log masking is treated as a backstop,
+   not as the control.
+
+### Enabling signing
+
+The workflow is deliberately inert until someone completes these steps — a
+`signed-release` run fails its preflight rather than emitting an unsigned file:
+
+1. Obtain an OV or EV code-signing certificate. EV (hardware-backed) removes the
+   SmartScreen reputation warm-up but cannot be exported as a `.pfx`; see the
+   HSM note below.
+2. Add both secrets to the `desktop-release` environment.
+3. Add the thumbprint to `frontend/src-tauri/tauri.conf.json`:
+
+   ```json
+   "bundle": {
+     "windows": {
+       "certificateThumbprint": "<thumbprint, uppercase, no spaces>",
+       "digestAlgorithm": "sha256",
+       "timestampUrl": "http://timestamp.digicert.com"
+     }
+   }
+   ```
+
+   A timestamp URL is required. Without it, every installer stops validating the
+   moment the certificate expires, including copies users already downloaded.
+
+4. Run the workflow manually with `sign: true` and confirm the
+   **Verify Authenticode signature** step passes.
+
+### EV certificates and HSMs
+
+An EV certificate lives on hardware and cannot be exported, so the `.pfx` flow
+above does not apply. The replacement is a cloud signing service — Azure Trusted
+Signing, DigiCert KeyLocker, SSL.com eSigner — driven through Tauri's
+`bundle.windows.signCommand`, which hands the artifact path to an external
+command instead of using the certificate store. That swaps the two secrets for
+service credentials and replaces the import step; the trust boundary, the
+verification step, and the draft-release behaviour are unchanged.
+
+### Rotation
+
+- **Scheduled:** certificates are typically valid 1–3 years. Rotate at least 30
+  days before expiry. Update both secrets, update `certificateThumbprint`, and
+  run a manual signed build to confirm before the old certificate lapses.
+- **Compromise:** revoke with the CA first, then rotate the secrets, then
+  re-issue. Timestamped signatures made before the revocation date stay valid,
+  which is the reason the timestamp URL is mandatory rather than optional.
+- Rotation touches a tracked file (`tauri.conf.json`), so thumbprint changes go
+  through review like any other change.
+
+---
+
+## Failure handling
+
+| Failure | Behaviour | Rationale |
+|---|---|---|
+| Secrets missing | Preflight fails before any build work | An unsigned artifact must never be attached to a release |
+| Thumbprint absent or wrong | `signtool verify` fails | Tauri emits an unsigned bundle rather than erroring, so verification is the only real detector |
+| Certificate expired | `signtool verify` fails | Same detector, before publication |
+| Timestamp server unreachable | Build fails | Signing without a timestamp produces an installer that expires with the certificate |
+| Rust/Tauri build breaks | `unsigned-build` fails on the pull request | This is the coverage gap the issue is about |
+
+Nothing in the signed path is best-effort. Every step that could silently
+degrade the artifact is checked.
+
+---
+
+## Version and release behaviour
+
+`scripts/bump_version.py --check` already runs in `ci.yml` and keeps
+`backend/pyproject.toml`, `frontend/package.json`,
+`frontend/src-tauri/Cargo.toml`, `Cargo.lock`, and `tauri.conf.json` on one
+version. The workflow therefore reads the version from `frontend/package.json`
+rather than accepting it as an input — a mismatch is not representable.
+
+- Tag: `v<version>` — the same tag `publish.yml` uses for images, so a release
+  has one tag covering both.
+- The release is created as a **draft** and never published automatically.
+- Re-running uploads with `--clobber`, so a re-signed artifact replaces the old
+  one instead of appending a duplicate.
+- `SHA256SUMS.txt` is generated in-job and attached, giving users a way to
+  verify a download independently of the signature.
+
+Publication stays manual: a maintainer opens the draft, checks the artifacts and
+checksums, and presses publish.
+
+---
+
+## Extension points (not verified)
+
+Described so the Windows design does not have to be redone later. Neither has
+been run.
+
+### macOS
+
+Needs, beyond a `macos-latest` runner:
+
+- A Developer ID Application certificate imported into a temporary keychain
+  (not the login keychain — CI must not leave credentials behind).
+- Notarization via `notarytool` with an App Store Connect API key, then
+  `xcrun stapler staple` so the app validates offline.
+- `APPLE_CERTIFICATE`, `APPLE_CERTIFICATE_PASSWORD`, `APPLE_SIGNING_IDENTITY`,
+  `APPLE_API_KEY`, `APPLE_API_ISSUER` on the same environment.
+- Universal binaries need both `aarch64-apple-darwin` and `x86_64-apple-darwin`
+  targets installed.
+
+Notarization is a network round-trip to Apple that can take minutes and can fail
+for reasons unrelated to the build, so it needs its own retry and timeout
+handling. Do not assume the Windows job's shape transfers.
+
+### Linux
+
+`.deb` and `.AppImage` come out of the same `tauri build`. Signing conventions
+differ from Authenticode: repository signing uses a GPG key over package
+metadata, and AppImage has its own embedded-signature scheme. Neither maps onto
+`signtool verify`, so the verification step would need replacing rather than
+parameterising.
+
+Linux also has the `glib` advisory tracked in #383, which is inherited from
+Tauri's gtk-rs 0.18 pin and is not fixable from this repository.
+
+---
+
+## Open questions
+
+- Should `unsigned-build` become a required status check? It is a Windows runner
+  and a cold cache costs roughly 15–20 minutes, so it is currently advisory.
+- Should the signed path move from manual dispatch to firing on `v*` tags once a
+  certificate exists? That would align it with `publish.yml`, at the cost of
+  making every tag push depend on signing infrastructure being healthy.
+- Tauri's built-in updater needs its own signing key
+  (`TAURI_SIGNING_PRIVATE_KEY`), separate from Authenticode. Out of scope until
+  an update channel exists.

--- a/docs/plans/partial/small-team-authentication.md
+++ b/docs/plans/partial/small-team-authentication.md
@@ -1,8 +1,8 @@
 # Small-Team Authentication (Instance Sharing)
 
-**Status:** In progress — backend auth foundation implemented  
-**Last reviewed:** 2026-05-30  
-**Current implementation status:** Backend auth foundation implemented (user model, session tokens, invite flow, join requests, admin approval, upload ownership tracking). Frontend UI, deletion-request workflow, and audit log remain unimplemented.
+**Status:** In progress — backend auth foundation and the Instance page implemented  
+**Last reviewed:** 2026-08-22  
+**Current implementation status:** Backend auth foundation implemented (user model, session tokens, invite flow, join requests, admin approval, upload ownership tracking). The Instance page at `frontend/src/app/instance/page.tsx` covers invite creation, join-request review, and the member list (#263); it is reached from the Account page in shared mode rather than from the sidebar, because a single-user install has no instance to manage. Still unimplemented: adding a user directly from the UI (no backend endpoint), the friendly instance name, the deletion-request workflow, and the audit log.
 
 ## Summary
 
@@ -40,8 +40,8 @@ Join an Instance (user flows)
 
 ## Instance Tab UI State Checklist
 
-Use this checklist when implementing or reviewing the future Instance tab. It documents expected UI
-states only; no frontend implementation exists yet.
+Use this checklist when reviewing the Instance page. The create-invite, join, review, and member-list
+states are implemented; the manual add-user, instance-name, and deletion-request states are not.
 
 ### General states
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,6 +1,9 @@
 # syntax=docker/dockerfile:1.7
 
-FROM node:22-alpine AS base
+# Node 24 is Active LTS. Keep this major in lockstep with `node-version` in
+# .github/workflows/ci.yml -- `docker-check` asserts the two agree, so changing
+# one alone fails CI.
+FROM node:24-alpine AS base
 ARG PNPM_VERSION=11.3.0
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"

--- a/frontend/e2e/pwa-install.spec.ts
+++ b/frontend/e2e/pwa-install.spec.ts
@@ -101,6 +101,34 @@ test.describe("offline shell", () => {
     expect(registered).toBe(true);
   });
 
+  test("never stores a search query in the cache key", async ({ page }) => {
+    // /search?q=... carries user input. Keying cache entries by the full URL
+    // would persist a searchable history of queries in Cache Storage, which is
+    // precisely the trace a local-first tool must not leave behind.
+    await page.goto("/timeline");
+    await page.evaluate(() => navigator.serviceWorker.ready);
+
+    await page.goto("/search?q=deeply-private-search-term");
+    await page.evaluate(() => navigator.serviceWorker.ready);
+
+    const keys = await page.evaluate(async () => {
+      const names = await caches.keys();
+      const all: string[] = [];
+      for (const name of names) {
+        const cache = await caches.open(name);
+        for (const request of await cache.keys()) {
+          all.push(request.url);
+        }
+      }
+      return all;
+    });
+
+    expect(keys.join(" ")).not.toContain("deeply-private-search-term");
+    expect(keys.join(" ")).not.toContain("?q=");
+    // The route itself is still cached, just without the query.
+    expect(keys.some((url) => url.endsWith("/search"))).toBe(true);
+  });
+
   test("shows the offline page when a navigation fails", async ({
     page,
     context,

--- a/frontend/e2e/pwa-install.spec.ts
+++ b/frontend/e2e/pwa-install.spec.ts
@@ -1,0 +1,124 @@
+import { expect, test } from "@playwright/test";
+
+/**
+ * PWA installability + offline shell E2E (#259).
+ *
+ * Like the other specs here, this needs no live backend: everything asserted is
+ * static shell, manifest, and service-worker plumbing that renders even when
+ * API calls fail.
+ *
+ * Note on the service worker itself: `pnpm start` serves over plain HTTP on
+ * localhost, which browsers treat as a secure context, so registration does
+ * happen here. What cannot be asserted in this environment is the *install
+ * prompt*, which Chrome gates behind engagement heuristics -- so these cases
+ * check the preconditions for installability rather than the prompt.
+ */
+
+test.describe("PWA manifest", () => {
+  test("links a manifest describing a standalone Find app", async ({
+    page,
+    request,
+  }) => {
+    await page.goto("/timeline");
+
+    const href = await page
+      .locator('link[rel="manifest"]')
+      .first()
+      .getAttribute("href");
+    expect(href).toBeTruthy();
+
+    const response = await request.get(href as string);
+    expect(response.ok()).toBe(true);
+
+    const manifest = await response.json();
+    expect(manifest.name).toContain("Find");
+    expect(manifest.short_name).toBe("Find");
+    expect(manifest.display).toBe("standalone");
+    expect(manifest.start_url).toBe("/");
+
+    // Chrome requires both a 192px and a 512px icon before it will offer
+    // installation, so a missing size is a silent installability failure.
+    const sizes = (manifest.icons ?? []).map(
+      (icon: { sizes: string }) => icon.sizes,
+    );
+    expect(sizes).toContain("192x192");
+    expect(sizes).toContain("512x512");
+  });
+
+  test("serves both declared icons", async ({ request }) => {
+    for (const path of ["/icon-192.png", "/icon-512.png"]) {
+      const response = await request.get(path);
+      expect(response.ok(), `${path} should be served`).toBe(true);
+      expect(response.headers()["content-type"]).toContain("image");
+    }
+  });
+
+  test("declares a theme colour matching the manifest", async ({
+    page,
+    request,
+  }) => {
+    await page.goto("/timeline");
+
+    const themeColor = await page
+      .locator('meta[name="theme-color"]')
+      .first()
+      .getAttribute("content");
+    const manifest = await (await request.get("/manifest.json")).json();
+
+    // A mismatch here shows up as an installed app whose title bar disagrees
+    // with its splash screen.
+    expect(themeColor?.toLowerCase()).toBe(manifest.theme_color.toLowerCase());
+  });
+});
+
+test.describe("offline shell", () => {
+  test("serves a self-contained offline fallback page", async ({ page }) => {
+    await page.goto("/offline.html");
+
+    await expect(
+      page.getByRole("heading", { name: /can.t reach your library/i }),
+    ).toBeVisible();
+    await expect(page.getByText(/staged on this device/i)).toBeVisible();
+    await expect(page.getByRole("button", { name: "Retry" })).toBeVisible();
+
+    // It must not depend on the app bundle -- if the network is down, no
+    // Next.js chunk is going to load.
+    await expect(page.locator('script[src*="/_next/"]')).toHaveCount(0);
+    await expect(page.locator('link[rel="stylesheet"]')).toHaveCount(0);
+  });
+
+  test("registers a service worker that controls the page", async ({
+    page,
+  }) => {
+    await page.goto("/timeline");
+
+    const registered = await page.evaluate(async () => {
+      if (!("serviceWorker" in navigator)) return false;
+      const registration = await navigator.serviceWorker.ready;
+      return Boolean(registration.active);
+    });
+
+    expect(registered).toBe(true);
+  });
+
+  test("shows the offline page when a navigation fails", async ({
+    page,
+    context,
+  }) => {
+    // Warm the service worker so the fallback is in its cache.
+    await page.goto("/timeline");
+    await page.evaluate(() => navigator.serviceWorker.ready);
+
+    await context.setOffline(true);
+    await page.goto("/gallery").catch(() => {
+      // A navigation to an uncached route can reject outright; the assertion
+      // below is what actually decides the outcome.
+    });
+
+    await expect(
+      page.getByRole("heading", { name: /can.t reach your library/i }),
+    ).toBeVisible();
+
+    await context.setOffline(false);
+  });
+});

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -46,6 +46,7 @@
     "@types/react-dom": "^19.2.4",
     "@vitejs/plugin-react": "^6.0.5",
     "cross-env": "^10.1.0",
+    "fake-indexeddb": "^6.2.5",
     "jsdom": "^30.0.1",
     "postcss": "^8.5.13",
     "tailwindcss": "^4.3.3",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -92,6 +92,9 @@ importers:
       cross-env:
         specifier: ^10.1.0
         version: 10.1.0
+      fake-indexeddb:
+        specifier: ^6.2.5
+        version: 6.2.5
       jsdom:
         specifier: ^30.0.1
         version: 30.0.1
@@ -1210,6 +1213,10 @@ packages:
   expect-type@1.4.0:
     resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
     engines: {node: '>=12.0.0'}
+
+  fake-indexeddb@6.2.5:
+    resolution: {integrity: sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w==}
+    engines: {node: '>=18'}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -2729,6 +2736,8 @@ snapshots:
       '@types/estree': 1.0.9
 
   expect-type@1.4.0: {}
+
+  fake-indexeddb@6.2.5: {}
 
   fdir@6.5.0(picomatch@4.0.5):
     optionalDependencies:

--- a/frontend/public/offline.html
+++ b/frontend/public/offline.html
@@ -1,0 +1,143 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Offline - Find</title>
+    <!--
+      Served by the service worker when a navigation fails and no cached copy of
+      the requested page exists. It must be completely self-contained: if the
+      network is down, no Next.js chunk, font, or stylesheet is going to load.
+    -->
+    <style>
+      :root {
+        color-scheme: light dark;
+        --bg: #ffffff;
+        --fg: #111827;
+        --muted: #6b7280;
+        --border: #e5e7eb;
+        --card: #f9fafb;
+      }
+      @media (prefers-color-scheme: dark) {
+        :root {
+          --bg: #0a0a0a;
+          --fg: #f3f4f6;
+          --muted: #9ca3af;
+          --border: #262626;
+          --card: #141414;
+        }
+      }
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        min-height: 100vh;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 1.5rem;
+        background: var(--bg);
+        color: var(--fg);
+        font-family:
+          ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto,
+          "Helvetica Neue", Arial, sans-serif;
+      }
+      main {
+        max-width: 30rem;
+        width: 100%;
+        text-align: center;
+      }
+      .badge {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.5rem;
+        padding: 0.35rem 0.75rem;
+        border: 1px solid var(--border);
+        border-radius: 9999px;
+        font-size: 0.8125rem;
+        color: var(--muted);
+        margin-bottom: 1.25rem;
+      }
+      .dot {
+        width: 0.5rem;
+        height: 0.5rem;
+        border-radius: 9999px;
+        background: #f59e0b;
+      }
+      h1 {
+        font-size: 1.5rem;
+        line-height: 1.3;
+        margin: 0 0 0.75rem;
+      }
+      p {
+        color: var(--muted);
+        line-height: 1.6;
+        margin: 0 0 1rem;
+      }
+      .card {
+        text-align: left;
+        background: var(--card);
+        border: 1px solid var(--border);
+        border-radius: 0.75rem;
+        padding: 1rem 1.25rem;
+        margin: 1.5rem 0;
+      }
+      .card h2 {
+        font-size: 0.9375rem;
+        margin: 0 0 0.5rem;
+      }
+      .card ul {
+        margin: 0;
+        padding-left: 1.1rem;
+        color: var(--muted);
+        line-height: 1.7;
+        font-size: 0.9375rem;
+      }
+      button {
+        font: inherit;
+        cursor: pointer;
+        padding: 0.6rem 1.25rem;
+        border-radius: 0.5rem;
+        border: 1px solid var(--border);
+        background: var(--fg);
+        color: var(--bg);
+      }
+      button:hover {
+        opacity: 0.9;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <span class="badge"><span class="dot"></span>Disconnected</span>
+      <h1>Find can&rsquo;t reach your library</h1>
+      <p>
+        Find runs against a backend on your own machine or network. This page is
+        being served from your browser&rsquo;s cache because that backend
+        can&rsquo;t be reached right now.
+      </p>
+
+      <div class="card">
+        <h2>Your data is safe</h2>
+        <ul>
+          <li>Nothing has been lost &mdash; your library lives on your server.</li>
+          <li>Files you queued for upload are still staged on this device.</li>
+          <li>They will be submitted automatically once the connection returns.</li>
+        </ul>
+      </div>
+
+      <p>
+        Check that the Find backend is running, then try again.
+      </p>
+      <button type="button" onclick="location.reload()">Retry</button>
+    </main>
+    <script>
+      // Reload as soon as the browser reports connectivity, so the user does not
+      // have to notice and press the button themselves.
+      window.addEventListener("online", () => {
+        location.reload();
+      });
+    </script>
+  </body>
+</html>

--- a/frontend/public/sw.js
+++ b/frontend/public/sw.js
@@ -90,6 +90,21 @@ self.addEventListener("fetch", (event) => {
 });
 
 /**
+ * Cache key for a navigation: origin + pathname, query string discarded.
+ *
+ * Caching the request as-is would key entries by their full URL, and this app
+ * puts user input in the query string -- /search?q=<whatever they typed>. That
+ * would persist a searchable history of queries in Cache Storage, which is
+ * exactly the kind of trace a local-first tool must not leave behind. The
+ * pathname is all the offline shell needs, and every route's real data comes
+ * from /api/, which is never cached at all.
+ */
+function navigationCacheKey(request) {
+  const url = new URL(request.url);
+  return new Request(`${url.origin}${url.pathname}`, { method: "GET" });
+}
+
+/**
  * Network-first: the app must never be served a stale shell while online,
  * because the shell is what tells the user whether the backend is reachable.
  */
@@ -98,11 +113,11 @@ async function handleNavigation(request) {
     const response = await fetch(request);
     if (response.ok) {
       const cache = await caches.open(SHELL_CACHE);
-      cache.put(request, response.clone());
+      cache.put(navigationCacheKey(request), response.clone());
     }
     return response;
   } catch {
-    const cached = await caches.match(request);
+    const cached = await caches.match(navigationCacheKey(request));
     if (cached) {
       return cached;
     }

--- a/frontend/public/sw.js
+++ b/frontend/public/sw.js
@@ -1,0 +1,136 @@
+/**
+ * Find service worker.
+ *
+ * Scope is deliberately narrow. This exists to make the app shell survive a
+ * dropped connection and to satisfy the installability requirement -- not to
+ * cache user data.
+ *
+ * Hard rule: nothing under /api/ is ever cached, and cross-origin requests are
+ * never intercepted. Photos, captions, OCR text, embeddings, and face data are
+ * exactly what a local-first tool must not leave lying in a browser cache, and
+ * media is served from object storage on another origin.
+ */
+
+const VERSION = "find-sw-v1";
+const SHELL_CACHE = `${VERSION}-shell`;
+const STATIC_CACHE = `${VERSION}-static`;
+const OFFLINE_URL = "/offline.html";
+
+// Only assets that exist regardless of the build output. Next.js hashes its
+// chunk filenames, so those are cached at runtime instead of precached -- a
+// hardcoded chunk list would go stale on the next build and fail the install.
+const PRECACHE_URLS = [
+  OFFLINE_URL,
+  "/manifest.json",
+  "/icon-192.png",
+  "/icon-512.png",
+];
+
+self.addEventListener("install", (event) => {
+  event.waitUntil(
+    caches
+      .open(SHELL_CACHE)
+      .then((cache) => cache.addAll(PRECACHE_URLS))
+      .then(() => self.skipWaiting()),
+  );
+});
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil(
+    caches
+      .keys()
+      .then((keys) =>
+        Promise.all(
+          keys
+            .filter((key) => !key.startsWith(VERSION))
+            .map((key) => caches.delete(key)),
+        ),
+      )
+      .then(() => self.clients.claim()),
+  );
+});
+
+function isStaticAsset(url) {
+  return (
+    url.pathname.startsWith("/_next/static/") ||
+    url.pathname === "/manifest.json" ||
+    /\.(?:png|svg|ico|webp|woff2?)$/.test(url.pathname)
+  );
+}
+
+self.addEventListener("fetch", (event) => {
+  const { request } = event;
+
+  if (request.method !== "GET") {
+    return;
+  }
+
+  const url = new URL(request.url);
+
+  // Same-origin only. Media comes from object storage on another origin and
+  // must not be intercepted, let alone stored.
+  if (url.origin !== self.location.origin) {
+    return;
+  }
+
+  // Never cache the API. A stale gallery or a cached search response is both a
+  // correctness bug and a privacy leak.
+  if (url.pathname.startsWith("/api/")) {
+    return;
+  }
+
+  if (request.mode === "navigate") {
+    event.respondWith(handleNavigation(request));
+    return;
+  }
+
+  if (isStaticAsset(url)) {
+    event.respondWith(handleStaticAsset(request));
+  }
+});
+
+/**
+ * Network-first: the app must never be served a stale shell while online,
+ * because the shell is what tells the user whether the backend is reachable.
+ */
+async function handleNavigation(request) {
+  try {
+    const response = await fetch(request);
+    if (response.ok) {
+      const cache = await caches.open(SHELL_CACHE);
+      cache.put(request, response.clone());
+    }
+    return response;
+  } catch {
+    const cached = await caches.match(request);
+    if (cached) {
+      return cached;
+    }
+    const offline = await caches.match(OFFLINE_URL);
+    if (offline) {
+      return offline;
+    }
+    return new Response("Offline", {
+      status: 503,
+      headers: { "Content-Type": "text/plain" },
+    });
+  }
+}
+
+/** Cache-first: Next.js static chunk URLs are content-hashed, so they are immutable. */
+async function handleStaticAsset(request) {
+  const cached = await caches.match(request);
+  if (cached) {
+    return cached;
+  }
+  try {
+    const response = await fetch(request);
+    if (response.ok) {
+      const cache = await caches.open(STATIC_CACHE);
+      cache.put(request, response.clone());
+    }
+    return response;
+  } catch {
+    return new Response("", { status: 504 });
+  }
+}

--- a/frontend/src/__tests__/instance-page.test.tsx
+++ b/frontend/src/__tests__/instance-page.test.tsx
@@ -1,0 +1,313 @@
+/**
+ * Component tests for the Instance management page (#263).
+ *
+ * Covers the four states the page can be in -- local mode, signed-out shared
+ * mode, member, admin -- plus the admin loading/empty/error branches and the
+ * approve/reject actions.
+ *
+ * Run with: pnpm vitest run src/__tests__/instance-page.test.tsx
+ */
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import InstancePage from "@/app/instance/page";
+
+const {
+  approveJoinRequest,
+  createInstanceInvite,
+  getCurrentAccount,
+  getInstanceInvites,
+  getInstanceUsers,
+  getJoinRequests,
+  rejectJoinRequest,
+  submitJoinRequest,
+} = vi.hoisted(() => ({
+  approveJoinRequest: vi.fn(),
+  createInstanceInvite: vi.fn(),
+  getCurrentAccount: vi.fn(),
+  getInstanceInvites: vi.fn(),
+  getInstanceUsers: vi.fn(),
+  getJoinRequests: vi.fn(),
+  rejectJoinRequest: vi.fn(),
+  submitJoinRequest: vi.fn(),
+}));
+
+vi.mock("@/lib/api", () => ({
+  approveJoinRequest,
+  createInstanceInvite,
+  getCurrentAccount,
+  getInstanceInvites,
+  getInstanceUsers,
+  getJoinRequests,
+  rejectJoinRequest,
+  submitJoinRequest,
+  extractErrorMessage: (_error: unknown, fallback: string) => fallback,
+}));
+
+function renderPage() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <InstancePage />
+    </QueryClientProvider>,
+  );
+}
+
+const ADMIN = {
+  mode: "shared" as const,
+  user: {
+    id: 1,
+    username: "admin",
+    display_name: "Admin",
+    role: "admin" as const,
+  },
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getInstanceUsers.mockResolvedValue([]);
+  getInstanceInvites.mockResolvedValue([]);
+  getJoinRequests.mockResolvedValue([]);
+});
+
+afterEach(cleanup);
+
+describe("local mode", () => {
+  it("explains that no instance is needed and never asks for setup", async () => {
+    getCurrentAccount.mockResolvedValue({ mode: "local", user: null });
+    renderPage();
+
+    expect(await screen.findByText("No instance needed")).toBeInTheDocument();
+    // Single-user installs must stay frictionless -- nothing on this page may
+    // read as a required step.
+    expect(screen.queryByText("Pending requests")).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /Enable accounts/ }),
+    ).toBeInTheDocument();
+  });
+
+  it("states the privacy consequence of enabling shared access", async () => {
+    getCurrentAccount.mockResolvedValue({ mode: "local", user: null });
+    renderPage();
+
+    expect(
+      await screen.findByText(/sharing is per-instance, not per-album/i),
+    ).toBeInTheDocument();
+  });
+});
+
+describe("signed-out shared mode", () => {
+  beforeEach(() => {
+    getCurrentAccount.mockResolvedValue({ mode: "shared", user: null });
+  });
+
+  it("offers the join form with an exposure warning", async () => {
+    renderPage();
+
+    expect(await screen.findByLabelText(/Invite token/)).toBeInTheDocument();
+    expect(
+      screen.getByText(/Only join a server you trust/i),
+    ).toBeInTheDocument();
+  });
+
+  it("submits a join request and confirms it is awaiting approval", async () => {
+    submitJoinRequest.mockResolvedValue({ join_request_id: 7 });
+    renderPage();
+
+    fireEvent.change(await screen.findByLabelText(/Invite token/), {
+      target: { value: "tok-123" },
+    });
+    fireEvent.change(screen.getByLabelText(/^Username$/), {
+      target: { value: "newbie" },
+    });
+    fireEvent.change(screen.getByLabelText(/^Password$/), {
+      target: { value: "longenough1" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /Request access/ }));
+
+    // React Query v5 appends its own context argument to every mutationFn
+    // call, so assert on the payload rather than the whole argument list.
+    await waitFor(() => expect(submitJoinRequest).toHaveBeenCalled());
+    expect(submitJoinRequest.mock.calls[0]?.[0]).toEqual({
+      invite_token: "tok-123",
+      username: "newbie",
+      password: "longenough1",
+      display_name: undefined,
+    });
+    expect(await screen.findByText("Request submitted")).toBeInTheDocument();
+  });
+
+  it("surfaces a rejected invite token as an alert", async () => {
+    submitJoinRequest.mockRejectedValue(new Error("bad token"));
+    renderPage();
+
+    fireEvent.change(await screen.findByLabelText(/Invite token/), {
+      target: { value: "nope" },
+    });
+    fireEvent.change(screen.getByLabelText(/^Username$/), {
+      target: { value: "newbie" },
+    });
+    fireEvent.change(screen.getByLabelText(/^Password$/), {
+      target: { value: "longenough1" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /Request access/ }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "Could not submit the request.",
+    );
+  });
+});
+
+describe("member view", () => {
+  it("shows membership without any admin control", async () => {
+    getCurrentAccount.mockResolvedValue({
+      mode: "shared",
+      user: { id: 2, username: "sam", display_name: "Sam", role: "member" },
+    });
+    renderPage();
+
+    expect(await screen.findByText("You are a member")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /Create invite/ }),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText("Pending requests")).not.toBeInTheDocument();
+    // A member must never trigger the admin-only endpoints.
+    expect(getJoinRequests).not.toHaveBeenCalled();
+    expect(getInstanceUsers).not.toHaveBeenCalled();
+  });
+});
+
+describe("admin view", () => {
+  beforeEach(() => {
+    getCurrentAccount.mockResolvedValue(ADMIN);
+  });
+
+  it("warns that access covers the whole library", async () => {
+    renderPage();
+    expect(
+      await screen.findByText(/every photo, caption, OCR result/i),
+    ).toBeInTheDocument();
+  });
+
+  it("shows empty states for invites and requests", async () => {
+    renderPage();
+
+    expect(await screen.findByText("No invites yet.")).toBeInTheDocument();
+    expect(
+      screen.getByText("Nobody is waiting for access."),
+    ).toBeInTheDocument();
+  });
+
+  it("surfaces a failed member load without breaking the page", async () => {
+    getInstanceUsers.mockRejectedValue(new Error("boom"));
+    renderPage();
+
+    expect(
+      await screen.findByText("Could not load members."),
+    ).toBeInTheDocument();
+    // The rest of the page still renders.
+    expect(screen.getByText("Pending requests")).toBeInTheDocument();
+  });
+
+  it("reveals a created invite token once, with a copy-now warning", async () => {
+    createInstanceInvite.mockResolvedValue({
+      id: 1,
+      invite_token: "secret-token",
+      expires_at: "2026-09-01T00:00:00+00:00",
+    });
+    renderPage();
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: /Create invite/ }),
+    );
+
+    expect(await screen.findByText("secret-token")).toBeInTheDocument();
+    expect(
+      screen.getByText(/shown once and is not recoverable/i),
+    ).toBeInTheDocument();
+  });
+
+  it("lists pending requests and approves one", async () => {
+    getJoinRequests.mockResolvedValue([
+      {
+        id: 9,
+        username: "newbie",
+        display_name: "New Bie",
+        status: "pending",
+        created_at: "2026-08-20T10:00:00+00:00",
+        reviewed_at: null,
+      },
+    ]);
+    approveJoinRequest.mockResolvedValue({ user: { id: 3 } });
+    renderPage();
+
+    expect(await screen.findByText("New Bie")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /Approve/ }));
+
+    await waitFor(() => expect(approveJoinRequest).toHaveBeenCalled());
+    expect(approveJoinRequest.mock.calls[0]?.[0]).toBe(9);
+  });
+
+  it("rejects a pending request", async () => {
+    getJoinRequests.mockResolvedValue([
+      {
+        id: 11,
+        username: "spammer",
+        display_name: null,
+        status: "pending",
+        created_at: null,
+        reviewed_at: null,
+      },
+    ]);
+    rejectJoinRequest.mockResolvedValue(undefined);
+    renderPage();
+
+    fireEvent.click(await screen.findByRole("button", { name: /Reject/ }));
+
+    await waitFor(() => expect(rejectJoinRequest).toHaveBeenCalled());
+    expect(rejectJoinRequest.mock.calls[0]?.[0]).toBe(11);
+  });
+
+  it("hides already-reviewed requests from the pending list", async () => {
+    getJoinRequests.mockResolvedValue([
+      {
+        id: 12,
+        username: "approved-already",
+        display_name: null,
+        status: "approved",
+        created_at: null,
+        reviewed_at: "2026-08-19T10:00:00+00:00",
+      },
+    ]);
+    renderPage();
+
+    expect(
+      await screen.findByText("Nobody is waiting for access."),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("approved-already")).not.toBeInTheDocument();
+  });
+
+  it("lists members with their role", async () => {
+    getInstanceUsers.mockResolvedValue([
+      { id: 1, username: "admin", display_name: "Admin", role: "admin" },
+      { id: 2, username: "sam", display_name: null, role: "member" },
+    ]);
+    renderPage();
+
+    const members = await screen.findByRole("list", { name: /Members/ });
+    expect(members).toHaveTextContent("Admin");
+    // display_name is null, so the username is shown as the primary label too.
+    expect(members).toHaveTextContent("sam");
+    expect(members).toHaveTextContent("admin");
+    expect(members).toHaveTextContent("member");
+  });
+});

--- a/frontend/src/__tests__/offline-queue.test.ts
+++ b/frontend/src/__tests__/offline-queue.test.ts
@@ -1,0 +1,275 @@
+/**
+ * Offline upload queue (#259).
+ *
+ * The behaviour worth protecting here is not "can we write to IndexedDB" but
+ * the three things that make a resume-on-reconnect queue safe: it must not send
+ * a file twice, it must not lose one when a send fails, and it must never hold
+ * a secret.
+ */
+
+import "fake-indexeddb/auto";
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  clearQueuedUploads,
+  countQueuedUploads,
+  enqueueFiles,
+  flushQueue,
+  isIndexedDbAvailable,
+  listQueuedUploads,
+  recoverStalledUploads,
+  removeQueuedUpload,
+  resetFlushGuardForTests,
+} from "@/lib/offline-queue";
+
+function makeFile(
+  name: string,
+  contents = "image-bytes",
+  lastModified = 1_700_000_000_000,
+) {
+  return new File([contents], name, { type: "image/jpeg", lastModified });
+}
+
+beforeEach(async () => {
+  resetFlushGuardForTests();
+  await clearQueuedUploads();
+});
+
+describe("environment", () => {
+  it("reports IndexedDB as available under the test shim", () => {
+    expect(isIndexedDbAvailable()).toBe(true);
+  });
+});
+
+describe("enqueueFiles", () => {
+  it("stages files and reports them back as metadata", async () => {
+    const { added, skipped } = await enqueueFiles([
+      makeFile("a.jpg"),
+      makeFile("b.jpg"),
+    ]);
+
+    expect(added).toHaveLength(2);
+    expect(skipped).toHaveLength(0);
+    expect(await countQueuedUploads()).toBe(2);
+
+    const items = await listQueuedUploads();
+    expect(items.map((item) => item.name)).toEqual(["a.jpg", "b.jpg"]);
+    expect(items[0]?.status).toBe("queued");
+    expect(items[0]?.attempts).toBe(0);
+  });
+
+  it("does not stage the same file twice across separate drops", async () => {
+    await enqueueFiles([makeFile("a.jpg")]);
+    const second = await enqueueFiles([makeFile("a.jpg")]);
+
+    expect(second.added).toHaveLength(0);
+    expect(second.skipped).toHaveLength(1);
+    expect(await countQueuedUploads()).toBe(1);
+  });
+
+  it("does not stage the same file twice within one drop", async () => {
+    const { added, skipped } = await enqueueFiles([
+      makeFile("a.jpg"),
+      makeFile("a.jpg"),
+    ]);
+
+    expect(added).toHaveLength(1);
+    expect(skipped).toHaveLength(1);
+    expect(await countQueuedUploads()).toBe(1);
+  });
+
+  it("treats a same-named file with different bytes as a distinct file", async () => {
+    await enqueueFiles([makeFile("a.jpg", "first", 1)]);
+    const second = await enqueueFiles([makeFile("a.jpg", "second-longer", 2)]);
+
+    expect(second.added).toHaveLength(1);
+    expect(await countQueuedUploads()).toBe(2);
+  });
+
+  it("is a no-op for an empty selection", async () => {
+    const result = await enqueueFiles([]);
+    expect(result.added).toHaveLength(0);
+    expect(await countQueuedUploads()).toBe(0);
+  });
+
+  it("omits the file bytes from the metadata it returns", async () => {
+    const { added } = await enqueueFiles([makeFile("a.jpg")]);
+    // The panel renders these straight into React state; carrying the bytes
+    // would pin every staged file in memory.
+    expect(added[0]).not.toHaveProperty("bytes");
+
+    const [listed] = await listQueuedUploads();
+    expect(listed).not.toHaveProperty("bytes");
+  });
+});
+
+describe("removal", () => {
+  it("removes a single queued file", async () => {
+    const { added } = await enqueueFiles([
+      makeFile("a.jpg"),
+      makeFile("b.jpg"),
+    ]);
+    const target = added[0];
+    if (!target) throw new Error("expected a queued file");
+
+    await removeQueuedUpload(target.id);
+
+    const remaining = await listQueuedUploads();
+    expect(remaining.map((item) => item.name)).toEqual(["b.jpg"]);
+  });
+
+  it("clears the whole queue", async () => {
+    await enqueueFiles([makeFile("a.jpg"), makeFile("b.jpg")]);
+    await clearQueuedUploads();
+    expect(await countQueuedUploads()).toBe(0);
+  });
+});
+
+describe("flushQueue", () => {
+  it("uploads every queued file and empties the queue", async () => {
+    await enqueueFiles([makeFile("a.jpg"), makeFile("b.jpg")]);
+    const uploader = vi.fn().mockResolvedValue({ results: [] });
+
+    const result = await flushQueue(uploader);
+
+    expect(result).toMatchObject({ uploaded: 2, failed: 0, skipped: false });
+    expect(uploader).toHaveBeenCalledTimes(2);
+    expect(await countQueuedUploads()).toBe(0);
+  });
+
+  it("hands the uploader a real File with the original name and type", async () => {
+    await enqueueFiles([makeFile("holiday.jpg")]);
+    const uploader = vi.fn().mockResolvedValue({ results: [] });
+
+    await flushQueue(uploader);
+
+    const [files] = uploader.mock.calls[0] ?? [];
+    const file = (files as File[])[0];
+    expect(file).toBeInstanceOf(File);
+    expect(file?.name).toBe("holiday.jpg");
+    expect(file?.type).toBe("image/jpeg");
+    expect(await file?.text()).toBe("image-bytes");
+  });
+
+  it("keeps a failed file queued and counts the attempt", async () => {
+    await enqueueFiles([makeFile("a.jpg")]);
+    const uploader = vi.fn().mockRejectedValue(new Error("Network Error"));
+
+    const result = await flushQueue(uploader);
+
+    expect(result).toMatchObject({ uploaded: 0, failed: 1 });
+    const [item] = await listQueuedUploads();
+    // Back to `queued`, not stranded in `uploading` -- otherwise the next flush
+    // would skip it forever.
+    expect(item?.status).toBe("queued");
+    expect(item?.attempts).toBe(1);
+    expect(item?.lastError).toBe("Network Error");
+  });
+
+  it("removes the files that succeed even when others fail", async () => {
+    await enqueueFiles([makeFile("good.jpg"), makeFile("bad.jpg")]);
+    const uploader = vi.fn(async (files: File[]) => {
+      if (files[0]?.name === "bad.jpg") throw new Error("rejected");
+      return { results: [] };
+    });
+
+    const result = await flushQueue(uploader);
+
+    expect(result).toMatchObject({ uploaded: 1, failed: 1 });
+    const remaining = await listQueuedUploads();
+    expect(remaining.map((item) => item.name)).toEqual(["bad.jpg"]);
+  });
+
+  it("does not submit the same file twice when two flushes overlap", async () => {
+    await enqueueFiles([makeFile("a.jpg")]);
+
+    let release: (() => void) | undefined;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const uploader = vi.fn(async () => {
+      await gate;
+      return { results: [] };
+    });
+
+    // Two triggers land together -- the `online` event and a manual retry.
+    const first = flushQueue(uploader);
+    const second = flushQueue(uploader);
+    release?.();
+    const [firstResult, secondResult] = await Promise.all([first, second]);
+
+    expect(uploader).toHaveBeenCalledTimes(1);
+    expect(firstResult.uploaded).toBe(1);
+    expect(secondResult.skipped).toBe(true);
+    expect(await countQueuedUploads()).toBe(0);
+  });
+
+  it("is a no-op on an empty queue", async () => {
+    const uploader = vi.fn();
+    const result = await flushQueue(uploader);
+    expect(uploader).not.toHaveBeenCalled();
+    expect(result).toMatchObject({ uploaded: 0, failed: 0 });
+  });
+});
+
+describe("recoverStalledUploads", () => {
+  it("returns a file stranded in `uploading` to `queued`", async () => {
+    await enqueueFiles([makeFile("a.jpg")]);
+
+    // Simulate a tab closed mid-upload: the uploader never settles, so the
+    // record is left marked `uploading`.
+    const neverResolves = vi.fn(() => new Promise<never>(() => {}));
+    void flushQueue(neverResolves);
+    await vi.waitFor(async () => {
+      const [item] = await listQueuedUploads();
+      expect(item?.status).toBe("uploading");
+    });
+
+    resetFlushGuardForTests();
+    const recovered = await recoverStalledUploads();
+
+    expect(recovered).toBe(1);
+    const [item] = await listQueuedUploads();
+    expect(item?.status).toBe("queued");
+  });
+
+  it("leaves an ordinary queued file alone", async () => {
+    await enqueueFiles([makeFile("a.jpg")]);
+    expect(await recoverStalledUploads()).toBe(0);
+  });
+});
+
+describe("secret containment", () => {
+  it("stores nothing beyond the file bytes and display metadata", async () => {
+    await enqueueFiles([makeFile("a.jpg")]);
+    const [item] = await listQueuedUploads();
+    if (!item) throw new Error("expected a queued file");
+
+    // Auth is cookie-based and the vault key is memory-only (store/vaultStore).
+    // Assert on the exact key set so adding a field to the record is a
+    // deliberate decision that has to come through this test.
+    expect(Object.keys(item).sort()).toEqual(
+      [
+        "attempts",
+        "id",
+        "lastModified",
+        "name",
+        "queuedAt",
+        "seq",
+        "size",
+        "status",
+        "type",
+      ].sort(),
+    );
+  });
+
+  it("does not leak a sentinel credential into the persisted record", async () => {
+    const sentinel = "vault-master-key-do-not-persist";
+    // A credential that happens to be in scope must not end up serialised into
+    // the queue by a future change to enqueueFiles.
+    await enqueueFiles([makeFile("a.jpg", sentinel)]);
+
+    const items = await listQueuedUploads();
+    expect(JSON.stringify(items)).not.toContain(sentinel);
+  });
+});

--- a/frontend/src/__tests__/offline-upload-queue.test.tsx
+++ b/frontend/src/__tests__/offline-upload-queue.test.tsx
@@ -1,0 +1,177 @@
+/**
+ * Component tests for the offline upload queue panel (#259).
+ *
+ * The panel is rendered from props rather than from the hook so these cases
+ * exercise the presentation contract -- when it appears, what it says, and
+ * which controls are reachable -- without an IndexedDB round trip. The storage
+ * behaviour has its own suite in offline-queue.test.ts.
+ *
+ * Run with: pnpm vitest run src/__tests__/offline-upload-queue.test.tsx
+ */
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { OfflineUploadQueue } from "@/components/offline-upload-queue";
+import type { QueuedUpload } from "@/lib/offline-queue";
+
+afterEach(cleanup);
+
+function queuedItem(overrides: Partial<QueuedUpload> = {}): QueuedUpload {
+  return {
+    id: "item-1",
+    name: "holiday.jpg",
+    size: 2_400_000,
+    type: "image/jpeg",
+    lastModified: 1_700_000_000_000,
+    queuedAt: 1_700_000_000_000,
+    seq: 1,
+    attempts: 0,
+    status: "queued",
+    ...overrides,
+  };
+}
+
+function renderPanel(
+  overrides: Partial<React.ComponentProps<typeof OfflineUploadQueue>> = {},
+) {
+  const props = {
+    items: [] as QueuedUpload[],
+    online: true,
+    flushing: false,
+    available: true,
+    refresh: vi.fn(),
+    flush: vi.fn(),
+    remove: vi.fn(),
+    clear: vi.fn(),
+    ...overrides,
+  };
+  render(<OfflineUploadQueue {...props} />);
+  return props;
+}
+
+describe("visibility", () => {
+  it("renders nothing when online with an empty queue", () => {
+    const { container } = render(
+      <OfflineUploadQueue
+        items={[]}
+        online
+        flushing={false}
+        available
+        refresh={vi.fn()}
+        flush={vi.fn()}
+        remove={vi.fn()}
+        clear={vi.fn()}
+      />,
+    );
+    // The normal path must look exactly as it did before this feature.
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders nothing when IndexedDB is unavailable", () => {
+    const { container } = render(
+      <OfflineUploadQueue
+        items={[queuedItem()]}
+        online={false}
+        flushing={false}
+        available={false}
+        refresh={vi.fn()}
+        flush={vi.fn()}
+        remove={vi.fn()}
+        clear={vi.fn()}
+      />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("announces the disconnected state even with nothing queued", () => {
+    renderPanel({ online: false });
+    expect(
+      screen.getByRole("heading", { name: "Offline" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Nothing has been sent yet/i)).toBeInTheDocument();
+  });
+
+  it("stays visible while a queue drains after reconnecting", () => {
+    renderPanel({ online: true, items: [queuedItem()] });
+    expect(
+      screen.getByRole("heading", { name: "Waiting to upload" }),
+    ).toBeInTheDocument();
+  });
+});
+
+describe("queued files", () => {
+  it("lists each staged file with a human-readable size", () => {
+    renderPanel({ online: false, items: [queuedItem()] });
+    expect(screen.getByText("holiday.jpg")).toBeInTheDocument();
+    expect(screen.getByText(/2\.3 MB/)).toBeInTheDocument();
+    expect(screen.getByText("1 file")).toBeInTheDocument();
+  });
+
+  it("pluralises the file count", () => {
+    renderPanel({
+      online: false,
+      items: [
+        queuedItem(),
+        queuedItem({ id: "item-2", name: "b.jpg", seq: 2 }),
+      ],
+    });
+    expect(screen.getByText("2 files")).toBeInTheDocument();
+  });
+
+  it("surfaces failed attempts and the last error", () => {
+    renderPanel({
+      online: false,
+      items: [queuedItem({ attempts: 2, lastError: "Network Error" })],
+    });
+    expect(screen.getByText(/2 failed attempts/)).toBeInTheDocument();
+    expect(screen.getByText(/Network Error/)).toBeInTheDocument();
+  });
+
+  it("removes a single file", () => {
+    const props = renderPanel({ online: false, items: [queuedItem()] });
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Remove holiday.jpg from the upload queue",
+      }),
+    );
+
+    expect(props.remove).toHaveBeenCalledWith("item-1");
+  });
+
+  it("clears the whole queue", () => {
+    const props = renderPanel({ online: false, items: [queuedItem()] });
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Remove all queued files" }),
+    );
+
+    expect(props.clear).toHaveBeenCalled();
+  });
+});
+
+describe("retry control", () => {
+  it("is disabled while offline", () => {
+    renderPanel({ online: false, items: [queuedItem()] });
+    expect(
+      screen.getByRole("button", { name: "Retry queued uploads now" }),
+    ).toBeDisabled();
+  });
+
+  it("is disabled while a flush is already running", () => {
+    renderPanel({ online: true, flushing: true, items: [queuedItem()] });
+    expect(
+      screen.getByRole("button", { name: "Retry queued uploads now" }),
+    ).toBeDisabled();
+  });
+
+  it("triggers a flush when online and idle", () => {
+    const props = renderPanel({ online: true, items: [queuedItem()] });
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Retry queued uploads now" }),
+    );
+
+    expect(props.flush).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/app/account/page.tsx
+++ b/frontend/src/app/account/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { KeyRound, LogOut, Shield, UserRound } from "lucide-react";
+import { KeyRound, LogOut, Shield, UserRound, Users } from "lucide-react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { type FormEvent, useEffect, useState } from "react";
@@ -144,13 +144,23 @@ export default function AccountPage() {
           </p>
           <h1 className="text-3xl font-semibold">Account settings</h1>
         </div>
-        <button
-          type="button"
-          onClick={() => logout.mutate()}
-          className="frost-button px-4 py-2 text-sm font-medium"
-        >
-          <LogOut className="h-4 w-4" /> Sign out
-        </button>
+        <div className="flex items-center gap-2">
+          {/* Only reachable in shared mode -- a single-user install has no
+              instance to manage, so this deliberately is not a nav entry. */}
+          <Link
+            href="/instance"
+            className="frost-button inline-flex items-center gap-2 px-4 py-2 text-sm font-medium"
+          >
+            <Users className="h-4 w-4" /> Instance
+          </Link>
+          <button
+            type="button"
+            onClick={() => logout.mutate()}
+            className="frost-button px-4 py-2 text-sm font-medium"
+          >
+            <LogOut className="h-4 w-4" /> Sign out
+          </button>
+        </div>
       </header>
 
       <div className="grid gap-6">

--- a/frontend/src/app/instance/page.tsx
+++ b/frontend/src/app/instance/page.tsx
@@ -1,0 +1,564 @@
+"use client";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  Check,
+  Copy,
+  ShieldAlert,
+  ShieldCheck,
+  UserPlus,
+  Users,
+  X,
+} from "lucide-react";
+import Link from "next/link";
+import { type FormEvent, useState } from "react";
+import {
+  approveJoinRequest,
+  type CreatedInvite,
+  createInstanceInvite,
+  extractErrorMessage,
+  getCurrentAccount,
+  getInstanceInvites,
+  getInstanceUsers,
+  getJoinRequests,
+  rejectJoinRequest,
+  submitJoinRequest,
+} from "@/lib/api";
+
+const INPUT_CLASS =
+  "mt-2 w-full rounded-xl border border-[var(--frost)] bg-[color:var(--void)] px-4 py-3 outline-none focus:border-[color:var(--blue)]";
+
+function formatDate(value: string | null): string {
+  if (!value) return "unknown";
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? "unknown" : parsed.toLocaleString();
+}
+
+export default function InstancePage() {
+  const account = useQuery({
+    queryKey: ["account"],
+    queryFn: getCurrentAccount,
+    retry: false,
+  });
+
+  if (account.isLoading) {
+    return (
+      <main className="page-surface mx-auto max-w-4xl py-10" aria-busy="true">
+        Loading instance…
+      </main>
+    );
+  }
+
+  if (account.isError) {
+    return (
+      <main className="page-surface mx-auto max-w-4xl py-10">
+        <h1 className="text-3xl font-semibold">Instance</h1>
+        <p className="mt-4 text-sm text-[color:var(--silver)]">
+          {extractErrorMessage(account.error, "Could not load this instance.")}
+        </p>
+      </main>
+    );
+  }
+
+  // Local mode is the default and must stay frictionless: a single-user
+  // install never needs an instance, so this page explains rather than
+  // prompts.
+  if (account.data?.mode === "local") {
+    return <LocalModeNotice />;
+  }
+
+  const user = account.data?.user ?? null;
+
+  if (!user) {
+    // Shared mode, not signed in. The join flow is the one thing a stranger
+    // with an invite legitimately needs from this page.
+    return <JoinWithInvite />;
+  }
+
+  if (user.role !== "admin") {
+    return <MemberView displayName={user.display_name ?? user.username} />;
+  }
+
+  return <AdminView />;
+}
+
+function PageHeader({ subtitle }: { subtitle: string }) {
+  return (
+    <header className="mb-8 border-b border-[var(--frost)] pb-5">
+      <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[color:var(--blue)]">
+        Instance
+      </p>
+      <h1 className="mt-1 text-3xl font-semibold">Shared access</h1>
+      <p className="mt-2 text-sm leading-6 text-[color:var(--silver)]">
+        {subtitle}
+      </p>
+    </header>
+  );
+}
+
+function LocalModeNotice() {
+  return (
+    <main className="page-surface mx-auto max-w-4xl py-10">
+      <PageHeader subtitle="This installation is running as a single-user library." />
+      <section className="rounded-3xl border border-[var(--frost)] bg-[color:var(--surface-soft)] p-7 sm:p-9">
+        <ShieldCheck className="h-7 w-7 text-[color:var(--green)]" />
+        <h2 className="mt-5 text-2xl font-semibold">No instance needed</h2>
+        <p className="mt-3 max-w-xl text-sm leading-6 text-[color:var(--silver)]">
+          Find is local-first. Nothing here is required to use your library, and
+          no account, invite, or sign-in exists until you deliberately enable
+          shared access.
+        </p>
+        <p className="mt-3 max-w-xl text-sm leading-6 text-[color:var(--silver)]">
+          Enabling accounts turns this server into a shared deployment. Anyone
+          you invite can see every photo, caption, face cluster, and search
+          result in this library — sharing is per-instance, not per-album.
+        </p>
+        <Link
+          href="/auth/setup"
+          className="white-pill mt-6 inline-flex px-5 py-3 text-sm font-semibold"
+        >
+          Enable accounts
+        </Link>
+      </section>
+    </main>
+  );
+}
+
+function MemberView({ displayName }: { displayName: string }) {
+  return (
+    <main className="page-surface mx-auto max-w-4xl py-10">
+      <PageHeader subtitle={`Signed in as ${displayName}.`} />
+      <section className="rounded-3xl border border-[var(--frost)] bg-[color:var(--surface-soft)] p-7 sm:p-9">
+        <Users className="h-7 w-7 text-[color:var(--blue)]" />
+        <h2 className="mt-5 text-2xl font-semibold">You are a member</h2>
+        <p className="mt-3 max-w-xl text-sm leading-6 text-[color:var(--silver)]">
+          You have access to this shared library. Inviting people and reviewing
+          join requests are administrator actions.
+        </p>
+        <p className="mt-3 max-w-xl text-sm leading-6 text-[color:var(--silver)]">
+          Everything you upload is visible to everyone else on this instance.
+        </p>
+        <Link
+          href="/account"
+          className="frost-button mt-6 inline-flex px-4 py-2 text-sm font-medium"
+        >
+          Account settings
+        </Link>
+      </section>
+    </main>
+  );
+}
+
+function JoinWithInvite() {
+  const [inviteToken, setInviteToken] = useState("");
+  const [username, setUsername] = useState("");
+  const [displayName, setDisplayName] = useState("");
+  const [password, setPassword] = useState("");
+
+  const join = useMutation({ mutationFn: submitJoinRequest });
+
+  const onSubmit = (event: FormEvent) => {
+    event.preventDefault();
+    join.mutate({
+      invite_token: inviteToken.trim(),
+      username: username.trim(),
+      password,
+      display_name: displayName.trim() || undefined,
+    });
+  };
+
+  if (join.isSuccess) {
+    return (
+      <main className="page-surface mx-auto max-w-2xl py-10">
+        <PageHeader subtitle="Your request has been sent." />
+        <section className="rounded-3xl border border-[var(--frost)] bg-[color:var(--surface-soft)] p-7 sm:p-9">
+          <Check className="h-7 w-7 text-[color:var(--green)]" />
+          <h2 className="mt-5 text-2xl font-semibold">Request submitted</h2>
+          <p className="mt-3 text-sm leading-6 text-[color:var(--silver)]">
+            An administrator has to approve it before you can sign in. Nothing
+            is shared with you until they do.
+          </p>
+          <Link
+            href="/auth/login"
+            className="frost-button mt-6 inline-flex px-4 py-2 text-sm font-medium"
+          >
+            Go to sign in
+          </Link>
+        </section>
+      </main>
+    );
+  }
+
+  return (
+    <main className="page-surface mx-auto max-w-2xl py-10">
+      <PageHeader subtitle="Join this shared library with an invite from its administrator." />
+
+      <section className="mb-6 rounded-2xl border border-[var(--frost)] bg-[color:var(--frost-soft)] p-4">
+        <div className="flex items-start gap-3">
+          <ShieldAlert
+            className="mt-0.5 h-4 w-4 shrink-0 text-[color:var(--yellow)]"
+            aria-hidden
+          />
+          <p className="text-xs leading-relaxed text-[color:var(--silver)]">
+            Joining gives you access to this instance&rsquo;s entire library,
+            and gives its administrator the ability to see that you have an
+            account here. Only join a server you trust.
+          </p>
+        </div>
+      </section>
+
+      <form onSubmit={onSubmit} className="space-y-4">
+        <label className="block text-sm">
+          <span className="font-medium">Invite token</span>
+          <input
+            required
+            value={inviteToken}
+            onChange={(event) => setInviteToken(event.target.value)}
+            className={INPUT_CLASS}
+          />
+        </label>
+        <label className="block text-sm">
+          <span className="font-medium">Username</span>
+          <input
+            autoComplete="username"
+            required
+            value={username}
+            onChange={(event) => setUsername(event.target.value)}
+            className={INPUT_CLASS}
+          />
+        </label>
+        <label className="block text-sm">
+          <span className="font-medium">Display name (optional)</span>
+          <input
+            autoComplete="name"
+            value={displayName}
+            onChange={(event) => setDisplayName(event.target.value)}
+            className={INPUT_CLASS}
+          />
+        </label>
+        <label className="block text-sm">
+          <span className="font-medium">Password</span>
+          <input
+            autoComplete="new-password"
+            minLength={8}
+            required
+            type="password"
+            value={password}
+            onChange={(event) => setPassword(event.target.value)}
+            className={INPUT_CLASS}
+          />
+        </label>
+
+        {join.isError && (
+          <p role="alert" className="text-sm text-[color:var(--red)]">
+            {extractErrorMessage(join.error, "Could not submit the request.")}
+          </p>
+        )}
+
+        <button
+          type="submit"
+          disabled={join.isPending}
+          className="white-pill px-5 py-3 text-sm font-semibold disabled:opacity-60"
+        >
+          {join.isPending ? "Sending…" : "Request access"}
+        </button>
+      </form>
+    </main>
+  );
+}
+
+function AdminView() {
+  const queryClient = useQueryClient();
+  const [createdInvite, setCreatedInvite] = useState<CreatedInvite | null>(
+    null,
+  );
+  const [copied, setCopied] = useState(false);
+
+  const users = useQuery({
+    queryKey: ["instance-users"],
+    queryFn: getInstanceUsers,
+  });
+  const requests = useQuery({
+    queryKey: ["instance-join-requests"],
+    queryFn: getJoinRequests,
+  });
+  const invites = useQuery({
+    queryKey: ["instance-invites"],
+    queryFn: getInstanceInvites,
+  });
+
+  const invalidateReviewQueries = async () => {
+    await Promise.all([
+      queryClient.invalidateQueries({ queryKey: ["instance-join-requests"] }),
+      queryClient.invalidateQueries({ queryKey: ["instance-users"] }),
+    ]);
+  };
+
+  const invite = useMutation({
+    mutationFn: () => createInstanceInvite(),
+    onSuccess: async (data) => {
+      setCreatedInvite(data);
+      setCopied(false);
+      await queryClient.invalidateQueries({ queryKey: ["instance-invites"] });
+    },
+  });
+  const approve = useMutation({
+    mutationFn: approveJoinRequest,
+    onSuccess: invalidateReviewQueries,
+  });
+  const reject = useMutation({
+    mutationFn: rejectJoinRequest,
+    onSuccess: invalidateReviewQueries,
+  });
+
+  const pending = (requests.data ?? []).filter(
+    (request) => request.status === "pending",
+  );
+  const reviewError = approve.error ?? reject.error;
+
+  return (
+    <main className="page-surface mx-auto max-w-4xl py-10">
+      <PageHeader subtitle="Invite people to this library and review who is asking for access." />
+
+      <section className="mb-6 rounded-2xl border border-[var(--frost)] bg-[color:var(--frost-soft)] p-4">
+        <div className="flex items-start gap-3">
+          <ShieldAlert
+            className="mt-0.5 h-4 w-4 shrink-0 text-[color:var(--yellow)]"
+            aria-hidden
+          />
+          <p className="text-xs leading-relaxed text-[color:var(--silver)]">
+            Everyone you approve can see this instance&rsquo;s whole library —
+            every photo, caption, OCR result, face cluster, and search. Access
+            is per-instance, not per-album, and cannot be scoped to a subset.
+          </p>
+        </div>
+      </section>
+
+      {/* --- Invites --- */}
+      <section
+        aria-labelledby="invites-heading"
+        className="mb-8 rounded-3xl border border-[var(--frost)] bg-[color:var(--surface-soft)] p-6 sm:p-7"
+      >
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <h2 id="invites-heading" className="text-lg font-semibold">
+            Invites
+          </h2>
+          <button
+            type="button"
+            onClick={() => invite.mutate()}
+            disabled={invite.isPending}
+            className="white-pill inline-flex items-center gap-2 px-4 py-2 text-sm font-semibold disabled:opacity-60"
+          >
+            <UserPlus className="h-4 w-4" aria-hidden />
+            {invite.isPending ? "Creating…" : "Create invite"}
+          </button>
+        </div>
+
+        {invite.isError && (
+          <p role="alert" className="mt-3 text-sm text-[color:var(--red)]">
+            {extractErrorMessage(invite.error, "Could not create an invite.")}
+          </p>
+        )}
+
+        {createdInvite && (
+          <div className="mt-4 rounded-xl border border-[var(--green-soft)] bg-[color:var(--green-soft)] p-4">
+            <p className="text-xs font-semibold uppercase tracking-wide">
+              Copy this now
+            </p>
+            <p className="mt-1 text-xs leading-relaxed text-[color:var(--silver)]">
+              The token is shown once and is not recoverable afterwards. Send it
+              over a channel you trust — anyone holding it can request access.
+            </p>
+            <div className="mt-3 flex items-center gap-2">
+              <code className="min-w-0 flex-1 truncate rounded-lg border border-[var(--frost)] bg-[color:var(--void)] px-3 py-2 text-xs">
+                {createdInvite.invite_token}
+              </code>
+              <button
+                type="button"
+                onClick={() => {
+                  void navigator.clipboard
+                    ?.writeText(createdInvite.invite_token)
+                    .then(() => setCopied(true))
+                    .catch(() => setCopied(false));
+                }}
+                className="icon-button shrink-0"
+                aria-label="Copy invite token"
+              >
+                {copied ? (
+                  <Check className="h-4 w-4" aria-hidden />
+                ) : (
+                  <Copy className="h-4 w-4" aria-hidden />
+                )}
+              </button>
+            </div>
+            <p className="mt-2 text-xs text-[color:var(--muted)]">
+              Expires {formatDate(createdInvite.expires_at)}
+            </p>
+          </div>
+        )}
+
+        {invites.isLoading && (
+          <p
+            className="mt-4 text-sm text-[color:var(--muted)]"
+            aria-busy="true"
+          >
+            Loading invites…
+          </p>
+        )}
+        {invites.isError && (
+          <p role="alert" className="mt-4 text-sm text-[color:var(--red)]">
+            {extractErrorMessage(invites.error, "Could not load invites.")}
+          </p>
+        )}
+        {invites.isSuccess && invites.data.length === 0 && (
+          <p className="mt-4 text-sm text-[color:var(--muted)]">
+            No invites yet.
+          </p>
+        )}
+        {invites.isSuccess && invites.data.length > 0 && (
+          <ul className="mt-4 space-y-2">
+            {invites.data.map((item) => (
+              <li
+                key={item.id}
+                className="flex flex-wrap items-center justify-between gap-2 rounded-xl border border-[var(--frost)] px-4 py-3 text-sm"
+              >
+                <span>Created {formatDate(item.created_at)}</span>
+                <span
+                  className={`accent-badge ${item.is_used ? "status-indexed" : "status-pending"}`}
+                >
+                  {item.is_used ? "used" : "unused"}
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      {/* --- Pending join requests --- */}
+      <section
+        aria-labelledby="requests-heading"
+        className="mb-8 rounded-3xl border border-[var(--frost)] bg-[color:var(--surface-soft)] p-6 sm:p-7"
+      >
+        <h2 id="requests-heading" className="text-lg font-semibold">
+          Pending requests
+        </h2>
+
+        {reviewError && (
+          <p role="alert" className="mt-3 text-sm text-[color:var(--red)]">
+            {extractErrorMessage(reviewError, "Could not update the request.")}
+          </p>
+        )}
+
+        {requests.isLoading && (
+          <p
+            className="mt-4 text-sm text-[color:var(--muted)]"
+            aria-busy="true"
+          >
+            Loading requests…
+          </p>
+        )}
+        {requests.isError && (
+          <p role="alert" className="mt-4 text-sm text-[color:var(--red)]">
+            {extractErrorMessage(
+              requests.error,
+              "Could not load join requests.",
+            )}
+          </p>
+        )}
+        {requests.isSuccess && pending.length === 0 && (
+          <p className="mt-4 text-sm text-[color:var(--muted)]">
+            Nobody is waiting for access.
+          </p>
+        )}
+        {pending.length > 0 && (
+          <ul className="mt-4 space-y-2">
+            {pending.map((request) => (
+              <li
+                key={request.id}
+                className="flex flex-wrap items-center justify-between gap-3 rounded-xl border border-[var(--frost)] px-4 py-3"
+              >
+                <div className="min-w-0">
+                  <p className="truncate text-sm font-medium">
+                    {request.display_name ?? request.username}
+                  </p>
+                  <p className="text-xs text-[color:var(--muted)]">
+                    {request.username} · requested{" "}
+                    {formatDate(request.created_at)}
+                  </p>
+                </div>
+                <div className="flex shrink-0 items-center gap-2">
+                  <button
+                    type="button"
+                    onClick={() => approve.mutate(request.id)}
+                    disabled={approve.isPending || reject.isPending}
+                    className="frost-button inline-flex items-center gap-1.5 px-3 py-2 text-sm disabled:opacity-60"
+                  >
+                    <Check className="h-4 w-4" aria-hidden />
+                    Approve
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => reject.mutate(request.id)}
+                    disabled={approve.isPending || reject.isPending}
+                    className="frost-button inline-flex items-center gap-1.5 px-3 py-2 text-sm disabled:opacity-60"
+                  >
+                    <X className="h-4 w-4" aria-hidden />
+                    Reject
+                  </button>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      {/* --- Members --- */}
+      <section
+        aria-labelledby="members-heading"
+        className="rounded-3xl border border-[var(--frost)] bg-[color:var(--surface-soft)] p-6 sm:p-7"
+      >
+        <h2 id="members-heading" className="text-lg font-semibold">
+          Members
+        </h2>
+
+        {users.isLoading && (
+          <p
+            className="mt-4 text-sm text-[color:var(--muted)]"
+            aria-busy="true"
+          >
+            Loading members…
+          </p>
+        )}
+        {users.isError && (
+          <p role="alert" className="mt-4 text-sm text-[color:var(--red)]">
+            {extractErrorMessage(users.error, "Could not load members.")}
+          </p>
+        )}
+        {users.isSuccess && (
+          <ul aria-labelledby="members-heading" className="mt-4 space-y-2">
+            {users.data.map((member) => (
+              <li
+                key={member.id}
+                className="flex flex-wrap items-center justify-between gap-2 rounded-xl border border-[var(--frost)] px-4 py-3"
+              >
+                <div className="min-w-0">
+                  <p className="truncate text-sm font-medium">
+                    {member.display_name ?? member.username}
+                  </p>
+                  <p className="text-xs text-[color:var(--muted)]">
+                    {member.username}
+                  </p>
+                </div>
+                <span
+                  className={`accent-badge ${member.role === "admin" ? "status-processing" : "status-default"}`}
+                >
+                  {member.role}
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </main>
+  );
+}

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,6 +1,7 @@
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import "./globals.css";
 import { AppShell } from "@/components/app-shell";
+import { ServiceWorkerRegistrar } from "@/components/service-worker-registrar";
 import { Providers } from "./providers";
 
 export const metadata: Metadata = {
@@ -8,6 +9,20 @@ export const metadata: Metadata = {
   description:
     "AI-powered image search and organization that runs entirely on your device",
   manifest: "/manifest.json",
+  // Installed on iOS the app runs standalone without Safari chrome; without
+  // this it opens in a browser tab instead (#259).
+  appleWebApp: {
+    capable: true,
+    title: "Find",
+    statusBarStyle: "black-translucent",
+  },
+};
+
+// themeColor lives on the viewport export in the Next.js App Router, not on
+// metadata. It must match manifest.json or the installed splash and title bar
+// disagree with the running app.
+export const viewport: Viewport = {
+  themeColor: "#000000",
 };
 
 export default function RootLayout({
@@ -19,6 +34,7 @@ export default function RootLayout({
     <html lang="en" suppressHydrationWarning>
       <body className="antialiased">
         <Providers>
+          <ServiceWorkerRegistrar />
           <AppShell>{children}</AppShell>
         </Providers>
       </body>

--- a/frontend/src/app/upload/page.tsx
+++ b/frontend/src/app/upload/page.tsx
@@ -14,6 +14,10 @@ import Link from "next/link";
 import { useCallback, useMemo, useState } from "react";
 import { useDropzone } from "react-dropzone";
 import { toast } from "sonner";
+import {
+  OfflineUploadQueue,
+  useOfflineUploadQueue,
+} from "@/components/offline-upload-queue";
 import { UploadStatusRing } from "@/components/upload-status-indicator";
 import {
   extractErrorMessage,
@@ -21,6 +25,7 @@ import {
   uploadImages,
   uploadImagesBulk,
 } from "@/lib/api";
+import { enqueueFiles, isIndexedDbAvailable } from "@/lib/offline-queue";
 import {
   getUploadItemProgress,
   type UploadQueueItem,
@@ -117,6 +122,11 @@ export default function UploadPage() {
 
   const isUploading = uploadPhase === "uploading";
 
+  // Offline staging (#259). `refresh` is pulled out because onDrop needs to
+  // re-render the panel after enqueuing without depending on the whole object.
+  const offlineQueue = useOfflineUploadQueue();
+  const { online: isOnline, refresh: refreshOfflineQueue } = offlineQueue;
+
   const activeJobs = useMemo(
     () =>
       uploadedFiles.filter(
@@ -135,6 +145,36 @@ export default function UploadPage() {
         toast.error("No valid images selected");
         return;
       }
+
+      // Offline: stage the bytes locally rather than firing a request that is
+      // going to fail. Without IndexedDB there is nowhere to stage them, so
+      // fall through and let the upload fail with a real error instead of
+      // silently accepting files we cannot keep.
+      if (!isOnline && isIndexedDbAvailable()) {
+        try {
+          const { added, skipped } = await enqueueFiles(acceptedFiles);
+          await refreshOfflineQueue();
+          if (added.length > 0) {
+            toast.success(
+              `Saved ${added.length} file${added.length === 1 ? "" : "s"} to upload when you reconnect`,
+            );
+          }
+          if (skipped.length > 0) {
+            toast.info(
+              `${skipped.length} file${skipped.length === 1 ? " is" : "s are"} already queued`,
+            );
+          }
+        } catch (error) {
+          toast.error(
+            extractErrorMessage(
+              error,
+              "Could not stage files for later upload",
+            ),
+          );
+        }
+        return;
+      }
+
       beginUpload();
       try {
         const data = await uploadImages(acceptedFiles, setUploadProgress);
@@ -148,7 +188,15 @@ export default function UploadPage() {
         toast.error(extractErrorMessage(error, "Upload failed"));
       }
     },
-    [beginUpload, completeUpload, failUpload, queryClient, setUploadProgress],
+    [
+      beginUpload,
+      completeUpload,
+      failUpload,
+      isOnline,
+      queryClient,
+      refreshOfflineQueue,
+      setUploadProgress,
+    ],
   );
 
   const onBulkDrop = useCallback(
@@ -335,6 +383,8 @@ export default function UploadPage() {
             </button>
           </div>
         </div>
+
+        <OfflineUploadQueue {...offlineQueue} />
 
         <div
           {...activeRootProps()}

--- a/frontend/src/components/offline-upload-queue.tsx
+++ b/frontend/src/components/offline-upload-queue.tsx
@@ -1,0 +1,238 @@
+"use client";
+
+import { CloudOff, RefreshCw, Trash2, WifiOff } from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
+import { toast } from "sonner";
+import { uploadImages } from "@/lib/api";
+import {
+  clearQueuedUploads,
+  countQueuedUploads,
+  flushQueue,
+  isIndexedDbAvailable,
+  listQueuedUploads,
+  type QueuedUpload,
+  recoverStalledUploads,
+  removeQueuedUpload,
+} from "@/lib/offline-queue";
+import { useOnlineStatus } from "@/lib/use-online-status";
+
+function formatSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(0)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+/**
+ * Queue state plus the actions the upload page needs.
+ *
+ * Kept as a hook so the page can stage files into the queue without rendering
+ * the panel, and the panel can render without owning the staging decision.
+ */
+export function useOfflineUploadQueue() {
+  const online = useOnlineStatus();
+  const [items, setItems] = useState<QueuedUpload[]>([]);
+  const [flushing, setFlushing] = useState(false);
+  const available = isIndexedDbAvailable();
+
+  const refresh = useCallback(async () => {
+    if (!available) return;
+    try {
+      setItems(await listQueuedUploads());
+    } catch (error) {
+      console.warn("Could not read the offline upload queue", error);
+    }
+  }, [available]);
+
+  const flush = useCallback(
+    async (options?: { silent?: boolean }) => {
+      if (!available) return;
+      if ((await countQueuedUploads()) === 0) return;
+
+      setFlushing(true);
+      try {
+        const result = await flushQueue((files) => uploadImages(files));
+        // `skipped` means another trigger was already flushing; reporting it
+        // would double-toast a single run.
+        if (!result.skipped && !options?.silent) {
+          if (result.uploaded > 0) {
+            toast.success(
+              `Uploaded ${result.uploaded} queued file${result.uploaded === 1 ? "" : "s"}`,
+            );
+          }
+          if (result.failed > 0) {
+            toast.error(
+              `${result.failed} queued file${result.failed === 1 ? "" : "s"} still pending`,
+            );
+          }
+        }
+      } catch (error) {
+        console.warn("Offline queue flush failed", error);
+      } finally {
+        setFlushing(false);
+        await refresh();
+      }
+    },
+    [available, refresh],
+  );
+
+  const remove = useCallback(
+    async (id: string) => {
+      await removeQueuedUpload(id);
+      await refresh();
+    },
+    [refresh],
+  );
+
+  const clear = useCallback(async () => {
+    await clearQueuedUploads();
+    await refresh();
+  }, [refresh]);
+
+  // On mount: recover anything a closed tab left mid-flight, then show it.
+  useEffect(() => {
+    if (!available) return;
+    void recoverStalledUploads()
+      .catch(() => 0)
+      .then(() => refresh());
+  }, [available, refresh]);
+
+  // Connectivity returned -- send whatever is staged. Silent: the user did not
+  // ask for this, so it should not interrupt them unless something fails.
+  useEffect(() => {
+    if (!available || !online) return;
+    void flush({ silent: false });
+  }, [available, online, flush]);
+
+  return { items, online, flushing, available, refresh, flush, remove, clear };
+}
+
+type OfflineUploadQueueProps = ReturnType<typeof useOfflineUploadQueue>;
+
+/**
+ * Panel listing files staged for upload while the backend was unreachable.
+ *
+ * Renders nothing when the queue is empty and the connection is fine, so the
+ * normal online path is visually unchanged (issue #259: "Existing desktop web
+ * behavior remains unchanged").
+ */
+export function OfflineUploadQueue({
+  items,
+  online,
+  flushing,
+  available,
+  flush,
+  remove,
+  clear,
+}: OfflineUploadQueueProps) {
+  if (!available) {
+    return null;
+  }
+  if (items.length === 0 && online) {
+    return null;
+  }
+
+  return (
+    <section
+      aria-labelledby="offline-queue-heading"
+      className="mb-5 rounded-xl border border-[var(--frost)] bg-[color:var(--frost-soft)] p-4"
+    >
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex items-center gap-2">
+          {online ? (
+            <CloudOff
+              className="h-4 w-4 text-[color:var(--yellow)]"
+              aria-hidden
+            />
+          ) : (
+            <WifiOff
+              className="h-4 w-4 text-[color:var(--yellow)]"
+              aria-hidden
+            />
+          )}
+          <h2
+            id="offline-queue-heading"
+            className="text-sm font-semibold text-[color:var(--near-white)]"
+          >
+            {online ? "Waiting to upload" : "Offline"}
+          </h2>
+          {items.length > 0 && (
+            <span className="accent-badge status-pending">
+              {items.length} file{items.length === 1 ? "" : "s"}
+            </span>
+          )}
+        </div>
+
+        {items.length > 0 && (
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={() => void flush()}
+              disabled={!online || flushing}
+              className="icon-button disabled:cursor-not-allowed disabled:opacity-50"
+              aria-label="Retry queued uploads now"
+              title={
+                online ? "Retry queued uploads now" : "Waiting for a connection"
+              }
+            >
+              <RefreshCw
+                className={`h-4 w-4 ${flushing ? "animate-spin" : ""}`}
+                aria-hidden
+              />
+            </button>
+            <button
+              type="button"
+              onClick={() => void clear()}
+              className="icon-button"
+              aria-label="Remove all queued files"
+              title="Remove all queued files"
+            >
+              <Trash2 className="h-4 w-4" aria-hidden />
+            </button>
+          </div>
+        )}
+      </div>
+
+      <p className="mt-2 text-xs leading-relaxed text-[color:var(--muted)]">
+        {online
+          ? "These files are staged on this device and are being submitted now."
+          : "Files you add are staged on this device and will be submitted automatically when the connection returns. Nothing has been sent yet."}
+      </p>
+
+      {items.length > 0 && (
+        <ul className="mt-3 space-y-1.5">
+          {items.map((item) => (
+            <li
+              key={item.id}
+              className="flex items-center justify-between gap-3 rounded-lg border border-[var(--frost)] px-3 py-2"
+            >
+              <div className="min-w-0">
+                <p className="truncate text-sm text-[color:var(--near-white)]">
+                  {item.name}
+                </p>
+                <p className="text-xs text-[color:var(--muted)]">
+                  {formatSize(item.size)}
+                  {item.attempts > 0 && (
+                    <>
+                      {" · "}
+                      {item.attempts} failed attempt
+                      {item.attempts === 1 ? "" : "s"}
+                    </>
+                  )}
+                  {item.lastError && <> · {item.lastError}</>}
+                </p>
+              </div>
+              <button
+                type="button"
+                onClick={() => void remove(item.id)}
+                className="icon-button shrink-0"
+                aria-label={`Remove ${item.name} from the upload queue`}
+              >
+                <Trash2 className="h-4 w-4" aria-hidden />
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/components/service-worker-registrar.tsx
+++ b/frontend/src/components/service-worker-registrar.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { useEffect } from "react";
+
+/**
+ * Registers the service worker that provides the offline shell (issue #259).
+ *
+ * Renders nothing. Mounted once from the root layout.
+ */
+export function ServiceWorkerRegistrar() {
+  useEffect(() => {
+    if (!shouldRegisterServiceWorker()) {
+      return;
+    }
+
+    // Registration is best-effort. A failure here means no offline shell, which
+    // is a degraded experience -- not a broken app -- so it must never surface
+    // as an error to the user.
+    navigator.serviceWorker
+      .register("/sw.js", { scope: "/" })
+      .catch((error) => {
+        console.warn("Service worker registration failed", error);
+      });
+  }, []);
+
+  return null;
+}
+
+/**
+ * Three environments must be excluded, for different reasons:
+ *
+ * - Development: a cached shell across `next dev` rebuilds produces stale-asset
+ *   bugs that look like application bugs.
+ * - Tauri desktop: the shell is loaded from the bundle over a custom protocol,
+ *   so there is no network to be offline from and nothing to cache.
+ * - Non-secure contexts: the browser rejects registration anyway.
+ */
+function shouldRegisterServiceWorker(): boolean {
+  if (typeof window === "undefined" || !("serviceWorker" in navigator)) {
+    return false;
+  }
+  if (process.env.NODE_ENV !== "production") {
+    return false;
+  }
+  if (!window.isSecureContext) {
+    return false;
+  }
+  // Tauri serves the static export over tauri:// or asset://, never http(s).
+  return (
+    window.location.protocol === "https:" ||
+    window.location.protocol === "http:"
+  );
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -314,6 +314,89 @@ export const revokeAccountSession = async (
   await api.delete(`/api/auth/sessions/${sessionId}`);
 };
 
+// --- Instance management (shared deployments, issue #263) ---
+
+export interface InstanceInvite {
+  id: number;
+  is_used: boolean;
+  expires_at: string | null;
+  created_at: string | null;
+}
+
+/**
+ * The raw token is returned by POST /auth/invites once and never stored, so it
+ * has to be surfaced to the admin immediately -- it cannot be re-read later.
+ */
+export interface CreatedInvite {
+  id: number;
+  invite_token: string;
+  expires_at: string;
+}
+
+export interface JoinRequest {
+  id: number;
+  username: string;
+  display_name: string | null;
+  status: "pending" | "approved" | "rejected";
+  created_at: string | null;
+  reviewed_at: string | null;
+}
+
+export const getInstanceUsers = async (): Promise<AccountUser[]> => {
+  const response = await api.get<{ users: AccountUser[] }>("/api/auth/users");
+  return response.data.users;
+};
+
+export const getInstanceInvites = async (): Promise<InstanceInvite[]> => {
+  const response = await api.get<{ invites: InstanceInvite[] }>(
+    "/api/auth/invites",
+  );
+  return response.data.invites;
+};
+
+export const createInstanceInvite = async (params?: {
+  ttl_hours?: number;
+}): Promise<CreatedInvite> => {
+  const response = await api.post<CreatedInvite>(
+    "/api/auth/invites",
+    params ?? {},
+  );
+  return response.data;
+};
+
+export const getJoinRequests = async (): Promise<JoinRequest[]> => {
+  const response = await api.get<{ requests: JoinRequest[] }>(
+    "/api/auth/join-requests",
+  );
+  return response.data.requests;
+};
+
+export const approveJoinRequest = async (
+  requestId: number,
+): Promise<{ user: AccountUser }> => {
+  const response = await api.post<{ user: AccountUser }>(
+    `/api/auth/join-requests/${requestId}/approve`,
+  );
+  return response.data;
+};
+
+export const rejectJoinRequest = async (requestId: number): Promise<void> => {
+  await api.post(`/api/auth/join-requests/${requestId}/reject`);
+};
+
+export const submitJoinRequest = async (params: {
+  invite_token: string;
+  username: string;
+  password: string;
+  display_name?: string;
+}): Promise<{ join_request_id: number }> => {
+  const response = await api.post<{ join_request_id: number }>(
+    "/api/auth/join",
+    params,
+  );
+  return response.data;
+};
+
 export type AccelMode = "auto" | "gpu" | "cpu";
 
 export interface HardwareCapabilities {

--- a/frontend/src/lib/offline-queue.ts
+++ b/frontend/src/lib/offline-queue.ts
@@ -1,0 +1,332 @@
+/**
+ * IndexedDB-backed queue for uploads staged while the backend is unreachable.
+ *
+ * Why IndexedDB rather than the existing zustand `uploadQueueStore`: that store
+ * persists to localStorage, which is synchronous, string-only, and capped at a
+ * few megabytes. This queue holds the file bytes themselves, so it needs a
+ * store that takes binary data and does not block the main thread.
+ *
+ * What this deliberately does NOT hold: anything secret. Only the file bytes the
+ * user chose plus the metadata needed to display and re-submit them. Auth is
+ * cookie-based and the vault key is memory-only (see store/vaultStore.ts) --
+ * neither may ever be written here.
+ */
+
+const DB_NAME = "find-offline-uploads";
+const DB_VERSION = 1;
+const STORE_NAME = "queued-uploads";
+
+/**
+ * `uploading` is persisted rather than kept in memory so a tab closed
+ * mid-flight leaves a recoverable marker instead of an item that looks queued
+ * and gets sent twice.
+ */
+export type QueuedUploadStatus = "queued" | "uploading";
+
+/** Metadata for one staged file. The bytes live in {@link QueuedUploadRecord}. */
+export interface QueuedUpload {
+  id: string;
+  name: string;
+  size: number;
+  type: string;
+  lastModified: number;
+  queuedAt: number;
+  /**
+   * Insertion order.
+   *
+   * `queuedAt` alone is not enough: a multi-file drop stages every file inside
+   * the same millisecond, so sorting on it leaves the panel order and the
+   * upload order arbitrary.
+   */
+  seq: number;
+  attempts: number;
+  status: QueuedUploadStatus;
+  lastError?: string;
+}
+
+/**
+ * A staged file including its bytes.
+ *
+ * Bytes are held as an ArrayBuffer rather than the original Blob. IndexedDB
+ * accepts Blobs in principle, but they survive a structured clone far less
+ * reliably across engines than a buffer does, and the File is reconstructed on
+ * the way out anyway.
+ */
+export interface QueuedUploadRecord extends QueuedUpload {
+  bytes: ArrayBuffer;
+}
+
+export interface EnqueueResult {
+  added: QueuedUpload[];
+  /** Files already present in the queue, matched on name + size + mtime. */
+  skipped: File[];
+}
+
+export interface FlushResult {
+  uploaded: number;
+  failed: number;
+  /** True when a flush was already running and this call did nothing. */
+  skipped: boolean;
+}
+
+/** Uploader injected by the caller so this module never imports the API client. */
+export type QueueUploader = (files: File[]) => Promise<unknown>;
+
+export function isIndexedDbAvailable(): boolean {
+  return typeof globalThis !== "undefined" && "indexedDB" in globalThis;
+}
+
+function openDb(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    if (!isIndexedDbAvailable()) {
+      reject(new Error("IndexedDB is not available in this environment"));
+      return;
+    }
+    const request = indexedDB.open(DB_NAME, DB_VERSION);
+    request.onupgradeneeded = () => {
+      const db = request.result;
+      if (!db.objectStoreNames.contains(STORE_NAME)) {
+        const store = db.createObjectStore(STORE_NAME, { keyPath: "id" });
+        store.createIndex("dedupeKey", "dedupeKey", { unique: false });
+        store.createIndex("seq", "seq", { unique: false });
+      }
+    };
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+}
+
+function runTransaction<T>(
+  mode: IDBTransactionMode,
+  work: (store: IDBObjectStore) => IDBRequest<T> | void,
+): Promise<T | undefined> {
+  return openDb().then(
+    (db) =>
+      new Promise<T | undefined>((resolve, reject) => {
+        const transaction = db.transaction(STORE_NAME, mode);
+        const store = transaction.objectStore(STORE_NAME);
+        let result: T | undefined;
+        const request = work(store);
+        if (request) {
+          request.onsuccess = () => {
+            result = request.result;
+          };
+        }
+        transaction.oncomplete = () => {
+          db.close();
+          resolve(result);
+        };
+        transaction.onerror = () => {
+          db.close();
+          reject(transaction.error);
+        };
+        transaction.onabort = () => {
+          db.close();
+          reject(transaction.error);
+        };
+      }),
+  );
+}
+
+/**
+ * Identity for dedupe. Content hashing would be stricter, but hashing a whole
+ * camera roll on the main thread to answer "did they pick this twice?" costs
+ * far more than it saves -- and the backend hashes on receipt anyway, so an
+ * escapee is still caught server-side and returned as `duplicate`.
+ */
+function dedupeKey(file: File): string {
+  return `${file.name}:${file.size}:${file.lastModified}`;
+}
+
+function toMetadata(
+  record: QueuedUploadRecord & { dedupeKey?: string },
+): QueuedUpload {
+  const { bytes: _bytes, dedupeKey: _key, ...metadata } = record;
+  return metadata;
+}
+
+function newId(): string {
+  if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
+    return crypto.randomUUID();
+  }
+  return `queued-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+/** Stage files for later upload, skipping ones already queued. */
+export async function enqueueFiles(files: File[]): Promise<EnqueueResult> {
+  if (files.length === 0) {
+    return { added: [], skipped: [] };
+  }
+
+  const records = await listRecords();
+  const existing = new Set(records.map((record) => record.dedupeKey));
+  let nextSeq =
+    records.reduce((max, record) => Math.max(max, record.seq), 0) + 1;
+
+  const added: QueuedUpload[] = [];
+  const skipped: File[] = [];
+  const pending: Array<QueuedUploadRecord & { dedupeKey: string }> = [];
+
+  for (const file of files) {
+    const key = dedupeKey(file);
+    // Check `existing` and this batch, so selecting the same file twice in one
+    // drop does not create two records.
+    if (existing.has(key) || pending.some((item) => item.dedupeKey === key)) {
+      skipped.push(file);
+      continue;
+    }
+    pending.push({
+      id: newId(),
+      name: file.name,
+      size: file.size,
+      type: file.type,
+      lastModified: file.lastModified,
+      queuedAt: Date.now(),
+      seq: nextSeq++,
+      attempts: 0,
+      status: "queued",
+      dedupeKey: key,
+      bytes: await file.arrayBuffer(),
+    });
+  }
+
+  if (pending.length > 0) {
+    await runTransaction("readwrite", (store) => {
+      for (const record of pending) {
+        store.put(record);
+      }
+    });
+    added.push(...pending.map(toMetadata));
+  }
+
+  return { added, skipped };
+}
+
+async function listRecords(): Promise<
+  Array<QueuedUploadRecord & { dedupeKey: string }>
+> {
+  const records = await runTransaction<
+    Array<QueuedUploadRecord & { dedupeKey: string }>
+  >(
+    "readonly",
+    (store) =>
+      store.getAll() as IDBRequest<
+        Array<QueuedUploadRecord & { dedupeKey: string }>
+      >,
+  );
+  return (records ?? []).sort((a, b) => a.seq - b.seq);
+}
+
+/**
+ * Queue contents for display, oldest first.
+ *
+ * Bytes are stripped: the panel renders names and sizes, and holding every
+ * staged file's bytes in React state would pin the whole queue in memory for
+ * no benefit.
+ */
+export async function listQueuedUploads(): Promise<QueuedUpload[]> {
+  const records = await listRecords();
+  return records.map(toMetadata);
+}
+
+export async function countQueuedUploads(): Promise<number> {
+  const count = await runTransaction<number>("readonly", (store) =>
+    store.count(),
+  );
+  return count ?? 0;
+}
+
+export async function removeQueuedUpload(id: string): Promise<void> {
+  await runTransaction("readwrite", (store) => {
+    store.delete(id);
+  });
+}
+
+export async function clearQueuedUploads(): Promise<void> {
+  await runTransaction("readwrite", (store) => {
+    store.clear();
+  });
+}
+
+/**
+ * Reset any record left in `uploading` back to `queued`.
+ *
+ * Called on start-up. A tab closed mid-upload leaves a stranded marker that
+ * {@link flushQueue} would otherwise skip forever, so the item would sit in the
+ * panel looking active and never send.
+ */
+export async function recoverStalledUploads(): Promise<number> {
+  const records = await listRecords();
+  const stalled = records.filter((record) => record.status === "uploading");
+  if (stalled.length === 0) {
+    return 0;
+  }
+  await runTransaction("readwrite", (store) => {
+    for (const record of stalled) {
+      store.put({ ...record, status: "queued" as const });
+    }
+  });
+  return stalled.length;
+}
+
+// Single-flight guard. The flush can be triggered by the `online` event, by a
+// manual retry, and by the upload page mounting -- all three can land at once,
+// and without this each would send the same file.
+let flushInFlight: Promise<FlushResult> | null = null;
+
+/**
+ * Upload everything staged, oldest first.
+ *
+ * An item is marked `uploading` before its request and deleted only after the
+ * upload resolves, so an interrupted flush never loses a file and never sends
+ * one twice. Failures stay queued with an incremented attempt count.
+ */
+export function flushQueue(uploader: QueueUploader): Promise<FlushResult> {
+  if (flushInFlight) {
+    return flushInFlight.then((result) => ({ ...result, skipped: true }));
+  }
+  flushInFlight = runFlush(uploader).finally(() => {
+    flushInFlight = null;
+  });
+  return flushInFlight;
+}
+
+async function runFlush(uploader: QueueUploader): Promise<FlushResult> {
+  const records = await listRecords();
+  const pending = records.filter((record) => record.status === "queued");
+  let uploaded = 0;
+  let failed = 0;
+
+  for (const record of pending) {
+    await runTransaction("readwrite", (store) => {
+      store.put({ ...record, status: "uploading" as const });
+    });
+
+    try {
+      const file = new File([record.bytes], record.name, {
+        type: record.type,
+        lastModified: record.lastModified,
+      });
+      await uploader([file]);
+      await removeQueuedUpload(record.id);
+      uploaded += 1;
+    } catch (error) {
+      failed += 1;
+      await runTransaction("readwrite", (store) => {
+        store.put({
+          ...record,
+          status: "queued" as const,
+          attempts: record.attempts + 1,
+          lastError: error instanceof Error ? error.message : "Upload failed",
+        });
+      });
+    }
+  }
+
+  return { uploaded, failed, skipped: false };
+}
+
+/** Test-only: drop the single-flight guard between cases. */
+export function resetFlushGuardForTests(): void {
+  flushInFlight = null;
+}

--- a/frontend/src/lib/use-online-status.ts
+++ b/frontend/src/lib/use-online-status.ts
@@ -1,0 +1,34 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+/**
+ * Track browser connectivity.
+ *
+ * `navigator.onLine` only reports whether the device has *a* network
+ * connection, not whether the Find backend is reachable -- a laptop on a wifi
+ * network with the backend stopped still reads `true`. It is used here purely
+ * as the trigger for retrying a queued upload, which is cheap and safe to
+ * attempt optimistically. Anything that needs to know the backend is actually
+ * up should ask the API instead.
+ */
+export function useOnlineStatus(): boolean {
+  // Start optimistic so server render and first client render agree; the effect
+  // corrects it immediately on mount. Reading navigator here would hydrate
+  // mismatched on a machine that is genuinely offline.
+  const [online, setOnline] = useState(true);
+
+  useEffect(() => {
+    const update = () => setOnline(navigator.onLine);
+    update();
+
+    window.addEventListener("online", update);
+    window.addEventListener("offline", update);
+    return () => {
+      window.removeEventListener("online", update);
+      window.removeEventListener("offline", update);
+    };
+  }, []);
+
+  return online;
+}


### PR DESCRIPTION
## Summary

Batches the five open issues that could be finished from the repository alone, after unassigning contributors who had been sitting on issues for three-plus weeks without activity.

Closes #396, #48, #353, #259, #263.

> **Scope note:** `AGENTS.md` says to keep a branch focused on one issue, and the checklist below has a "scoped to a single issue" box that this PR cannot honestly tick. This is a deliberate maintainer batch, requested as one PR. The five issues touch different subsystems and the commits are split one topic per commit, so it can be reviewed commit by commit.

Six other issues were assessed and **deliberately left open** — see "What is not here" at the bottom. None of them can be closed without measurements from real hardware or a backend contract that does not exist yet, and inventing either would have been worse than leaving them open.

## Type of change

- [x] Feature
- [x] Documentation update
- [x] CI / tooling

## Release impact

- [x] Minor (backward-compatible feature)

## What changed

### #396 — Docker images now build on PRs, and Node moves to 24 LTS

`publish.yml` was the only workflow that built either Dockerfile, and it runs on release. A broken Dockerfile stayed invisible until a release build, and the version pins in `ci.yml` drifted from the ones in the images with nothing comparing them.

- New `docker-check` job builds `backend/Dockerfile` (default `no-ai` profile) and `frontend/Dockerfile` (`production` target). Build only — no push, no registry credentials, no QEMU.
- A narrow `docker` paths filter so it wakes for the Dockerfiles and the manifests they install from, not for every source edit. An image build is expensive and editing a React component cannot break a Dockerfile that `COPY`s the whole tree anyway.
- A drift guard asserting the Node and Python pins agree across `ci.yml` and both Dockerfiles. It fails loudly with the two values named.
- Node 22 → 24 in the same commit. Because this PR touches `ci.yml`, `docker-check` runs here, so the bump is verified by an actual image build in the PR that makes it — which is what step 2 of the issue was waiting for.

### #48 — Signed desktop installer pipeline

- `.github/workflows/desktop-installer.yml`: an unsigned Windows Tauri build on PRs touching the desktop paths, plus a maintainer-only signed path.
- The split is enforced by GitHub's environment model, not a conditional. Signing secrets are scoped to a `desktop-release` environment, and environment secrets are unavailable to `pull_request` runs from forks — so a fork cannot reach them even by editing the workflow on its own branch, which a conditional would not prevent.
- The signed job is **inert until a certificate is provisioned**: it fails preflight rather than emitting an unsigned installer, and `signtool verify` gates every artifact before it reaches a draft release.
- `docs/plans/not-started/desktop-installer-release.md` covers certificate storage, the EV/HSM variant, rotation (scheduled and post-compromise), a failure table, version/tag and draft-release behaviour, and the macOS/Linux extension points — explicitly marked unverified.

### #353 — BYOK inference plugin boundary (design only)

`docs/plans/not-started/byok-inference-plugin-boundary.md`. No adapter, SDK, or credential UI ships with it.

The document's main argument is that the existing `ML_MODE=remote` path answers "is the pipe safe", which TLS plus a bearer token settles, whereas BYOK asks "what leaves, to whom, under what consent, and what happens to it afterwards" — so a BYOK provider must never be configurable through the `REMOTE_ML_*` settings. It also singles out two capabilities that need consent separate from the image ones: `embed_text`, which turns every query the user types into a third-party log line, and `cluster`, which ships biometric data even though no pixels leave.

Includes a manifest format, per-capability consent bound to the manifest hash, secret handling, egress control, a 12-row threat model, and the test strategy that gates any future adapter.

### #259 — PWA shell and offline upload queue

- Service worker (`public/sw.js`) + a self-contained `public/offline.html`. It never caches `/api/`, never intercepts cross-origin requests, and is skipped in dev, in Tauri, and in non-secure contexts.
- IndexedDB queue that stages files when the backend is unreachable and resumes on reconnect, with a panel to inspect and remove them.

Three details carry the correctness, and two were found by tests failing rather than by design:

- Files are stored as **ArrayBuffers, not Blobs**. Blobs survive a structured clone far less reliably across engines.
- Records carry an explicit **`seq`**. A multi-file drop stages every file inside the same millisecond, so sorting on `queuedAt` left both the panel order and the upload order arbitrary.
- Flushing is **single-flight** and marks a record `uploading` before its request, deleting it only once that resolves. The `online` event, a manual retry, and the page mounting can all fire at once; without the guard each would resend the same file, and without the persisted marker a tab closed mid-upload would strand a record that later flushes skip forever.

The panel renders nothing when online with an empty queue, so the existing desktop path is visually unchanged.

### #263 — Instance management UI

The backend had every flow except one: nothing listed the accounts on an instance. The join-request list cannot substitute — the first admin comes from `/auth/setup` and never appears as a request. So this adds an admin-only `GET /auth/users` returning the same `_user_dict` projection every other user-bearing response uses.

The page resolves to one of four states rather than showing a disabled admin panel to everyone: local mode (explains that no instance is needed, never prompts), signed-out shared mode (the join form), member (no admin controls, and no calls to the admin-only endpoints), and admin (invites, pending requests, members).

Access is per-instance and cannot be scoped to a subset of the library, so each state says so plainly instead of leaving it implied. Entry point is the Account page in shared mode rather than the sidebar, because `NAV_GROUPS` is static and an always-present Instance link would advertise a concept that does not exist on a single-user install.

## How to test

```bash
# Backend
cd backend
uv run ruff check . && uv run ruff format --check .
ML_MODE=mock uv run pytest tests/ -q
ML_MODE=mock uv run pytest tests/test_auth.py -q      # the new GET /auth/users cases

# Frontend
cd frontend
pnpm install
pnpm check && pnpm test && pnpm build
pnpm test:e2e                                          # includes the new PWA specs

# The CI drift guard, run locally
grep -oP 'node-version:\s*\K[0-9]+' .github/workflows/ci.yml     # 24
grep -oP '^FROM node:\K[0-9]+' frontend/Dockerfile               # 24
```

Manual PWA check: `pnpm build && pnpm start`, open the app, then go offline in DevTools and navigate — the offline page should appear. Drop files onto `/upload` while offline; they stage in IndexedDB and submit when you go back online.

## What was tested, and what was not

**Verified locally:**
- Backend: `ruff check` clean, `ruff format --check` clean, full `pytest` suite.
- Frontend: `pnpm check` clean, 356 unit/component tests, `pnpm build` on Node 24, 20 Playwright tests including a real service-worker-served navigation while offline.
- The Node/Python drift guard was checked in both directions — it passes on the current tree and fails when the Dockerfile is moved to a different major.

**Not verified locally, and why:**
- The `docker-check` image builds themselves — no Docker daemon on this machine. They run for the first time on this PR.
- The unsigned Windows Tauri build — needs a Windows runner with the Tauri toolchain. Also runs for the first time here.
- The signed release path — cannot be run at all until a certificate exists on the `desktop-release` environment. It is written to fail loudly rather than produce an unsigned artifact.
- The PWA install prompt — Chrome gates it behind engagement heuristics. The E2E asserts the preconditions (manifest, both icon sizes, theme-colour agreement, an active service worker) rather than the prompt.

## What is not here

Six issues were assessed and left open, with the reason recorded on each:

| Issue | Why it stays open |
|---|---|
| #404 | Needs antelopev2 downloaded from cold and real photos run through it. The embedding-dimension check is the whole point and cannot be faked. |
| #382 | `pytorch-cu128` caps at torch 2.11.0 while CVE-2025-3000 needs 2.13.0, so two of the four alerts are unfixable. The 2.9.1 → 2.11.0 move needs full-stack GPU verification. |
| #383 | The issue itself says nothing is actionable — glib 0.18.5 is the ceiling for the gtk-rs 0.18 stack Tauri pins. It is a tracker. |
| #340, #343, #344 | Benchmark issues whose entire deliverable is measured numbers from real hardware. |
| #99 | Blocked on the #100 evaluation harness, as the issue states. |
| #261 | The settings API exposes `ml_mode` but not `REMOTE_ML_URL`, `REMOTE_ML_API_KEY`, `REMOTE_ML_FEATURES`, or `REMOTE_ML_STRIP_EXIF`, and there is no connection-test endpoint. Building the UI would mean inventing backend contracts, which the issue explicitly forbids. |

#339 is partly done already (`compose.cpu.yml`, the `cpu` extra, the `FIND_BUILD_PROFILE` build arg) but its acceptance requires recorded image size, idle/peak RAM, and per-image latency on a CPU-only machine, so it also stays open.

#335 is untouched — it belongs to #452.

## Checklist

- [x] I linked the related issue
- [x] I ran required checks from CONTRIBUTING.md
- [x] I updated docs/env notes if needed
- [ ] My PR is scoped to a single issue — see the scope note above
- [x] I followed commit message conventions
- [x] I am not committing secrets or local artifacts
- [x] This PR targets `canary` unless it is the maintainer promotion PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an Instance page for shared installations with join requests, invitations, member listings, and administrator approvals.
  * Added offline upload staging with automatic retry when connectivity returns.
  * Added installable PWA support with offline navigation, service-worker caching, and a helpful offline page.
  * Added Windows desktop installer builds and release artifacts.
* **Documentation**
  * Updated authentication status and documented BYOK and desktop-release plans.
* **Bug Fixes**
  * Improved handling of failed and interrupted offline uploads without losing queued files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->